### PR TITLE
Validate chatbot colors as hex to block CSS injection

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -41,9 +41,9 @@ function wcwp_register_settings() {
     register_setting('wcwp_settings_group', 'wcwp_gpt_api_endpoint', ['sanitize_callback' => 'wcwp_sanitize_url']);
     register_setting('wcwp_settings_group', 'wcwp_gpt_api_key', ['sanitize_callback' => 'wcwp_sanitize_text']);
     register_setting('wcwp_settings_group', 'wcwp_gpt_model', ['sanitize_callback' => 'wcwp_sanitize_text']);
-    register_setting('wcwp_settings_group', 'wcwp_chatbot_bg', ['sanitize_callback' => 'wcwp_sanitize_text']);
-    register_setting('wcwp_settings_group', 'wcwp_chatbot_text', ['sanitize_callback' => 'wcwp_sanitize_text']);
-    register_setting('wcwp_settings_group', 'wcwp_chatbot_icon_color', ['sanitize_callback' => 'wcwp_sanitize_text']);
+    register_setting('wcwp_settings_group', 'wcwp_chatbot_bg', ['sanitize_callback' => 'wcwp_sanitize_hex_color']);
+    register_setting('wcwp_settings_group', 'wcwp_chatbot_text', ['sanitize_callback' => 'wcwp_sanitize_hex_color']);
+    register_setting('wcwp_settings_group', 'wcwp_chatbot_icon_color', ['sanitize_callback' => 'wcwp_sanitize_hex_color']);
     register_setting('wcwp_settings_group', 'wcwp_chatbot_icon', ['sanitize_callback' => 'wcwp_sanitize_text']);
     register_setting('wcwp_settings_group', 'wcwp_chatbot_welcome', ['sanitize_callback' => 'wcwp_sanitize_text']);
     register_setting('wcwp_settings_group', 'wcwp_data_retention_days', ['sanitize_callback' => 'wcwp_sanitize_int']);

--- a/includes/chatbot-engine.php
+++ b/includes/chatbot-engine.php
@@ -56,11 +56,15 @@ function wcwp_chatbot_shortcode() {
 }
 
 function wcwp_get_chatbot_settings() {
+    // Hex colors are also validated at write-time via the register_setting
+    // sanitize_callback; this is the read-time defense-in-depth that
+    // guarantees the chatbot template never sees an invalid color, even
+    // for values saved before the validator existed.
     return [
-        'bubble_color' => get_option('wcwp_chatbot_bg', '#1c7c54'),
-        'text_color' => get_option('wcwp_chatbot_text', '#ffffff'),
-        'icon_color' => get_option('wcwp_chatbot_icon_color', '#2ec4b6'),
-        'icon' => get_option('wcwp_chatbot_icon', '💬'),
-        'welcome' => get_option('wcwp_chatbot_welcome', 'Hi! How can I help you?'),
+        'bubble_color' => wcwp_sanitize_hex_color(get_option('wcwp_chatbot_bg', '#1c7c54'), '#1c7c54'),
+        'text_color'   => wcwp_sanitize_hex_color(get_option('wcwp_chatbot_text', '#ffffff'), '#ffffff'),
+        'icon_color'   => wcwp_sanitize_hex_color(get_option('wcwp_chatbot_icon_color', '#2ec4b6'), '#2ec4b6'),
+        'icon'         => get_option('wcwp_chatbot_icon', '💬'),
+        'welcome'      => get_option('wcwp_chatbot_welcome', 'Hi! How can I help you?'),
     ];
 }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -25,6 +25,24 @@ function wcwp_sanitize_provider($value) {
     return in_array($value, ['twilio', 'cloud'], true) ? $value : 'twilio';
 }
 
+/**
+ * Validate a value as a 3- or 6-digit hex color (with leading #).
+ *
+ * Used both as a register_setting() sanitize_callback (write-time, single
+ * argument) and at render-time with an explicit default (read-time defense
+ * for any legacy values that were saved before this validator existed).
+ *
+ * @param mixed  $value   Incoming value.
+ * @param string $default Fallback when the value is not a valid hex color.
+ * @return string Valid hex color (e.g. '#1c7c54') or the supplied default.
+ */
+function wcwp_sanitize_hex_color($value, $default = '') {
+    if (is_string($value) && preg_match('/^#([A-Fa-f0-9]{3}){1,2}$/', $value)) {
+        return $value;
+    }
+    return $default;
+}
+
 function wcwp_is_woocommerce_active() {
     if (class_exists('WooCommerce')) return true;
     if (!function_exists('is_plugin_active')) {


### PR DESCRIPTION
## Summary

Addresses **Audit point #5** — `templates/chatbot-widget.php` echoes `wcwp_chatbot_bg` / `wcwp_chatbot_text` / `wcwp_chatbot_icon_color` directly into an inline `<style>` block. `esc_attr()` does not escape CSS-relevant characters (`;`, `{`, `}`), so a value like
```
#abc;background:url(http://attacker.example/exfil.gif)
```
would inject arbitrary CSS into every visitor's page — remote URL requests, off-domain font loads, content-positioning attacks, etc.

## Defense in depth — two layers

**1. Write-time** — new helper `wcwp_sanitize_hex_color()` in `includes/helpers.php`:
```php
function wcwp_sanitize_hex_color(\$value, \$default = '') {
    if (is_string(\$value) && preg_match('/^#([A-Fa-f0-9]{3}){1,2}\$/', \$value)) {
        return \$value;
    }
    return \$default;
}
```
Wired as the `register_setting()` `sanitize_callback` for `wcwp_chatbot_bg`, `wcwp_chatbot_text`, and `wcwp_chatbot_icon_color`. Anything that isn't strict `#RGB` / `#RRGGBB` is dropped to `''`.

**2. Read-time** — `wcwp_get_chatbot_settings()` in `includes/chatbot-engine.php` now passes each color through the same helper with the original default as fallback:
```php
'bubble_color' => wcwp_sanitize_hex_color(get_option('wcwp_chatbot_bg', '#1c7c54'), '#1c7c54'),
```

The template is guaranteed a valid color even for values saved before this validator existed.

## Why both layers

- The admin UI uses `<input type=\"color\">` which only submits hex, but options can also be written via REST API, WP-CLI, import/export, or other plugins — write-time alone isn't enough.
- Existing stores may already have non-hex strings saved — read-time alone covers them without forcing a re-save.

## Test plan

- [x] Open the **Chatbot** tab, change all three colors via the pickers, save, reload — confirm the values stick and the chatbot widget on the frontend renders with the new colors.
- [x] Manually set a malicious value (only possible via DB / WP-CLI):
  ```
  wp option update wcwp_chatbot_bg '#abc;background:url(//evil.example)'
  ```
  Reload a frontend page → confirm the chatbot uses the **default** (`#1c7c54`) and no extra CSS rule is injected.
- [x] Save a valid 3-char hex like `#abc` → confirm it's accepted.
- [x] Save an empty string via the picker (clear the input) → confirm the chatbot falls back to defaults rather than rendering with broken CSS.

## Risk / rollback

Touches three files (~30 lines). No schema changes, no UI changes, no nonce/cap changes. If the chatbot stops rendering colors, reverting the commit restores the previous behavior with no data effects.