### PR TITLE
Validate click-tracking redirect host against site URLs

### DIFF
--- a/includes/analytics.php
+++ b/includes/analytics.php
@@ -291,6 +291,55 @@ function wcwp_analytics_tracking_url($event_id, $redirect_url) {
     ], home_url('/'));
 }
 
+/**
+ * Validate a click-tracking redirect target against this site's hosts.
+ *
+ * Tracking URLs are always generated against home_url('/') with the
+ * destination as a query arg, so a legitimate redirect target must
+ * resolve to the same host as home_url() / site_url(). Anything else is
+ * either a misconfiguration or an open-redirect attempt.
+ *
+ * @param string $url Raw URL from the request.
+ * @return string Safe URL — original if it passes, home_url('/') otherwise.
+ */
+function wcwp_validate_tracking_redirect($url) {
+    $fallback = home_url('/');
+    if (!is_string($url) || $url === '') {
+        return $fallback;
+    }
+
+    $parts = wp_parse_url($url);
+    if (!is_array($parts) || empty($parts['scheme']) || empty($parts['host'])) {
+        return $fallback;
+    }
+
+    if (!in_array(strtolower($parts['scheme']), ['http', 'https'], true)) {
+        return $fallback;
+    }
+
+    $allowed_hosts = array_filter([
+        wp_parse_url(home_url(), PHP_URL_HOST),
+        wp_parse_url(site_url(), PHP_URL_HOST),
+    ]);
+
+    /**
+     * Filter the host allowlist for click-tracking redirects.
+     *
+     * Useful for multisite, CDN-fronted setups, or stores that legitimately
+     * redirect to a sister domain. Hosts are compared case-insensitively.
+     *
+     * @param string[] $allowed_hosts Default: home_url and site_url hosts.
+     */
+    $allowed_hosts = (array) apply_filters('wcwp_tracking_allowed_hosts', $allowed_hosts);
+    $allowed_hosts = array_map('strtolower', array_filter($allowed_hosts));
+
+    if (!in_array(strtolower($parts['host']), $allowed_hosts, true)) {
+        return $fallback;
+    }
+
+    return $url;
+}
+
 function wcwp_handle_tracking_request() {
     if (!isset($_GET['wcwp_track'])) return;
     $type = sanitize_text_field(wp_unslash($_GET['wcwp_track']));
@@ -301,10 +350,8 @@ function wcwp_handle_tracking_request() {
         wcwp_analytics_update_event($event_id, ['status' => 'clicked']);
     }
 
-    $redirect = isset($_GET['redirect']) ? esc_url_raw(wp_unslash($_GET['redirect'])) : home_url('/');
-    if (!$redirect || strpos($redirect, 'http') !== 0) {
-        $redirect = home_url('/');
-    }
+    $redirect_raw = isset($_GET['redirect']) ? esc_url_raw(wp_unslash($_GET['redirect'])) : '';
+    $redirect = wcwp_validate_tracking_redirect($redirect_raw);
     wp_safe_redirect($redirect);
     exit;
 }


### PR DESCRIPTION
## Summary

Addresses **Audit point #4** — tightens the redirect-URL guard in the click-tracking handler. The old check was `strpos(\$redirect, 'http') !== 0`, which is satisfied by `http://evil.com`, `https://evil.com`, and even `httpfoo://...`. The real safety net was `wp_safe_redirect`, but on a host mismatch that falls back to `admin_url()` — sending a frontend visitor who clicked a tracked link to the WP login screen instead of back to the store.

## What changed

`includes/analytics.php`:

1. New helper `wcwp_validate_tracking_redirect(\$url)`:
   - Parses with `wp_parse_url`.
   - Requires non-empty `scheme` ∈ {`http`, `https`} and non-empty `host`.
   - Requires the host to match `home_url()` **or** `site_url()` (case-insensitive).
   - Returns `home_url('/')` on any failure.
2. New filter `wcwp_tracking_allowed_hosts` so multisite / CDN-fronted / sister-domain setups can extend the allowlist.
3. `wcwp_handle_tracking_request()` now calls the validator instead of the inline `strpos` check.
4. `wp_safe_redirect` remains in place as defense-in-depth.

## Why it's safe for existing flows

Tracking URLs are always built via `add_query_arg([...], home_url('/'))` in `wcwp_analytics_tracking_url()`, with destinations from `wc_get_cart_url()` and similar — all on the same host as `home_url()`. The new validation is strictly tighter than the previous behavior for legitimate redirects.

## Test plan

- [x] Place a cart-recovery test send so a tracking URL is generated; visit it → confirm redirect to the cart, `clicked` total increments, event row updates.
- [x] Manually craft a tracking URL with `redirect=https://example.com/bad` → confirm you land on `home_url('/')` instead.
- [x] Manually craft `redirect=javascript:alert(1)` → confirm you land on `home_url('/')`.
- [x] Manually craft `redirect=http%3A%2F%2F<your-site-host>/some/path` → confirm you land on the encoded path.
- [x] If on multisite or behind a CDN with a different external host, confirm you can extend with:
  ```php
  add_filter('wcwp_tracking_allowed_hosts', function (\$hosts) {
      \$hosts[] = 'cdn.example.com';
      return \$hosts;
  });
  ```
  and that redirects to that host now succeed.

## Risk / rollback

Single-file change, ~50 lines added, no schema or option changes. If any legitimate tracked redirect 404s back to home, the filter handles it; reverting the commit restores the old (looser) check.