### PR TITLE
Convert manual order WhatsApp send from GET to POST

### DIFF
--- a/assets/js/admin-orders.js
+++ b/assets/js/admin-orders.js
@@ -1,0 +1,49 @@
+// WooChat Pro – Admin orders list: manual "Send WhatsApp" button.
+// Submits via POST + nonce so the action is no longer a GET side-effect.
+
+(function () {
+    'use strict';
+
+    function getAjaxUrl() {
+        return (window.wcwpManualSend && window.wcwpManualSend.ajaxUrl)
+            ? window.wcwpManualSend.ajaxUrl
+            : '';
+    }
+
+    document.addEventListener('click', function (e) {
+        var btn = e.target.closest('.wcwp-send-whatsapp');
+        if (!btn) return;
+
+        e.preventDefault();
+        if (btn.disabled) return;
+
+        var orderId = btn.getAttribute('data-order-id');
+        var nonce = btn.getAttribute('data-nonce');
+        var ajaxUrl = getAjaxUrl();
+        if (!orderId || !nonce || !ajaxUrl) return;
+
+        btn.disabled = true;
+
+        var form = new FormData();
+        form.append('action', 'wcwp_send_manual_whatsapp');
+        form.append('order_id', orderId);
+        form.append('nonce', nonce);
+
+        fetch(ajaxUrl, {
+            method: 'POST',
+            credentials: 'same-origin',
+            body: form
+        }).then(function (res) {
+            return res.json().catch(function () { return null; });
+        }).then(function (data) {
+            var redirect = data && data.data && data.data.redirect;
+            if (redirect) {
+                window.location.href = redirect;
+                return;
+            }
+            btn.disabled = false;
+        }).catch(function () {
+            btn.disabled = false;
+        });
+    });
+})();

--- a/includes/order-hooks.php
+++ b/includes/order-hooks.php
@@ -34,27 +34,68 @@ function wcwp_send_whatsapp_on_order_complete($order_id) {
 // Add manual WhatsApp message button to order admin screen
 add_action('woocommerce_admin_order_actions_end', function($order) {
     $order_id = $order->get_id();
-    echo '<a class="button tips wcwp-send-whatsapp" href="' . esc_url( wp_nonce_url( admin_url( 'admin-ajax.php?action=wcwp_send_manual_whatsapp&order_id=' . $order_id ), 'wcwp_send_manual_whatsapp_' . $order_id ) ) . '" data-tip="Send WhatsApp Message"><span class="dashicons dashicons-format-chat"></span></a>';
+    $nonce    = wp_create_nonce('wcwp_send_manual_whatsapp_' . $order_id);
+    printf(
+        '<button type="button" class="button tips wcwp-send-whatsapp" data-order-id="%1$d" data-nonce="%2$s" data-tip="%3$s" aria-label="%3$s"><span class="dashicons dashicons-format-chat"></span></button>',
+        (int) $order_id,
+        esc_attr($nonce),
+        esc_attr__('Send WhatsApp Message', 'woochat-pro')
+    );
+});
+
+// Enqueue the small handler script only on Woo orders screens (HPOS + legacy).
+add_action('admin_enqueue_scripts', function() {
+    $screen = function_exists('get_current_screen') ? get_current_screen() : null;
+    if (!$screen) return;
+    $allowed = ['woocommerce_page_wc-orders', 'edit-shop_order', 'shop_order'];
+    if (!in_array($screen->id, $allowed, true)) return;
+    wp_enqueue_script(
+        'wcwp-admin-orders',
+        WCWP_URL . 'assets/js/admin-orders.js',
+        [],
+        WCWP_VERSION,
+        true
+    );
+    wp_localize_script('wcwp-admin-orders', 'wcwpManualSend', [
+        'ajaxUrl' => admin_url('admin-ajax.php'),
+    ]);
 });
 
 add_action('wp_ajax_wcwp_send_manual_whatsapp', function() {
-    if (!current_user_can('manage_woocommerce')) wp_die(esc_html__('Unauthorized', 'woochat-pro'));
-    $order_id = intval($_GET['order_id'] ?? 0);
-    if (!$order_id || !wp_verify_nonce($_GET['_wpnonce'] ?? '', 'wcwp_send_manual_whatsapp_' . $order_id)) wp_die(esc_html__('Invalid nonce', 'woochat-pro'));
-    $order = wc_get_order($order_id);
-    if (!$order) wp_die(esc_html__('Order not found', 'woochat-pro'));
-    $to = sanitize_text_field($order->get_billing_phone());
-    $name = $order->get_billing_first_name();
-    $total = $order->get_total();
-    $template = get_option('wcwp_order_message_template', 'Hi {name}, thanks for your order #{order_id}! Total: {total} PKR.');
-    $message = str_replace(['{name}', '{order_id}', '{total}'], [$name, $order_id, $total], $template);
-    $result = wcwp_send_whatsapp_message($to, $message, true, ['type' => 'order', 'order_id' => $order_id]);
-    if ($result === true) {
-        wp_safe_redirect( admin_url('post.php?post=' . $order_id . '&action=edit&wcwp_msg=success') );
-    } else {
-        wp_safe_redirect( admin_url('post.php?post=' . $order_id . '&action=edit&wcwp_msg=fail') );
+    if (!current_user_can('manage_woocommerce')) {
+        wp_send_json_error(['message' => __('Unauthorized', 'woochat-pro')], 403);
     }
-    exit;
+
+    $order_id = isset($_POST['order_id']) ? absint(wp_unslash($_POST['order_id'])) : 0;
+    if (!$order_id) {
+        wp_send_json_error(['message' => __('Invalid order', 'woochat-pro')], 400);
+    }
+
+    if (!check_ajax_referer('wcwp_send_manual_whatsapp_' . $order_id, 'nonce', false)) {
+        wp_send_json_error(['message' => __('Invalid nonce', 'woochat-pro')], 400);
+    }
+
+    $order = wc_get_order($order_id);
+    if (!$order) {
+        wp_send_json_error(['message' => __('Order not found', 'woochat-pro')], 404);
+    }
+
+    $to       = sanitize_text_field($order->get_billing_phone());
+    $name     = $order->get_billing_first_name();
+    $total    = $order->get_total();
+    $template = get_option('wcwp_order_message_template', 'Hi {name}, thanks for your order #{order_id}! Total: {total} PKR.');
+    $message  = str_replace(['{name}', '{order_id}', '{total}'], [$name, $order_id, $total], $template);
+    $result   = wcwp_send_whatsapp_message($to, $message, true, ['type' => 'order', 'order_id' => $order_id]);
+
+    $redirect = add_query_arg(
+        ['wcwp_msg' => $result === true ? 'success' : 'fail'],
+        admin_url('post.php?post=' . $order_id . '&action=edit')
+    );
+
+    if ($result === true) {
+        wp_send_json_success(['redirect' => $redirect]);
+    }
+    wp_send_json_error(['redirect' => $redirect, 'message' => __('Send failed', 'woochat-pro')]);
 });
 
 // Admin test message sender


### PR DESCRIPTION
## Summary

Addresses **Audit point #1** — the manual *Send WhatsApp* button in the WooCommerce orders admin was a nonce'd GET link to `admin-ajax.php` that mutated server state. State-changing GETs can fire from prefetchers, image/iframe loads, browser accelerators, and security scanners — even with a nonce. Converted to a proper POST flow.

## Changes

- **Button** is now a `<button>` with `data-order-id` and `data-nonce` attributes (no href, no GET).
- **Handler** `wp_ajax_wcwp_send_manual_whatsapp` reads `\$_POST` only, uses `check_ajax_referer`, and responds JSON with a `redirect` URL.
- **New file** `assets/js/admin-orders.js` — submits the click via `fetch` POST and follows the redirect. Enqueued **only** on Woo orders screens (HPOS `woocommerce_page_wc-orders` + legacy `edit-shop_order` / `shop_order`).
- **Existing admin notice** (`?wcwp_msg=success|fail`) is preserved by including it in the redirect URL.
- `wp_unslash` applied where the new handler reads `\$_POST['order_id']`.

## What stays the same

- Button renders in the same column (`woocommerce_admin_order_actions_end`), same icon, same tooltip / aria label.
- Capability check (`manage_woocommerce`), nonce action name (`wcwp_send_manual_whatsapp_<order_id>`), and the success/fail admin notice are unchanged.
- Test mode, opt-out check, analytics logging — all run through the same `wcwp_send_whatsapp_message()` call with the same arguments.

## Test plan

- [x] Open **WooCommerce → Orders** (HPOS) and the legacy orders list, confirm the chat icon button still appears next to each order.
- [x] Click the button on an order with a billing phone configured → verify the WhatsApp message is sent (or logged in test mode), the page reloads, and a green "WhatsApp message sent successfully" notice appears.
- [x] Click on an order with no provider credentials → verify the red "Failed to send" notice appears.
- [x] Open browser DevTools → Network tab while clicking → confirm the request method is **POST** to `admin-ajax.php` with `action=wcwp_send_manual_whatsapp`, and the response is JSON.
- [x] Confirm a logged-out user / non-admin cannot trigger the action (manual `curl -X POST` returns 403 / 400).
- [x] Confirm `assets/js/admin-orders.js` is **not** loaded on unrelated admin screens (Posts, Media, Settings, etc.).

## Risk / rollback

Touches one file plus one new JS file. If the button stops working, reverting the commit restores the previous GET-based flow with no DB or option changes.