### PR TITLE
Move click-tracking handler off init to template_redirect

### DIFF
--- a/includes/analytics.php
+++ b/includes/analytics.php
@@ -4,7 +4,13 @@ if (!defined('ABSPATH')) exit;
 // Simple in-option analytics store with capped events
 const WCWP_ANALYTICS_MAX_EVENTS = 200;
 
-add_action('init', 'wcwp_handle_tracking_request');
+// Click-tracking redirect handler — only attach when the parameter is
+// actually present, and only on frontend requests. Tracking URLs are
+// always built against home_url('/'), so template_redirect is the right
+// hook (admin / AJAX / REST / cron paths never need this callback).
+if (!empty($_GET['wcwp_track'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- presence-only switch; nonce-free public click tracker, validated inside the handler.
+    add_action('template_redirect', 'wcwp_handle_tracking_request', 1);
+}
 add_action('wp_ajax_wcwp_track_event', 'wcwp_track_event_ajax');
 add_action('wp_ajax_nopriv_wcwp_track_event', 'wcwp_track_event_ajax');
 


### PR DESCRIPTION
## Summary

Addresses **Audit point #3** — `wcwp_handle_tracking_request` was hooked on `init`, so the callback fired on **every** request (admin pages, AJAX, REST, cron, login, WP-CLI) and then early-returned because `\$_GET['wcwp_track']` was absent. The early return is cheap; the function call, action dispatch, and stack frame are not, especially on busy admin/AJAX-heavy sites.

## What changed

`includes/analytics.php` — replaced:

```php
add_action('init', 'wcwp_handle_tracking_request');
```

with a presence-gated registration on `template_redirect`:

```php
if (!empty(\$_GET['wcwp_track'])) {
    add_action('template_redirect', 'wcwp_handle_tracking_request', 1);
}
```

## Why `template_redirect` is correct here

Tracking URLs are always built via `add_query_arg([...], home_url('/'))` (see `wcwp_analytics_tracking_url()`), so the redirect target is always a **frontend** request. `template_redirect`:

- fires only on frontend page loads,
- runs before output starts (safe for `wp_safe_redirect`),
- is skipped entirely on admin / AJAX / REST / cron / login / WP-CLI paths.

Combined with the conditional registration, the result is **zero overhead** on any request that isn't an actual click-track hop.

## What stays the same

- The handler itself is byte-identical (sanitize → increment `clicked` counter → update event status → `wp_safe_redirect` → `exit`).
- Tracking URL format, query keys (`wcwp_track`, `event_id`, `redirect`), and the `wcwp_track_event_ajax` (delivered) handler are unchanged.

## Test plan

- [x] Place a cart-recovery test send so a tracking URL is generated (or build one manually: `home_url('/?wcwp_track=click&event_id=<existing_event_id>&redirect=' + encoded_target)`).
- [x] Visit the URL → confirm you land on the redirect target.
- [x] Confirm the `clicked` total in the Analytics tab increments.
- [x] Confirm the event row's status flips to `clicked` in `wp_wcwp_analytics_events`.
- [x] Visit a regular admin page (e.g. WooCommerce → Orders) without the `wcwp_track` param → confirm no errors and no tracking handler runs (no extra row written, no log noise).
- [x] Hit `admin-ajax.php` for any other action → still works (we did not move the AJAX handlers, only the redirect handler).

## Risk / rollback

Single-file, ~7-line change. If for any reason a tracking URL stops redirecting, reverting the commit restores the prior `init` registration with no DB or option changes.