### PR TITLE
Feature/make wc require for woochat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ Thumbs.db
 *.bak
 *.swp
 *.tmp
+*node_modules/
+*package-lock.json
+*package.json

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,6 +1,17 @@
 <?php
 if (!defined('WP_UNINSTALL_PLUGIN')) exit;
 
+if (!function_exists('wcwp_is_woocommerce_active')) {
+    $helpers = WP_PLUGIN_DIR . '/woochat-pro/includes/helpers.php';
+    if (file_exists($helpers)) {
+        include_once $helpers;
+    }
+}
+
+if (function_exists('wcwp_is_woocommerce_active') && !wcwp_is_woocommerce_active()) {
+    return;
+}
+
 $delete = get_option('wcwp_delete_data_on_uninstall', 'no');
 if ($delete !== 'yes') {
     return;

--- a/woochat-pro.php
+++ b/woochat-pro.php
@@ -5,6 +5,10 @@
  * Version: 1.0.1
  * Author: ZeeCreatives
  * License: GPL2
+ * Requires Plugins: woocommerce
+ * Requires at least: 6.0
+ * Tested up to: 6.7
+ * Requires PHP: 7.4
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
@@ -14,30 +18,92 @@ define( 'WCWP_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WCWP_URL', plugin_dir_url( __FILE__ ) );
 define( 'WCWP_PLUGIN_FILE', __FILE__ );
 
-// Load core modules
+// Load helpers early for dependency checks.
 require_once WCWP_PATH . 'includes/helpers.php';
-require_once WCWP_PATH . 'includes/analytics.php';
-require_once WCWP_PATH . 'admin/settings-page.php';
-require_once WCWP_PATH . 'includes/chatbot-engine.php';
-require_once WCWP_PATH . 'includes/license-manager.php';
-require_once WCWP_PATH . 'includes/optout.php';
-require_once WCWP_PATH . 'includes/update-checker.php';
 
-if (function_exists('wcwp_is_woocommerce_active') && wcwp_is_woocommerce_active()) {
+function wcwp_wc_dependency_link() {
+	$plugin_file = 'woocommerce/woocommerce.php';
+	$is_installed = file_exists(WP_PLUGIN_DIR . '/' . $plugin_file);
+
+	if ($is_installed) {
+		if (current_user_can('activate_plugins')) {
+			$url = wp_nonce_url(self_admin_url('plugins.php?action=activate&plugin=' . $plugin_file), 'activate-plugin_' . $plugin_file);
+			return '<a href="' . esc_url($url) . '">Activate WooCommerce</a>';
+		}
+		return '';
+	}
+
+	if (current_user_can('install_plugins')) {
+		$url = wp_nonce_url(self_admin_url('update.php?action=install-plugin&plugin=woocommerce'), 'install-plugin_woocommerce');
+		return '<a href="' . esc_url($url) . '">Install WooCommerce</a>';
+	}
+
+	return '';
+}
+
+function wcwp_wc_dependency_notice_message() {
+	$link = wcwp_wc_dependency_link();
+	$tail = $link ? ' ' . $link . '.' : '';
+	return '<strong>WooChat Pro</strong> requires WooCommerce. Please install and activate WooCommerce.' . $tail;
+}
+
+function wcwp_bootstrap() {
+	require_once WCWP_PATH . 'includes/analytics.php';
+	require_once WCWP_PATH . 'admin/settings-page.php';
+	require_once WCWP_PATH . 'includes/chatbot-engine.php';
+	require_once WCWP_PATH . 'includes/license-manager.php';
+	require_once WCWP_PATH . 'includes/optout.php';
+	require_once WCWP_PATH . 'includes/update-checker.php';
+
 	require_once WCWP_PATH . 'includes/order-hooks.php';
 	require_once WCWP_PATH . 'includes/cart-recovery.php';
 	require_once WCWP_PATH . 'includes/scheduler.php';
+}
+
+if (function_exists('wcwp_is_woocommerce_active') && wcwp_is_woocommerce_active()) {
+	wcwp_bootstrap();
 } else {
 	add_action('admin_notices', function() {
 		if (!current_user_can('activate_plugins')) return;
-		echo '<div class="notice notice-error"><p><b>WooChat Pro:</b> WooCommerce is required. Please install and activate WooCommerce to use order messaging and cart recovery.</p></div>';
+		$screen = function_exists('get_current_screen') ? get_current_screen() : null;
+		if ($screen && $screen->id !== 'plugins') return;
+		echo '<div class="notice notice-error"><p>' . wcwp_wc_dependency_notice_message() . '</p></div>';
+	});
+	add_action('network_admin_notices', function() {
+		if (!current_user_can('activate_plugins')) return;
+		$screen = function_exists('get_current_screen') ? get_current_screen() : null;
+		if ($screen && $screen->id !== 'plugins-network') return;
+		echo '<div class="notice notice-error"><p>' . wcwp_wc_dependency_notice_message() . '</p></div>';
 	});
 }
 
 register_activation_hook(__FILE__, 'wcwp_activate_plugin');
 register_deactivation_hook(__FILE__, 'wcwp_deactivate_plugin');
 
-function wcwp_activate_plugin() {
+function wcwp_activate_plugin($network_wide) {
+	if (!function_exists('wcwp_is_woocommerce_active') || !wcwp_is_woocommerce_active()) {
+		if ($network_wide && is_multisite()) {
+			if (!function_exists('is_plugin_active_for_network')) {
+				include_once ABSPATH . 'wp-admin/includes/plugin.php';
+			}
+			if (function_exists('is_plugin_active_for_network') && !is_plugin_active_for_network('woocommerce/woocommerce.php')) {
+				deactivate_plugins(plugin_basename(__FILE__));
+				$plugins_url = network_admin_url('plugins.php');
+				wp_die(
+					'<p><strong>WooChat Pro</strong> requires WooCommerce to be network-activated.</p><p><a href="' . esc_url($plugins_url) . '">Return to Plugins</a></p>',
+					'WooChat Pro',
+					['response' => 200]
+				);
+			}
+		}
+		deactivate_plugins(plugin_basename(__FILE__));
+		$plugins_url = is_network_admin() ? network_admin_url('plugins.php') : admin_url('plugins.php');
+		wp_die(
+			'<p><strong>WooChat Pro</strong> requires WooCommerce to be installed and active.</p><p><a href="' . esc_url($plugins_url) . '">Return to Plugins</a></p>',
+			'WooChat Pro',
+			['response' => 200]
+		);
+	}
 	if (function_exists('wcwp_create_cart_recovery_table')) {
 		wcwp_create_cart_recovery_table();
 	}
@@ -54,6 +120,25 @@ function wcwp_deactivate_plugin() {
 		wcwp_unschedule_cart_recovery_cron();
 	}
 }
+
+add_action('admin_init', function() {
+	if (!function_exists('is_plugin_active')) {
+		include_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+	if (function_exists('wcwp_is_woocommerce_active') && !wcwp_is_woocommerce_active() && is_plugin_active(plugin_basename(__FILE__))) {
+		deactivate_plugins(plugin_basename(__FILE__));
+		add_action('admin_notices', function() {
+			if (!current_user_can('activate_plugins')) return;
+			echo '<div class="notice notice-error"><p><strong>WooChat Pro</strong> was deactivated because WooCommerce is not active.</p></div>';
+		});
+	}
+});
+
+add_action('after_plugin_row_' . plugin_basename(__FILE__), function($plugin_file, $plugin_data, $status) {
+	if (function_exists('wcwp_is_woocommerce_active') && wcwp_is_woocommerce_active()) return;
+	if (!current_user_can('activate_plugins')) return;
+	echo '<tr class="plugin-update-tr"><td colspan="3" class="plugin-update colspanchange"><div class="update-message notice inline notice-error notice-alt"><p>' . wcwp_wc_dependency_notice_message() . '</p></div></td></tr>';
+}, 10, 3);
 
 // Browser polyfills used across frontend hooks
 add_action('wp_head', function() {


### PR DESCRIPTION
  - Added Requires Plugins: woocommerce and core WP.org header fields.                                                                         
  - Blocked activation without WooCommerce and auto-deactivate when missing.                                                                   
  - Scoped dependency notices to plugin screens and added row-level notice.                                                                    
  - Added install/activate WooCommerce links in notices.                                                                                       
  - Handled multisite network activation dependency checks.                                                                                    
  - Gated all module loading behind WooCommerce check.                                                                                         
  - Guarded uninstall from running when WooCommerce is inactive.   