### PR TITLE
Harden opt-out webhook with rate limit and signature verification

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -31,6 +31,7 @@ function wcwp_register_settings() {
     register_setting('wcwp_settings_group', 'wcwp_cloud_token', ['sanitize_callback' => 'wcwp_sanitize_text']);
     register_setting('wcwp_settings_group', 'wcwp_cloud_phone_id', ['sanitize_callback' => 'wcwp_sanitize_text']);
     register_setting('wcwp_settings_group', 'wcwp_cloud_from', ['sanitize_callback' => 'wcwp_sanitize_text']);
+    register_setting('wcwp_settings_group', 'wcwp_cloud_app_secret', ['sanitize_callback' => 'wcwp_sanitize_text']);
     register_setting('wcwp_settings_group', 'wcwp_cart_recovery_delay', ['sanitize_callback' => 'wcwp_sanitize_int']);
     register_setting('wcwp_settings_group', 'wcwp_cart_recovery_message', ['sanitize_callback' => 'wcwp_sanitize_textarea']);
     register_setting('wcwp_settings_group', 'wcwp_cart_recovery_require_consent', ['sanitize_callback' => 'wcwp_sanitize_yes_no']);
@@ -167,6 +168,11 @@ function wcwp_render_settings_page() {
                     <tr class="wcwp-cloud-fields" style="display:none;">
                         <th scope="row"><label for="wcwp_cloud_from"><?php esc_html_e('From Number', 'woochat-pro'); ?></label><span class="wcwp-help-icon">?<span class="wcwp-tooltip"><?php esc_html_e('The WhatsApp-enabled number from your Cloud API account. Format: +1234567890', 'woochat-pro'); ?></span></span></th>
                         <td><input type="text" name="wcwp_cloud_from" id="wcwp_cloud_from" value="<?php echo esc_attr(get_option('wcwp_cloud_from')); ?>" class="regular-text" placeholder="e.g. +14155238886" /></td>
+                    </tr>
+                    <tr class="wcwp-cloud-fields" style="display:none;">
+                        <th scope="row"><label for="wcwp_cloud_app_secret"><?php esc_html_e('Cloud App Secret', 'woochat-pro'); ?></label><span class="wcwp-help-icon">?<span class="wcwp-tooltip"><?php esc_html_e('Optional. Meta App Secret used to verify X-Hub-Signature-256 on incoming opt-out webhooks. Different from the access token.', 'woochat-pro'); ?></span></span></th>
+                        <td><input type="password" name="wcwp_cloud_app_secret" id="wcwp_cloud_app_secret" value="<?php echo esc_attr(get_option('wcwp_cloud_app_secret')); ?>" class="regular-text" autocomplete="off" />
+                            <p class="description"><?php esc_html_e('Leave blank to skip Meta webhook signature verification (token check still applies).', 'woochat-pro'); ?></p></td>
                     </tr>
                     <tr>
                         <td colspan="2">

--- a/includes/optout.php
+++ b/includes/optout.php
@@ -9,17 +9,161 @@ add_action('rest_api_init', function () {
     ]);
 });
 
-function wcwp_optout_webhook_handler(WP_REST_Request $request) {
-    $token = (string) $request->get_param('token');
-    if (!$token) {
-        $header_token = $request->get_header('x-wcwp-token');
-        if ($header_token) {
-            $token = (string) $header_token;
-        }
+/**
+ * Per-IP rate limit for the public opt-out webhook.
+ *
+ * The endpoint is reachable without a WordPress login, so even with a
+ * 32-char random token the prudent thing is to bound how many tries any
+ * single source can make. Filterable for sites that legitimately receive
+ * heavy webhook traffic.
+ *
+ * @param string $ip Caller's IP.
+ * @return bool True if request is within the limit, false if blocked.
+ */
+function wcwp_optout_rate_limit_ok($ip) {
+    if (!$ip) return true;
+
+    /** @var int $limit  Max requests per window. Default 30. Filtered to 0 disables the limiter. */
+    $limit  = (int) apply_filters('wcwp_optout_rate_limit', 30);
+    /** @var int $window Window length in seconds. Default HOUR_IN_SECONDS. */
+    $window = (int) apply_filters('wcwp_optout_rate_window', HOUR_IN_SECONDS);
+
+    if ($limit < 1 || $window < 1) return true;
+
+    $key  = 'wcwp_optout_rate_' . md5($ip);
+    $data = get_transient($key);
+
+    if (!is_array($data) || !isset($data['count'], $data['start'])) {
+        set_transient($key, ['count' => 1, 'start' => time()], $window);
+        return true;
     }
-    $expected = (string) get_option('wcwp_optout_webhook_token', '');
-    if (!$expected || !hash_equals($expected, $token)) {
-        return new WP_REST_Response(['message' => __('Unauthorized', 'woochat-pro')], 401);
+
+    if ((time() - (int) $data['start']) > $window) {
+        set_transient($key, ['count' => 1, 'start' => time()], $window);
+        return true;
+    }
+
+    if ((int) $data['count'] >= $limit) {
+        return false;
+    }
+
+    $data['count'] = (int) $data['count'] + 1;
+    set_transient($key, $data, $window);
+    return true;
+}
+
+/**
+ * Verify a Twilio webhook signature.
+ *
+ * Twilio computes X-Twilio-Signature as
+ *   base64(HMAC-SHA1(auth_token, full_url + sorted_post_params_concat))
+ * where sorted_post_params_concat is "k1v1k2v2..." with keys sorted.
+ *
+ * Returns:
+ *   - null  : not a Twilio request (no header), or no auth token configured
+ *             (we cannot verify and don't want to falsely reject).
+ *   - true  : signature verified.
+ *   - false : signature header present but does not match — forged or misrouted.
+ *
+ * @param WP_REST_Request $request
+ * @return bool|null
+ */
+function wcwp_verify_twilio_signature(WP_REST_Request $request) {
+    $sig = (string) $request->get_header('x-twilio-signature');
+    if ($sig === '') return null;
+
+    $auth_token = (string) get_option('wcwp_twilio_auth_token', '');
+    if ($auth_token === '') return null;
+
+    $scheme = is_ssl() ? 'https' : 'http';
+    $host   = isset($_SERVER['HTTP_HOST']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_HOST'])) : '';
+    $uri    = isset($_SERVER['REQUEST_URI']) ? wp_unslash($_SERVER['REQUEST_URI']) : '';
+    $url    = $scheme . '://' . $host . $uri;
+
+    /**
+     * Filter the URL used to compute the Twilio signature.
+     *
+     * Useful when WordPress sits behind a reverse proxy / load balancer
+     * that rewrites the host or path before Twilio's request reaches PHP.
+     */
+    $url = (string) apply_filters('wcwp_optout_twilio_verify_url', $url, $request);
+
+    $params = $request->get_body_params();
+    if (!is_array($params)) $params = [];
+    ksort($params);
+
+    $data = $url;
+    foreach ($params as $k => $v) {
+        $data .= $k . (is_scalar($v) ? (string) $v : '');
+    }
+
+    $expected = base64_encode(hash_hmac('sha1', $data, $auth_token, true));
+    return hash_equals($expected, $sig);
+}
+
+/**
+ * Verify a Meta Cloud webhook signature.
+ *
+ * Meta sends X-Hub-Signature-256 as "sha256=<hex>" where the HMAC is over
+ * the raw request body, keyed by the App Secret (NOT the access token).
+ *
+ * Returns null if the header / app secret are absent, true on match,
+ * false on mismatch.
+ *
+ * @param WP_REST_Request $request
+ * @return bool|null
+ */
+function wcwp_verify_meta_signature(WP_REST_Request $request) {
+    $sig_header = (string) $request->get_header('x-hub-signature-256');
+    if ($sig_header === '') return null;
+
+    $secret = (string) get_option('wcwp_cloud_app_secret', '');
+    if ($secret === '') return null;
+
+    if (strpos($sig_header, 'sha256=') !== 0) return false;
+    $sig = substr($sig_header, 7);
+
+    $body     = (string) $request->get_body();
+    $expected = hash_hmac('sha256', $body, $secret);
+
+    return hash_equals($expected, $sig);
+}
+
+function wcwp_optout_webhook_handler(WP_REST_Request $request) {
+    // Rate-limit before any other work — keeps token / signature checks
+    // from being a probing oracle.
+    $ip = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field(wp_unslash($_SERVER['REMOTE_ADDR'])) : '';
+    if (!wcwp_optout_rate_limit_ok($ip)) {
+        return new WP_REST_Response(['message' => __('Rate limited', 'woochat-pro')], 429);
+    }
+
+    // Provider-signature verification. If a known provider's signature
+    // header is present we MUST verify it; this prevents a forged request
+    // that simply sends a guessed token from succeeding when the caller
+    // claims to be Twilio / Meta.
+    $twilio = wcwp_verify_twilio_signature($request);
+    if ($twilio === false) {
+        return new WP_REST_Response(['message' => __('Invalid signature', 'woochat-pro')], 401);
+    }
+    $meta = wcwp_verify_meta_signature($request);
+    if ($meta === false) {
+        return new WP_REST_Response(['message' => __('Invalid signature', 'woochat-pro')], 401);
+    }
+
+    // If no provider signature was attempted, fall back to the static
+    // token (preserves existing custom-integration behavior).
+    if ($twilio === null && $meta === null) {
+        $token = (string) $request->get_param('token');
+        if (!$token) {
+            $header_token = $request->get_header('x-wcwp-token');
+            if ($header_token) {
+                $token = (string) $header_token;
+            }
+        }
+        $expected = (string) get_option('wcwp_optout_webhook_token', '');
+        if (!$expected || !hash_equals($expected, $token)) {
+            return new WP_REST_Response(['message' => __('Unauthorized', 'woochat-pro')], 401);
+        }
     }
 
     $from = (string) $request->get_param('from');

--- a/uninstall.php
+++ b/uninstall.php
@@ -35,6 +35,7 @@ $option_keys = [
     'wcwp_cloud_token',
     'wcwp_cloud_phone_id',
     'wcwp_cloud_from',
+    'wcwp_cloud_app_secret',
     'wcwp_cart_recovery_delay',
     'wcwp_cart_recovery_message',
     'wcwp_cart_recovery_require_consent',


### PR DESCRIPTION
## Summary

Addresses **Audit point #6** — `/wp-json/wcwp/v1/optout` is publicly reachable (`permission_callback => __return_true`) and previously gated only by a static token compared with `hash_equals`. No rate limiting, no signature verification. A leaked token (browser extension, support ticket, accidental commit) plus the open endpoint = anyone can mark customer phones as opted out and silently suppress legitimate marketing.

Three layers of defense added.

## 1. Per-IP rate limit (always on)

Default **30 requests / hour / IP**, set BEFORE any token or signature check so the endpoint can't be used as a timing/probing oracle.

Filterable for sites that legitimately receive heavy webhook traffic:

```php
add_filter('wcwp_optout_rate_limit', fn() => 200);     // requests
add_filter('wcwp_optout_rate_window', fn() => HOUR_IN_SECONDS); // window
```

Setting the limit to `0` disables the limiter entirely.

## 2. Twilio signature verification

When `X-Twilio-Signature` header is present **AND** `wcwp_twilio_auth_token` is configured, the request signature is recomputed per [Twilio's algorithm](https://www.twilio.com/docs/usage/security#validating-requests):

- HMAC-SHA1 over `full_request_url + sorted_post_params_concatenated`
- base64-encoded
- Compared with `hash_equals`

URL is filterable via `wcwp_optout_twilio_verify_url` for sites behind reverse proxies that rewrite host/path.

## 3. Meta Cloud signature verification

When `X-Hub-Signature-256` is present **AND** a new `wcwp_cloud_app_secret` option is set, signature is recomputed as `sha256=<HMAC-SHA256(app_secret, raw_body)>` and compared with `hash_equals`.

The App Secret is **different** from the access token used for sending — Meta uses it specifically for webhook signing. Added:

- New `wcwp_cloud_app_secret` option, registered with `sanitize_text_field`.
- New password input in **General → Cloud fields** section, shown only when API provider is Cloud.
- Added to `uninstall.php` cleanup list.

## Fallback (preserves existing behavior)

If neither provider signature header is present, the original token check (`?token=` query param or `X-WCWP-Token` header) is still applied. This preserves compatibility with custom / non-Twilio / non-Meta integrations that just hit the endpoint with the token.

## What stays the same

- Endpoint URL, route name (`wcwp/v1/optout`), method (POST).
- Token-based auth path (still works for clients that don't sign).
- Body parsing logic (Twilio form-encoded, Meta JSON envelope, generic `from`/`body` params).
- Opt-out keyword matching and `wcwp_add_optout` semantics.

## Test plan

- [x] **Token-only path**: hit the endpoint with a valid token and `body=stop` → confirm the number is added to the opt-out list.
- [x] **Wrong token**: hit with a bad token → 401.
- [x] **Rate limit**: hit 31 times within an hour from the same IP → confirm the 31st returns 429.
- [x] **Twilio signed (valid)**: simulate a Twilio webhook with a correct `X-Twilio-Signature` (compute against your auth token) → confirm 200.
- [x] **Twilio signed (forged)**: send with `X-Twilio-Signature: bogus` → confirm 401, with body NOT processed.
- [x] **Meta signed (valid)**: set `wcwp_cloud_app_secret`, send with `X-Hub-Signature-256: sha256=<hmac>` → confirm 200.
- [x] **Meta signed (forged)**: same setup, wrong signature → confirm 401.
- [x] **No app secret set**: send a request with `X-Hub-Signature-256: sha256=anything` while `wcwp_cloud_app_secret` is empty → falls through to token check (signature is treated as not-attempted because we can't verify). Test that token still works.
- [x] **Reverse-proxy URL filter**: if Twilio verification 401s on a fronted setup, override:
  ```php
  add_filter('wcwp_optout_twilio_verify_url', fn(\$url) => 'https://public.example.com/wp-json/wcwp/v1/optout');
  ```
  → confirm signature now verifies.
- [x] **Settings UI**: open the General tab with API Provider = Cloud → confirm new "Cloud App Secret" password field is visible, saves, and persists.

## Risk / rollback

Three-file change. Endpoint behavior is strictly additive: any caller that worked before still works (token path is unchanged). If signature verification erroneously rejects a legitimate webhook, the user can:
- Clear the corresponding option (auth token / app secret) → falls back to token-only.
- Use the URL filter for Twilio.
- Or revert this commit. No DB schema, no destructive changes.