### PR TITLE
Mark API-secret options autoload=no with run-once migration

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -26,6 +26,86 @@ function wcwp_sanitize_provider($value) {
 }
 
 /**
+ * List of option keys that hold credentials / integration config.
+ *
+ * These are only read when sending a message, on the admin settings
+ * page, or by the opt-out / license webhooks — never on every frontend
+ * page load. Keeping them OUT of the autoload set means fewer bytes
+ * pulled into wp-cache 'alloptions' on every WordPress request, and
+ * avoids unnecessarily exposing secret material in process memory.
+ *
+ * @return string[]
+ */
+function wcwp_get_secret_option_keys() {
+    return [
+        'wcwp_twilio_sid',
+        'wcwp_twilio_auth_token',
+        'wcwp_twilio_from',
+        'wcwp_cloud_token',
+        'wcwp_cloud_phone_id',
+        'wcwp_cloud_from',
+        'wcwp_cloud_app_secret',
+        'wcwp_gpt_api_key',
+        'wcwp_gpt_api_endpoint',
+        'wcwp_gpt_model',
+        'wcwp_optout_webhook_token',
+        'wcwp_license_key',
+    ];
+}
+
+/**
+ * Flip autoload to 'no' for any existing rows in the secret-keys list.
+ *
+ * Idempotent. Uses wp_set_option_autoload_values() on WP 6.4+ for a
+ * batch update; falls back to direct $wpdb on older versions.
+ */
+function wcwp_set_secrets_autoload_no() {
+    $keys = wcwp_get_secret_option_keys();
+
+    if (function_exists('wp_set_option_autoload_values')) {
+        wp_set_option_autoload_values(array_fill_keys($keys, 'no'));
+        return;
+    }
+
+    global $wpdb;
+    $placeholders = implode(',', array_fill(0, count($keys), '%s'));
+    $sql = "UPDATE {$wpdb->options} SET autoload = 'no' WHERE autoload != 'no' AND option_name IN ($placeholders)";
+    $wpdb->query($wpdb->prepare($sql, $keys));
+    wp_cache_delete('alloptions', 'options');
+}
+
+/**
+ * Ensure fresh installs create secret option rows with autoload=no
+ * before WordPress's settings.php save flow ever sees them. add_option
+ * is a no-op when the option already exists, so this is safe to call
+ * repeatedly.
+ */
+function wcwp_ensure_secret_option_rows() {
+    foreach (wcwp_get_secret_option_keys() as $key) {
+        // Fourth arg: autoload. add_option(name, value, deprecated, autoload).
+        add_option($key, '', '', 'no');
+    }
+}
+
+/**
+ * Versioned, run-once migration runner. Safe to invoke on every admin
+ * request — the version flag short-circuits after the migration has
+ * been applied.
+ */
+function wcwp_run_migrations() {
+    $stored = (int) get_option('wcwp_db_version', 0);
+
+    if ($stored < 1) {
+        wcwp_ensure_secret_option_rows();
+        wcwp_set_secrets_autoload_no();
+    }
+
+    if ($stored < 1) {
+        update_option('wcwp_db_version', 1, false);
+    }
+}
+
+/**
  * Validate a value as a 3- or 6-digit hex color (with leading #).
  *
  * Used both as a register_setting() sanitize_callback (write-time, single

--- a/uninstall.php
+++ b/uninstall.php
@@ -58,6 +58,7 @@ $option_keys = [
     'wcwp_optout_keywords',
     'wcwp_optout_list',
     'wcwp_optout_webhook_token',
+    'wcwp_db_version',
 ];
 
 foreach ($option_keys as $key) {

--- a/woochat-pro.php
+++ b/woochat-pro.php
@@ -130,7 +130,20 @@ function wcwp_activate_plugin($network_wide) {
 	if (function_exists('wcwp_schedule_cart_recovery_cron')) {
 		wcwp_schedule_cart_recovery_cron();
 	}
+	if (function_exists('wcwp_run_migrations')) {
+		wcwp_run_migrations();
+	}
 }
+
+// Run versioned migrations on admin pages too — covers WP auto-updates
+// where the activation hook does not fire. The runner short-circuits on
+// the wcwp_db_version flag so this is effectively free after the first
+// successful pass.
+add_action('admin_init', function() {
+	if (function_exists('wcwp_run_migrations')) {
+		wcwp_run_migrations();
+	}
+}, 5);
 
 function wcwp_deactivate_plugin() {
 	if (function_exists('wcwp_unschedule_cart_recovery_cron')) {


### PR DESCRIPTION
## Summary

Addresses **Audit point #7** — the plugin's credential / integration options were stored in `wp_options` with `autoload=yes` (the WP default). That meant every WordPress request — frontend pages, AJAX calls, cron, REST routes — loaded these secret strings into the autoloaded options blob and into PHP process memory, even on pages that never touch `wcwp_send_whatsapp_message`.

Two costs:
1. **Bytes** — wasted space in `wp_load_alloptions()` and the cache key it produces, slower on every request.
2. **Exposure** — secret material sitting in process memory on requests that have no business knowing it.

## Scope

The 12 keys flipped to `autoload=no`:

```
wcwp_twilio_sid, wcwp_twilio_auth_token, wcwp_twilio_from,
wcwp_cloud_token, wcwp_cloud_phone_id, wcwp_cloud_from, wcwp_cloud_app_secret,
wcwp_gpt_api_key, wcwp_gpt_api_endpoint, wcwp_gpt_model,
wcwp_optout_webhook_token, wcwp_license_key
```

These are all read **only** when sending a message, on the admin settings page, by the opt-out webhook, or during license validation — never on the hot frontend path.

Options that **ARE** read on every frontend `wp_footer` (`wcwp_chatbot_enabled`, `wcwp_cart_recovery_enabled`, `wcwp_license_status`) intentionally remain autoloaded — flipping them would cost an extra DB roundtrip on every page load for sites without persistent object cache.

## Implementation

`includes/helpers.php` — new functions:

- `wcwp_get_secret_option_keys()` — single source of truth for the list.
- `wcwp_set_secrets_autoload_no()` — flips existing rows. Uses WP 6.4+ `wp_set_option_autoload_values()` for a batch update + cache invalidation when available; falls back to a single prepared `\$wpdb->query` plus `wp_cache_delete('alloptions','options')` on older WP.
- `wcwp_ensure_secret_option_rows()` — `add_option(\$key, '', '', 'no')` for each. Idempotent. Ensures fresh installs never let the WP `options.php` save flow create the row with `autoload=yes`.
- `wcwp_run_migrations()` — version-gated on a new `wcwp_db_version` option (`0` → `1`). Effectively free after the first successful pass.

`woochat-pro.php`:
- Activation hook now calls `wcwp_run_migrations()` after the table-create steps.
- `admin_init` priority 5 also calls it — covers WP auto-update flows where activation does **not** re-fire.

`uninstall.php`:
- `wcwp_db_version` added to the cleanup list.

## What stays the same

- All option **values** are unchanged. Save flow through Settings API is unchanged. WP `update_option` preserves the existing `autoload` flag on update.
- No schema changes. No nonce / capability changes. No public function signatures changed.
- The selected keys are read in exactly the same places they were before.

## Test plan

- [x] **Fresh install**: deactivate the plugin, drop `wp_wcwp_*` options + the keys above, reactivate → verify `wcwp_db_version=1`, all 12 secret keys exist in `wp_options` with `autoload='no'` (empty values), and the settings page loads without warnings.
- [x] **Existing install**: activate the plugin in an env that already has secret values saved → verify the values survive intact, `autoload` flips to `'no'` for all 12 keys.
- [x] **Save settings**: enter a Twilio token in the General tab, hit Save → verify the value persists, `autoload` stays `'no'`.
- [x] **Send a real message** (test mode is fine): trigger a manual send / cart-recovery → confirm the credentials are still readable and the send works.
- [x] **License flow**: activate / deactivate the license → confirm `wcwp_license_key` value persists with `autoload=no`.
- [x] **Idempotency**: visit `/wp-admin/` twice → confirm `wcwp_db_version` stays at `1` (no thrash, no extra writes).
- [x] **Uninstall**: enable "Delete data on uninstall", uninstall the plugin → confirm all secret keys plus `wcwp_db_version` are removed.

You can verify autoload via `wp db query` or:
```sql
SELECT option_name, autoload FROM wp_options WHERE option_name LIKE 'wcwp_%';
```

## Risk / rollback

Pure data-layer hardening. If anything goes wrong:
- Reverting the commit only removes the helper / hook calls; existing rows keep `autoload='no'` (no harm — they're still loaded on demand).
- To restore `autoload='yes'` for any specific row: `UPDATE wp_options SET autoload='yes' WHERE option_name='...'` and clear the alloptions cache.