### PR TITLE
Drop option-store analytics fallback (audit #10)

### DIFF
--- a/includes/analytics.php
+++ b/includes/analytics.php
@@ -1,9 +1,6 @@
 <?php
 if (!defined('ABSPATH')) exit;
 
-// Simple in-option analytics store with capped events
-const WCWP_ANALYTICS_MAX_EVENTS = 200;
-
 // Click-tracking redirect handler — only attach when the parameter is
 // actually present, and only on frontend requests. Tracking URLs are
 // always built against home_url('/'), so template_redirect is the right
@@ -19,13 +16,6 @@ add_action('wcwp_cleanup_analytics', 'wcwp_cleanup_analytics');
 function wcwp_get_analytics_table_name() {
     global $wpdb;
     return $wpdb->prefix . 'wcwp_analytics_events';
-}
-
-function wcwp_analytics_table_exists() {
-    global $wpdb;
-    $table = wcwp_get_analytics_table_name();
-    $exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table));
-    return $exists === $table;
 }
 
 function wcwp_create_analytics_table() {
@@ -64,7 +54,6 @@ function wcwp_create_analytics_table() {
 function wcwp_cleanup_analytics() {
     $days = absint(get_option('wcwp_data_retention_days', 0));
     if ($days < 1) return;
-    if (!wcwp_analytics_table_exists()) return;
 
     global $wpdb;
     $table = wcwp_get_analytics_table_name();
@@ -88,115 +77,11 @@ function wcwp_analytics_log_event($type, $data = []) {
         'meta' => isset($data['meta']) && is_array($data['meta']) ? $data['meta'] : [],
     ];
 
-    if (wcwp_analytics_table_exists()) {
-        wcwp_analytics_insert_event($event);
-        return $id;
-    }
-
-    $events = get_option('wcwp_analytics_events', []);
-    array_unshift($events, $event);
-    $events = wcwp_analytics_apply_retention($events);
-    if (count($events) > WCWP_ANALYTICS_MAX_EVENTS) {
-        $events = array_slice($events, 0, WCWP_ANALYTICS_MAX_EVENTS);
-    }
-
-    update_option('wcwp_analytics_events', $events, false);
+    wcwp_analytics_insert_event($event);
     return $id;
 }
 
 function wcwp_analytics_update_event($event_id, $fields = []) {
-    if (wcwp_analytics_table_exists()) {
-        wcwp_analytics_update_event_row($event_id, $fields);
-        return;
-    }
-
-    $events = get_option('wcwp_analytics_events', []);
-    $updated = false;
-    foreach ($events as &$evt) {
-        if (!isset($evt['id']) || $evt['id'] !== $event_id) continue;
-        foreach ($fields as $key => $val) {
-            if ($key === 'meta' && is_array($val)) {
-                $evt['meta'] = array_merge(isset($evt['meta']) && is_array($evt['meta']) ? $evt['meta'] : [], $val);
-            } else {
-                $evt[$key] = $val;
-            }
-        }
-        $updated = true;
-        break;
-    }
-    if ($updated) {
-        update_option('wcwp_analytics_events', $events, false);
-    }
-}
-
-function wcwp_analytics_increment_total($bucket, $amount = 1) {
-    $totals = get_option('wcwp_analytics_totals', [
-        'sent' => 0,
-        'delivered' => 0,
-        'clicked' => 0,
-    ]);
-    if (!isset($totals[$bucket])) {
-        $totals[$bucket] = 0;
-    }
-    $totals[$bucket] += $amount;
-    update_option('wcwp_analytics_totals', $totals, false);
-}
-
-function wcwp_analytics_get_totals() {
-    if (wcwp_analytics_table_exists()) {
-        global $wpdb;
-        $table = wcwp_get_analytics_table_name();
-        $rows = $wpdb->get_results("SELECT status, COUNT(*) AS total FROM {$table} GROUP BY status");
-        $totals = [ 'sent' => 0, 'delivered' => 0, 'clicked' => 0 ];
-        if ($rows) {
-            foreach ($rows as $row) {
-                if (isset($totals[$row->status])) {
-                    $totals[$row->status] = intval($row->total);
-                }
-            }
-        }
-        return $totals;
-    }
-
-    $defaults = [ 'sent' => 0, 'delivered' => 0, 'clicked' => 0 ];
-    $totals = get_option('wcwp_analytics_totals', $defaults);
-    return wp_parse_args($totals, $defaults);
-}
-
-function wcwp_analytics_get_events($limit = 50, $filters = []) {
-    if (wcwp_analytics_table_exists()) {
-        return wcwp_analytics_get_events_db($limit, $filters);
-    }
-
-    $events = get_option('wcwp_analytics_events', []);
-    $events = wcwp_analytics_apply_retention($events);
-    update_option('wcwp_analytics_events', $events, false);
-    return array_slice($events, 0, absint($limit));
-}
-
-function wcwp_analytics_insert_event($event) {
-    global $wpdb;
-    $table = wcwp_get_analytics_table_name();
-    $wpdb->insert(
-        $table,
-        [
-            'event_id' => $event['id'],
-            'type' => $event['type'],
-            'status' => $event['status'],
-            'phone' => $event['phone'],
-            'order_id' => $event['order_id'],
-            'message_preview' => $event['message_preview'],
-            'provider' => $event['provider'],
-            'message_id' => $event['message_id'],
-            'meta' => wp_json_encode($event['meta']),
-            'created_at' => $event['time'],
-            'updated_at' => $event['time'],
-        ],
-        ['%s','%s','%s','%s','%d','%s','%s','%s','%s','%s','%s']
-    );
-}
-
-function wcwp_analytics_update_event_row($event_id, $fields = []) {
     global $wpdb;
     $table = wcwp_get_analytics_table_name();
 
@@ -219,7 +104,31 @@ function wcwp_analytics_update_event_row($event_id, $fields = []) {
     }
 }
 
-function wcwp_analytics_get_events_db($limit = 50, $filters = []) {
+/**
+ * @deprecated 1.0.2 Totals are derived from the analytics events table; this
+ * is now a no-op kept only for backward compatibility with any external
+ * code that may still call it. See wcwp_analytics_get_totals().
+ */
+function wcwp_analytics_increment_total($bucket, $amount = 1) {
+    // No-op.
+}
+
+function wcwp_analytics_get_totals() {
+    global $wpdb;
+    $table = wcwp_get_analytics_table_name();
+    $rows = $wpdb->get_results("SELECT status, COUNT(*) AS total FROM {$table} GROUP BY status");
+    $totals = [ 'sent' => 0, 'delivered' => 0, 'clicked' => 0 ];
+    if ($rows) {
+        foreach ($rows as $row) {
+            if (isset($totals[$row->status])) {
+                $totals[$row->status] = intval($row->total);
+            }
+        }
+    }
+    return $totals;
+}
+
+function wcwp_analytics_get_events($limit = 50, $filters = []) {
     global $wpdb;
     $table = wcwp_get_analytics_table_name();
 
@@ -267,19 +176,26 @@ function wcwp_analytics_get_events_db($limit = 50, $filters = []) {
     return $rows;
 }
 
-function wcwp_analytics_apply_retention($events) {
-    $days = absint(get_option('wcwp_data_retention_days', 0));
-    if ($days < 1) return $events;
-    $cutoff = time() - ($days * DAY_IN_SECONDS);
-    $filtered = [];
-    foreach ($events as $evt) {
-        $time_str = isset($evt['time']) ? $evt['time'] : '';
-        $ts = $time_str ? strtotime($time_str) : 0;
-        if ($ts && $ts >= $cutoff) {
-            $filtered[] = $evt;
-        }
-    }
-    return $filtered;
+function wcwp_analytics_insert_event($event) {
+    global $wpdb;
+    $table = wcwp_get_analytics_table_name();
+    $wpdb->insert(
+        $table,
+        [
+            'event_id' => $event['id'],
+            'type' => $event['type'],
+            'status' => $event['status'],
+            'phone' => $event['phone'],
+            'order_id' => $event['order_id'],
+            'message_preview' => $event['message_preview'],
+            'provider' => $event['provider'],
+            'message_id' => $event['message_id'],
+            'meta' => wp_json_encode($event['meta']),
+            'created_at' => $event['time'],
+            'updated_at' => $event['time'],
+        ],
+        ['%s','%s','%s','%s','%d','%s','%s','%s','%s','%s','%s']
+    );
 }
 
 function wcwp_analytics_tracking_url($event_id, $redirect_url) {
@@ -346,7 +262,6 @@ function wcwp_handle_tracking_request() {
     $event_id = isset($_GET['event_id']) ? sanitize_text_field(wp_unslash($_GET['event_id'])) : '';
 
     if ($type === 'click' && $event_id) {
-        wcwp_analytics_increment_total('clicked');
         wcwp_analytics_update_event($event_id, ['status' => 'clicked']);
     }
 
@@ -366,7 +281,6 @@ function wcwp_track_event_ajax() {
         wp_send_json_error(['message' => __('Missing data', 'woochat-pro')], 400);
     }
     if ($type === 'delivered') {
-        wcwp_analytics_increment_total('delivered');
         wcwp_analytics_update_event($event_id, ['status' => 'delivered']);
     }
     wp_send_json_success();

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -98,11 +98,52 @@ function wcwp_run_migrations() {
     if ($stored < 1) {
         wcwp_ensure_secret_option_rows();
         wcwp_set_secrets_autoload_no();
+        update_option('wcwp_db_version', 1, false);
+        $stored = 1;
     }
 
-    if ($stored < 1) {
-        update_option('wcwp_db_version', 1, false);
+    if ($stored < 2) {
+        wcwp_migrate_analytics_options_to_table();
+        update_option('wcwp_db_version', 2, false);
+        $stored = 2;
     }
+}
+
+/**
+ * Move any legacy option-store analytics rows into the events table, then
+ * drop the option keys. The option-store fallback was retired in favor of
+ * a single source of truth (the {prefix}wcwp_analytics_events table); this
+ * runs once per install to carry forward any data that accumulated while
+ * the table-creation activation hook had not yet fired (e.g. very early
+ * installs that activated before the table existed).
+ */
+function wcwp_migrate_analytics_options_to_table() {
+    if (function_exists('wcwp_create_analytics_table')) {
+        wcwp_create_analytics_table();
+    }
+
+    $events = get_option('wcwp_analytics_events', []);
+    if (is_array($events) && !empty($events) && function_exists('wcwp_analytics_insert_event')) {
+        foreach ($events as $event) {
+            if (!is_array($event) || empty($event['id']) || empty($event['type'])) continue;
+            $event = wp_parse_args($event, [
+                'id' => '',
+                'type' => '',
+                'time' => current_time('mysql'),
+                'status' => 'pending',
+                'phone' => '',
+                'order_id' => 0,
+                'message_preview' => '',
+                'provider' => '',
+                'message_id' => '',
+                'meta' => [],
+            ]);
+            wcwp_analytics_insert_event($event);
+        }
+    }
+
+    delete_option('wcwp_analytics_events');
+    delete_option('wcwp_analytics_totals');
 }
 
 /**

--- a/includes/messaging.php
+++ b/includes/messaging.php
@@ -174,9 +174,6 @@ function wcwp_send_whatsapp_message( $to, $message, $manual = false, $context = 
             'message_id' => $result['message_id'] ?? '',
         ] );
     }
-    if ( function_exists( 'wcwp_analytics_increment_total' ) ) {
-        wcwp_analytics_increment_total( 'sent' );
-    }
     return true;
 }
 


### PR DESCRIPTION
## Summary

Audit point #10 — drop the dead option-store fallback in `includes/analytics.php`. The plugin maintained both an option-based store (`wcwp_analytics_events`, `wcwp_analytics_totals`) and a custom DB table (`{prefix}wcwp_analytics_events`), with `wcwp_analytics_table_exists()` switching every getter and setter between the two. The table is created on activation, so the option path was unreachable for reads but still wrote dead rows on every incoming event.

This PR removes that branch entirely, derives totals from the events table, and adds a one-time migration to clean up the legacy option rows.

## What changed

**`includes/analytics.php`**
- Removed `WCWP_ANALYTICS_MAX_EVENTS`, `wcwp_analytics_table_exists()`, `wcwp_analytics_apply_retention()` — option-store-only helpers.
- `wcwp_analytics_log_event()` / `_update_event()` / `_get_totals()` / `_get_events()` now go straight to the DB with no branching.
- `wcwp_analytics_increment_total()` is preserved as a `@deprecated` no-op so any external integration still loads cleanly. It was already a dead write — `get_totals()` has been reading `COUNT(*) GROUP BY status` from the table whenever the table exists.
- `wcwp_cleanup_analytics()` loses its table-existence guard — table is guaranteed by activation + migration v2.

**`includes/helpers.php`**
- Adds migration v2 (`wcwp_migrate_analytics_options_to_table`): ensures the table exists, copies any leftover `wcwp_analytics_events` option rows into it, deletes both `wcwp_analytics_events` and `wcwp_analytics_totals` options, bumps `wcwp_db_version` to 2.
- Restructured `wcwp_run_migrations()` so each completed step bumps the version inline — partial failures cannot strand the install at a stale version.

**`includes/messaging.php`**
- Removed the redundant `wcwp_analytics_increment_total('sent')` call after a successful send. Totals are derived from the event row's status (which the same code path already sets).

## What stays the same

- All public function signatures (`wcwp_analytics_log_event`, `wcwp_analytics_update_event`, `wcwp_analytics_get_totals`, `wcwp_analytics_get_events`, `wcwp_analytics_increment_total`).
- Observable behavior of the dashboard totals widget — the table reader was already the live code path; the option totals were dead writes.
- `uninstall.php` still deletes the legacy option keys defensively in case a site is uninstalled before the migration ran.

## Test plan

- [x] Fresh activate on a clean install: analytics table created, `wcwp_db_version` = 2, no `wcwp_analytics_events` / `wcwp_analytics_totals` options exist.
- [x] Upgrade from a pre-migration site: pre-existing option rows (if any) are copied into the table; option keys deleted afterwards.
- [x] Send a test message: event row inserted with status `pending`, transitions to `sent` (or `failed`/`test`).
- [x] Click a tracking URL: redirect target validated, event row status flips to `clicked`.
- [x] Delivery webhook (AJAX): event row status flips to `delivered`.
- [x] Dashboard widget renders sent / open-rate / clicked totals from the table.
- [x] Analytics tab filters (type, status, phone, date range) still work.
- [x] `wcwp_cleanup_analytics` cron deletes rows older than `wcwp_data_retention_days` when set.

## Risk / rollback

Low — no schema changes. Public function signatures preserved, including the deprecated no-op `wcwp_analytics_increment_total()`. Rollback is `git revert` — the migration writes are idempotent (`delete_option` is a no-op for missing keys, `wcwp_db_version` only counts up).