### PR TITLE
Test Mode development steps in WooChat Pro

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -26,6 +26,8 @@ function wcwp_register_settings() {
     register_setting('wcwp_settings_group', 'wcwp_chatbot_enabled');
     register_setting('wcwp_settings_group', 'wcwp_faq_pairs');
     register_setting('wcwp_settings_group', 'wcwp_license_key');
+    register_setting('wcwp_settings_group', 'wcwp_test_mode_enabled');
+
 }
 
 function wcwp_render_settings_page() {
@@ -98,6 +100,13 @@ function wcwp_render_settings_page() {
                             }
                             ?>
                         </p>
+                    </td>
+                </tr>
+                <tr valign="top">
+                    <th scope="row">Enable Test Mode</th>
+                    <td>
+                        <input type="checkbox" name="wcwp_test_mode_enabled" value="yes" <?php checked(get_option('wcwp_test_mode_enabled'), 'yes'); ?> />
+                        <label for="wcwp_test_mode_enabled">Log messages instead of sending via WhatsApp (for testing only)</label>
                     </td>
                 </tr>
             </table>

--- a/includes/cart-recovery.php
+++ b/includes/cart-recovery.php
@@ -55,7 +55,17 @@ function wcwp_send_cart_recovery_whatsapp($phone, $cart_items) {
 
     $body = implode("\n", $items);
     $message = "👋 Hey! You left items in your cart:\n\n$body\n\nTotal: $total PKR\nClick here to complete your order: " . wc_get_cart_url();
-    
+
+    // Check if test mode is enabled
+    $test_mode = get_option('wcwp_test_mode_enabled', 'no');
+    if ($test_mode === 'yes') {
+        // Log message to debug.log
+        if (defined('WP_DEBUG') && WP_DEBUG === true) {
+            error_log("[WooChat Pro - TEST MODE] Message to $phone: $message");
+        }
+        return; // Skip sending real message
+    }
+
     if (function_exists('wcwp_send_whatsapp_message')) {
         wcwp_send_whatsapp_message($phone, $message);
     }

--- a/includes/order-hooks.php
+++ b/includes/order-hooks.php
@@ -24,6 +24,15 @@ function wcwp_send_whatsapp_on_order_complete($order_id) {
 }
 
 function wcwp_send_whatsapp_message($to, $message) {
+    $test_mode = get_option('wcwp_test_mode_enabled', 'no');
+
+    if ($test_mode === 'yes') {
+        if (defined('WP_DEBUG') && WP_DEBUG === true) {
+            error_log("[WooChat Pro - TEST MODE] Order message to $to: $message");
+        }
+        return; // ✅ Skip real Twilio request
+    }
+
     $sid = get_option('wcwp_twilio_sid');
     $token = get_option('wcwp_twilio_auth_token');
     $from = get_option('wcwp_twilio_from');
@@ -57,3 +66,4 @@ function wcwp_send_whatsapp_message($to, $message) {
         error_log("WhatsApp message sent to $to_number");
     }
 }
+


### PR DESCRIPTION
- feat: Add “Enable Test Mode” option to WooChat settings page
- chore: Register test mode setting using WordPress Settings API
- feat: Implement test mode logic in cart recovery functionality
- feat: Implement test mode logic in order confirmation WhatsApp hook
- refactor: Route all test mode messages to debug.log if WP_DEBUG is enabled
- test: Verified message logging for both order and cart recovery in test mode