### PR TITLE
Apply wp_unslash to all superglobal reads before sanitization

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -364,11 +364,11 @@ function wcwp_render_settings_page() {
                 <?php $totals = function_exists('wcwp_analytics_get_totals') ? wcwp_analytics_get_totals() : ['sent' => 0, 'delivered' => 0, 'clicked' => 0]; ?>
                 <?php
                 $filters = [
-                    'type' => isset($_GET['wcwp_type']) ? sanitize_text_field($_GET['wcwp_type']) : '',
-                    'status' => isset($_GET['wcwp_status']) ? sanitize_text_field($_GET['wcwp_status']) : '',
-                    'phone' => isset($_GET['wcwp_phone']) ? sanitize_text_field($_GET['wcwp_phone']) : '',
-                    'date_from' => isset($_GET['wcwp_date_from']) ? sanitize_text_field($_GET['wcwp_date_from']) : '',
-                    'date_to' => isset($_GET['wcwp_date_to']) ? sanitize_text_field($_GET['wcwp_date_to']) : '',
+                    'type' => isset($_GET['wcwp_type']) ? sanitize_text_field(wp_unslash($_GET['wcwp_type'])) : '',
+                    'status' => isset($_GET['wcwp_status']) ? sanitize_text_field(wp_unslash($_GET['wcwp_status'])) : '',
+                    'phone' => isset($_GET['wcwp_phone']) ? sanitize_text_field(wp_unslash($_GET['wcwp_phone'])) : '',
+                    'date_from' => isset($_GET['wcwp_date_from']) ? sanitize_text_field(wp_unslash($_GET['wcwp_date_from'])) : '',
+                    'date_to' => isset($_GET['wcwp_date_to']) ? sanitize_text_field(wp_unslash($_GET['wcwp_date_to'])) : '',
                 ];
                 $events = function_exists('wcwp_analytics_get_events') ? wcwp_analytics_get_events(25, $filters) : [];
                 ?>

--- a/includes/analytics.php
+++ b/includes/analytics.php
@@ -287,15 +287,15 @@ function wcwp_analytics_tracking_url($event_id, $redirect_url) {
 
 function wcwp_handle_tracking_request() {
     if (!isset($_GET['wcwp_track'])) return;
-    $type = sanitize_text_field($_GET['wcwp_track']);
-    $event_id = sanitize_text_field($_GET['event_id'] ?? '');
+    $type = sanitize_text_field(wp_unslash($_GET['wcwp_track']));
+    $event_id = isset($_GET['event_id']) ? sanitize_text_field(wp_unslash($_GET['event_id'])) : '';
 
     if ($type === 'click' && $event_id) {
         wcwp_analytics_increment_total('clicked');
         wcwp_analytics_update_event($event_id, ['status' => 'clicked']);
     }
 
-    $redirect = isset($_GET['redirect']) ? esc_url_raw($_GET['redirect']) : home_url('/');
+    $redirect = isset($_GET['redirect']) ? esc_url_raw(wp_unslash($_GET['redirect'])) : home_url('/');
     if (!$redirect || strpos($redirect, 'http') !== 0) {
         $redirect = home_url('/');
     }
@@ -307,8 +307,8 @@ function wcwp_track_event_ajax() {
     if ( ! check_ajax_referer( 'wcwp_track_event', 'nonce', false ) ) {
         wp_send_json_error( [ 'message' => __( 'Invalid nonce', 'woochat-pro' ) ], 403 );
     }
-    $type = sanitize_text_field($_REQUEST['type'] ?? '');
-    $event_id = sanitize_text_field($_REQUEST['event_id'] ?? '');
+    $type = isset($_REQUEST['type']) ? sanitize_text_field(wp_unslash($_REQUEST['type'])) : '';
+    $event_id = isset($_REQUEST['event_id']) ? sanitize_text_field(wp_unslash($_REQUEST['event_id'])) : '';
     if (!$type || !$event_id) {
         wp_send_json_error(['message' => __('Missing data', 'woochat-pro')], 400);
     }

--- a/includes/cart-recovery.php
+++ b/includes/cart-recovery.php
@@ -100,7 +100,7 @@ function wcwp_unschedule_cart_recovery_cron() {
 }
 
 function wcwp_save_cart_ajax() {
-    if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'wcwp_cart_nonce')) {
+    if (!check_ajax_referer('wcwp_cart_nonce', 'nonce', false)) {
         wp_send_json_error(['message' => __('Unauthorized', 'woochat-pro')]);
         return;
     }
@@ -110,10 +110,11 @@ function wcwp_save_cart_ajax() {
         return;
     }
 
-    $phone = sanitize_text_field($_POST['phone'] ?? '');
+    $phone = isset($_POST['phone']) ? sanitize_text_field(wp_unslash($_POST['phone'])) : '';
     $phone = function_exists('wcwp_normalize_phone') ? wcwp_normalize_phone($phone) : $phone;
-    $cart_items = json_decode(stripslashes($_POST['cart'] ?? ''), true);
-    $consent = sanitize_text_field($_POST['consent'] ?? 'no');
+    $cart_raw = isset($_POST['cart']) ? wp_unslash($_POST['cart']) : '';
+    $cart_items = json_decode(is_string($cart_raw) ? $cart_raw : '', true);
+    $consent = isset($_POST['consent']) ? sanitize_text_field(wp_unslash($_POST['consent'])) : 'no';
     $consent_time = current_time('mysql');
 
     if (!wcwp_cart_rate_limit_ok($phone)) {
@@ -365,7 +366,7 @@ function wcwp_process_cart_recovery_queue() {
 }
 
 function wcwp_cart_rate_limit_ok($phone) {
-    $ip = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field($_SERVER['REMOTE_ADDR']) : '';
+    $ip = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field(wp_unslash($_SERVER['REMOTE_ADDR'])) : '';
     $key = 'wcwp_rate_' . md5($ip . '|' . $phone);
     $data = get_transient($key);
     $limit = 5;
@@ -396,7 +397,8 @@ function wcwp_cart_rate_limit_ok($phone) {
 }
 
 add_action('woocommerce_checkout_order_processed', function($order_id) {
-    $consent = isset($_POST['wcwp-cart-consent']) && $_POST['wcwp-cart-consent'] === 'yes' ? 'yes' : 'no';
+    $consent_raw = isset($_POST['wcwp-cart-consent']) ? sanitize_text_field(wp_unslash($_POST['wcwp-cart-consent'])) : '';
+    $consent = $consent_raw === 'yes' ? 'yes' : 'no';
     $order = wc_get_order( $order_id );
     if ( ! $order ) {
         return;
@@ -417,7 +419,7 @@ add_action('wp_ajax_wcwp_resend_cart_recovery', function() {
     if (!current_user_can('manage_woocommerce')) wp_send_json_error(['message' => __('Unauthorized', 'woochat-pro')], 403);
     if (!check_ajax_referer('wcwp_resend_cart', 'nonce', false)) wp_send_json_error(['message' => __('Bad nonce', 'woochat-pro')], 400);
 
-    $attempt_id = sanitize_text_field($_POST['attempt_id'] ?? '');
+    $attempt_id = isset($_POST['attempt_id']) ? sanitize_text_field(wp_unslash($_POST['attempt_id'])) : '';
     if (!$attempt_id) wp_send_json_error(['message' => __('Missing attempt id', 'woochat-pro')], 400);
 
     $attempts = get_transient('wcwp_cart_recovery_attempts') ?: [];

--- a/includes/license-manager.php
+++ b/includes/license-manager.php
@@ -79,7 +79,7 @@ function wcwp_activate_license_ajax() {
     if (!current_user_can('manage_options')) wp_send_json_error(['message' => __('Unauthorized', 'woochat-pro')], 403);
     check_ajax_referer('wcwp_license_nonce', 'nonce');
 
-    $license_key = sanitize_text_field($_POST['license_key'] ?? '');
+    $license_key = isset($_POST['license_key']) ? sanitize_text_field(wp_unslash($_POST['license_key'])) : '';
     if (!$license_key) wp_send_json_error(['message' => __('License key required', 'woochat-pro')], 400);
 
     $result = wcwp_license_request('activate', $license_key);

--- a/includes/order-hooks.php
+++ b/includes/order-hooks.php
@@ -107,8 +107,8 @@ add_action('wp_ajax_wcwp_send_test_whatsapp', function() {
         wp_send_json_error(['message' => __('Bad nonce', 'woochat-pro')], 400);
     }
 
-    $phone = sanitize_text_field($_POST['phone'] ?? '');
-    $message = sanitize_textarea_field($_POST['message'] ?? '');
+    $phone = isset($_POST['phone']) ? sanitize_text_field(wp_unslash($_POST['phone'])) : '';
+    $message = isset($_POST['message']) ? sanitize_textarea_field(wp_unslash($_POST['message'])) : '';
 
     if (!$phone || !$message) {
         wp_send_json_error(['message' => __('Phone and message required', 'woochat-pro')], 400);
@@ -132,9 +132,10 @@ add_action('wp_ajax_wcwp_send_test_whatsapp', function() {
 // Show admin notice for manual send result
 add_action('admin_notices', function() {
     if (!isset($_GET['wcwp_msg'])) return;
-    if ($_GET['wcwp_msg'] === 'success') {
+    $msg = sanitize_text_field(wp_unslash($_GET['wcwp_msg']));
+    if ($msg === 'success') {
         echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__('WhatsApp message sent successfully.', 'woochat-pro') . '</p></div>';
-    } elseif ($_GET['wcwp_msg'] === 'fail') {
+    } elseif ($msg === 'fail') {
         echo '<div class="notice notice-error is-dismissible"><p>' . esc_html__('Failed to send WhatsApp message. Check logs for details.', 'woochat-pro') . '</p></div>';
     }
 });


### PR DESCRIPTION
## Summary

Addresses **Audit point #2** — every read of `\$_GET`, `\$_POST`, `\$_REQUEST`, and `\$_SERVER` now passes through `wp_unslash()` before sanitization.

WordPress applies magic-quotes-style escaping to all superglobals on every request. Reading them without `wp_unslash()` means escaped characters (`\'`, `\"`) get baked into option values, log lines, DB rows, and admin notices. WPCS flags every such read under `WordPress.Security.ValidatedSanitizedInput`.

## What changed

| File | Spots fixed |
|------|-------------|
| `admin/settings-page.php` | 5 analytics filter `\$_GET` reads |
| `includes/cart-recovery.php` | cart-save POST (phone, cart JSON, consent), rate-limit IP, checkout consent, resend-attempt id — **plus** replaced raw `wp_verify_nonce(\$_POST['nonce'])` with `check_ajax_referer()` (handles unslashing internally, idiomatic WP) |
| `includes/analytics.php` | tracking redirect handler (`wcwp_track`, `event_id`, `redirect`) and AJAX track handler (`type`, `event_id`) |
| `includes/license-manager.php` | license-key activation POST |
| `includes/order-hooks.php` | test-message handler (phone, message) and the `wcwp_msg` admin notice reader |

## Pattern used

Every read now follows:

```php
\$value = isset(\$_POST['key']) ? sanitize_text_field(wp_unslash(\$_POST['key'])) : '';
```

For URLs: `esc_url_raw(wp_unslash(...))`. For textareas: `sanitize_textarea_field(wp_unslash(...))`. For ints: `absint(wp_unslash(...))`.

## What stays the same

- No nonce action names, capability checks, or AJAX actions changed.
- All sanitization functions are unchanged — this only inserts `wp_unslash` before them.
- The cart-save flow's nonce check moves from `wp_verify_nonce` → `check_ajax_referer` but the action name (`wcwp_cart_nonce`) and JS payload are unchanged, so the existing nonce sent by `cart-tracker.js` is still accepted.

## Test plan

- [x] **Analytics filters**: open the Analytics tab, enter values in the type/status/phone/from/to fields, click Filter — confirm filters apply and the URL still encodes the params.
- [x] **Cart recovery save**: trigger a cart-tracker save (add to cart on checkout with billing phone filled) — confirm the row lands in `wp_wcwp_abandoned_carts` with the cart JSON intact.
- [x] **Cart recovery rate limit**: hit the AJAX endpoint repeatedly from the same IP — confirm 429 still fires after 5 saves.
- [x] **Checkout consent**: place an order with the consent checkbox enabled in settings — confirm `_wcwp_cart_consent` order meta is `yes`.
- [x] **Resend cart recovery**: click Resend on a recent cart attempt in the admin — confirm it succeeds.
- [x] **Click tracking**: click a tracked cart-recovery URL → confirm redirect happens and the analytics event flips to `clicked`.
- [x] **Click tracking AJAX (delivered)**: trigger `wcwp_track_event` AJAX with type=delivered — confirm event status updates.
- [x] **License activate/deactivate**: hit Activate / Deactivate from the License tab — confirm both calls reach the license server.
- [x] **Test message**: send a test from the Messaging tab — confirm it sends / logs in test mode.
- [x] **Manual order send**: click the chat icon on an order — confirm success/fail notice fires (uses `wcwp_msg` GET, now unslashed).

## Risk / rollback

Pure hardening — no logic, no schema, no nonce/capability changes. If anything misbehaves, reverting the commit restores the prior reads with no data effects.