### PR TITLE
Introduce WooChatPro\Plugin class for bootstrap orchestration (audit #13)

### DIFF
--- a/includes/class-wcwp-plugin.php
+++ b/includes/class-wcwp-plugin.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * WooChat Pro plugin entry-point class.
+ *
+ * Owns bootstrap orchestration: HPOS compat declaration, text domain
+ * loading, WooCommerce-dependency gate, module require chain, activation
+ * / deactivation logic, migration runner wiring, and the front-end UUID
+ * polyfill enqueue. The procedural helpers in includes/*.php are still
+ * the implementation surface for now — this class is a thin orchestrator
+ * that loads them and registers the plugin's top-level hooks.
+ */
+
+namespace WooChatPro;
+
+if (!defined('ABSPATH')) exit;
+
+final class Plugin {
+    /** @var Plugin|null */
+    private static $instance = null;
+
+    public static function instance() {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    private function __construct() {}
+
+    /**
+     * Wire up the plugin: HPOS compat, i18n, dependency gate, modules,
+     * migrations, polyfill, and the plugins-page row notice.
+     */
+    public function init() {
+        add_action('before_woocommerce_init', [$this, 'declare_hpos_compat']);
+        add_action('init', [$this, 'load_textdomain']);
+
+        if (function_exists('wcwp_is_woocommerce_active') && wcwp_is_woocommerce_active()) {
+            $this->boot_modules();
+        } else {
+            add_action('admin_notices', [$this, 'render_wc_admin_notice']);
+            add_action('network_admin_notices', [$this, 'render_wc_network_admin_notice']);
+        }
+
+        // Migrations also run on admin requests — covers WP auto-updates
+        // where the activation hook never fires. Short-circuits on the
+        // wcwp_db_version flag, so this is effectively free post-migration.
+        add_action('admin_init', [$this, 'run_migrations'], 5);
+
+        add_action('admin_init', [$this, 'enforce_woocommerce_dependency']);
+
+        add_action(
+            'after_plugin_row_' . plugin_basename(WCWP_PLUGIN_FILE),
+            [$this, 'render_plugin_row_notice'],
+            10,
+            3
+        );
+
+        add_action('wp_enqueue_scripts', [$this, 'enqueue_uuid_polyfill'], 1);
+    }
+
+    public function declare_hpos_compat() {
+        if (class_exists(\Automattic\WooCommerce\Utilities\FeaturesUtil::class)) {
+            \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('custom_order_tables', WCWP_PLUGIN_FILE, true);
+        }
+    }
+
+    public function load_textdomain() {
+        load_plugin_textdomain('woochat-pro', false, dirname(plugin_basename(WCWP_PLUGIN_FILE)) . '/languages');
+    }
+
+    /**
+     * Load every module file. Order matters — providers come before the
+     * messaging dispatcher that resolves them via wcwp_get_provider().
+     */
+    public function boot_modules() {
+        require_once WCWP_PATH . 'includes/providers/abstract-class-wcwp-provider.php';
+        require_once WCWP_PATH . 'includes/providers/class-wcwp-provider-twilio.php';
+        require_once WCWP_PATH . 'includes/providers/class-wcwp-provider-cloud.php';
+        require_once WCWP_PATH . 'includes/messaging.php';
+
+        require_once WCWP_PATH . 'includes/analytics.php';
+        require_once WCWP_PATH . 'admin/settings-page.php';
+        require_once WCWP_PATH . 'includes/chatbot-engine.php';
+        require_once WCWP_PATH . 'includes/license-manager.php';
+        require_once WCWP_PATH . 'includes/optout.php';
+        require_once WCWP_PATH . 'includes/update-checker.php';
+
+        require_once WCWP_PATH . 'includes/order-hooks.php';
+        require_once WCWP_PATH . 'includes/cart-recovery.php';
+        require_once WCWP_PATH . 'includes/scheduler.php';
+    }
+
+    public function run_migrations() {
+        if (function_exists('wcwp_run_migrations')) {
+            wcwp_run_migrations();
+        }
+    }
+
+    public function activate($network_wide) {
+        if (!function_exists('wcwp_is_woocommerce_active') || !wcwp_is_woocommerce_active()) {
+            $this->die_missing_woocommerce($network_wide);
+        }
+        if (function_exists('wcwp_create_cart_recovery_table')) {
+            wcwp_create_cart_recovery_table();
+        }
+        if (function_exists('wcwp_create_analytics_table')) {
+            wcwp_create_analytics_table();
+        }
+        if (function_exists('wcwp_schedule_cart_recovery_cron')) {
+            wcwp_schedule_cart_recovery_cron();
+        }
+        if (function_exists('wcwp_run_migrations')) {
+            wcwp_run_migrations();
+        }
+    }
+
+    public function deactivate() {
+        if (function_exists('wcwp_unschedule_cart_recovery_cron')) {
+            wcwp_unschedule_cart_recovery_cron();
+        }
+    }
+
+    /**
+     * Self-deactivate when WooCommerce is not active. Catches the case
+     * where WC was deactivated without our activation hook firing.
+     */
+    public function enforce_woocommerce_dependency() {
+        if (!function_exists('is_plugin_active')) {
+            include_once ABSPATH . 'wp-admin/includes/plugin.php';
+        }
+        if (function_exists('wcwp_is_woocommerce_active')
+            && !wcwp_is_woocommerce_active()
+            && is_plugin_active(plugin_basename(WCWP_PLUGIN_FILE))
+        ) {
+            deactivate_plugins(plugin_basename(WCWP_PLUGIN_FILE));
+            add_action('admin_notices', function() {
+                if (!current_user_can('activate_plugins')) return;
+                echo '<div class="notice notice-error"><p><strong>'
+                    . esc_html__('WooChat Pro', 'woochat-pro') . '</strong> '
+                    . esc_html__('was deactivated because WooCommerce is not active.', 'woochat-pro')
+                    . '</p></div>';
+            });
+        }
+    }
+
+    public function render_wc_admin_notice() {
+        if (!current_user_can('activate_plugins')) return;
+        $screen = function_exists('get_current_screen') ? get_current_screen() : null;
+        if ($screen && $screen->id !== 'plugins') return;
+        echo '<div class="notice notice-error"><p>' . $this->dependency_notice_message() . '</p></div>';
+    }
+
+    public function render_wc_network_admin_notice() {
+        if (!current_user_can('activate_plugins')) return;
+        $screen = function_exists('get_current_screen') ? get_current_screen() : null;
+        if ($screen && $screen->id !== 'plugins-network') return;
+        echo '<div class="notice notice-error"><p>' . $this->dependency_notice_message() . '</p></div>';
+    }
+
+    public function render_plugin_row_notice($plugin_file, $plugin_data, $status) {
+        if (function_exists('wcwp_is_woocommerce_active') && wcwp_is_woocommerce_active()) return;
+        if (!current_user_can('activate_plugins')) return;
+        echo '<tr class="plugin-update-tr"><td colspan="3" class="plugin-update colspanchange"><div class="update-message notice inline notice-error notice-alt"><p>'
+            . $this->dependency_notice_message()
+            . '</p></div></td></tr>';
+    }
+
+    /**
+     * Browser polyfill — only loaded when chatbot or cart recovery is on.
+     * Enqueued at priority 1 with in_footer=false so it lands in <head>
+     * before any consumer scripts. Loading as a real asset (not inline)
+     * keeps the page CSP-friendly and avoids shipping bytes when both
+     * features are off.
+     */
+    public function enqueue_uuid_polyfill() {
+        $chatbot_on = get_option('wcwp_chatbot_enabled', 'no') === 'yes';
+        $cart_on    = get_option('wcwp_cart_recovery_enabled', 'no') === 'yes';
+        if (!$chatbot_on && !$cart_on) {
+            return;
+        }
+        wp_enqueue_script(
+            'wcwp-uuid-polyfill',
+            WCWP_URL . 'assets/js/uuid-polyfill.js',
+            [],
+            WCWP_VERSION,
+            false
+        );
+    }
+
+    private function die_missing_woocommerce($network_wide) {
+        if ($network_wide && is_multisite()) {
+            if (!function_exists('is_plugin_active_for_network')) {
+                include_once ABSPATH . 'wp-admin/includes/plugin.php';
+            }
+            if (function_exists('is_plugin_active_for_network') && !is_plugin_active_for_network('woocommerce/woocommerce.php')) {
+                deactivate_plugins(plugin_basename(WCWP_PLUGIN_FILE));
+                $plugins_url = network_admin_url('plugins.php');
+                wp_die(
+                    '<p><strong>' . esc_html__('WooChat Pro', 'woochat-pro') . '</strong> '
+                    . esc_html__('requires WooCommerce to be network-activated.', 'woochat-pro')
+                    . '</p><p><a href="' . esc_url($plugins_url) . '">'
+                    . esc_html__('Return to Plugins', 'woochat-pro') . '</a></p>',
+                    esc_html__('WooChat Pro', 'woochat-pro'),
+                    ['response' => 200]
+                );
+            }
+        }
+        deactivate_plugins(plugin_basename(WCWP_PLUGIN_FILE));
+        $plugins_url = is_network_admin() ? network_admin_url('plugins.php') : admin_url('plugins.php');
+        wp_die(
+            '<p><strong>' . esc_html__('WooChat Pro', 'woochat-pro') . '</strong> '
+            . esc_html__('requires WooCommerce to be installed and active.', 'woochat-pro')
+            . '</p><p><a href="' . esc_url($plugins_url) . '">'
+            . esc_html__('Return to Plugins', 'woochat-pro') . '</a></p>',
+            esc_html__('WooChat Pro', 'woochat-pro'),
+            ['response' => 200]
+        );
+    }
+
+    private function dependency_link() {
+        $plugin_file = 'woocommerce/woocommerce.php';
+        $is_installed = file_exists(WP_PLUGIN_DIR . '/' . $plugin_file);
+
+        if ($is_installed) {
+            if (current_user_can('activate_plugins')) {
+                $url = wp_nonce_url(self_admin_url('plugins.php?action=activate&plugin=' . $plugin_file), 'activate-plugin_' . $plugin_file);
+                return '<a href="' . esc_url($url) . '">' . esc_html__('Activate WooCommerce', 'woochat-pro') . '</a>';
+            }
+            return '';
+        }
+
+        if (current_user_can('install_plugins')) {
+            $url = wp_nonce_url(self_admin_url('update.php?action=install-plugin&plugin=woocommerce'), 'install-plugin_woocommerce');
+            return '<a href="' . esc_url($url) . '">' . esc_html__('Install WooCommerce', 'woochat-pro') . '</a>';
+        }
+
+        return '';
+    }
+
+    private function dependency_notice_message() {
+        $link = $this->dependency_link();
+        $tail = $link ? ' ' . $link . '.' : '';
+        return '<strong>' . esc_html__('WooChat Pro', 'woochat-pro') . '</strong> '
+            . esc_html__('requires WooCommerce. Please install and activate WooCommerce.', 'woochat-pro')
+            . $tail;
+    }
+}

--- a/woochat-pro.php
+++ b/woochat-pro.php
@@ -23,177 +23,27 @@ define( 'WCWP_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WCWP_URL', plugin_dir_url( __FILE__ ) );
 define( 'WCWP_PLUGIN_FILE', __FILE__ );
 
-// HPOS compatibility declaration.
-add_action( 'before_woocommerce_init', function () {
-	if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
-		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
-	}
-} );
-
-// Load text domain for translations.
-add_action( 'init', function () {
-	load_plugin_textdomain( 'woochat-pro', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
-} );
-
-// Load helpers early for dependency checks.
+// Helpers must load before the plugin class so its dependency checks
+// (wcwp_is_woocommerce_active) can resolve.
 require_once WCWP_PATH . 'includes/helpers.php';
+require_once WCWP_PATH . 'includes/class-wcwp-plugin.php';
 
-function wcwp_wc_dependency_link() {
-	$plugin_file = 'woocommerce/woocommerce.php';
-	$is_installed = file_exists(WP_PLUGIN_DIR . '/' . $plugin_file);
+\WooChatPro\Plugin::instance()->init();
 
-	if ($is_installed) {
-		if (current_user_can('activate_plugins')) {
-			$url = wp_nonce_url(self_admin_url('plugins.php?action=activate&plugin=' . $plugin_file), 'activate-plugin_' . $plugin_file);
-			return '<a href="' . esc_url($url) . '">' . esc_html__('Activate WooCommerce', 'woochat-pro') . '</a>';
-		}
-		return '';
-	}
+register_activation_hook( __FILE__, 'wcwp_activate_plugin' );
+register_deactivation_hook( __FILE__, 'wcwp_deactivate_plugin' );
 
-	if (current_user_can('install_plugins')) {
-		$url = wp_nonce_url(self_admin_url('update.php?action=install-plugin&plugin=woocommerce'), 'install-plugin_woocommerce');
-		return '<a href="' . esc_url($url) . '">' . esc_html__('Install WooCommerce', 'woochat-pro') . '</a>';
-	}
-
-	return '';
+/**
+ * Global activation/deactivation shims. WordPress invokes these by name
+ * via register_activation_hook / register_deactivation_hook, so they
+ * cannot be class methods (the callback is resolved by string at the
+ * time WP fires the hook, before class autoloading). Both delegate to
+ * the Plugin singleton.
+ */
+function wcwp_activate_plugin( $network_wide ) {
+	\WooChatPro\Plugin::instance()->activate( $network_wide );
 }
-
-function wcwp_wc_dependency_notice_message() {
-	$link = wcwp_wc_dependency_link();
-	$tail = $link ? ' ' . $link . '.' : '';
-	return '<strong>' . esc_html__('WooChat Pro', 'woochat-pro') . '</strong> ' . esc_html__('requires WooCommerce. Please install and activate WooCommerce.', 'woochat-pro') . $tail;
-}
-
-function wcwp_bootstrap() {
-	// Provider classes — load before messaging.php / order-hooks.php so
-	// the dispatcher can resolve them via wcwp_get_provider().
-	require_once WCWP_PATH . 'includes/providers/abstract-class-wcwp-provider.php';
-	require_once WCWP_PATH . 'includes/providers/class-wcwp-provider-twilio.php';
-	require_once WCWP_PATH . 'includes/providers/class-wcwp-provider-cloud.php';
-	require_once WCWP_PATH . 'includes/messaging.php';
-
-	require_once WCWP_PATH . 'includes/analytics.php';
-	require_once WCWP_PATH . 'admin/settings-page.php';
-	require_once WCWP_PATH . 'includes/chatbot-engine.php';
-	require_once WCWP_PATH . 'includes/license-manager.php';
-	require_once WCWP_PATH . 'includes/optout.php';
-	require_once WCWP_PATH . 'includes/update-checker.php';
-
-	require_once WCWP_PATH . 'includes/order-hooks.php';
-	require_once WCWP_PATH . 'includes/cart-recovery.php';
-	require_once WCWP_PATH . 'includes/scheduler.php';
-}
-
-if (function_exists('wcwp_is_woocommerce_active') && wcwp_is_woocommerce_active()) {
-	wcwp_bootstrap();
-} else {
-	add_action('admin_notices', function() {
-		if (!current_user_can('activate_plugins')) return;
-		$screen = function_exists('get_current_screen') ? get_current_screen() : null;
-		if ($screen && $screen->id !== 'plugins') return;
-		echo '<div class="notice notice-error"><p>' . wcwp_wc_dependency_notice_message() . '</p></div>';
-	});
-	add_action('network_admin_notices', function() {
-		if (!current_user_can('activate_plugins')) return;
-		$screen = function_exists('get_current_screen') ? get_current_screen() : null;
-		if ($screen && $screen->id !== 'plugins-network') return;
-		echo '<div class="notice notice-error"><p>' . wcwp_wc_dependency_notice_message() . '</p></div>';
-	});
-}
-
-register_activation_hook(__FILE__, 'wcwp_activate_plugin');
-register_deactivation_hook(__FILE__, 'wcwp_deactivate_plugin');
-
-function wcwp_activate_plugin($network_wide) {
-	if (!function_exists('wcwp_is_woocommerce_active') || !wcwp_is_woocommerce_active()) {
-		if ($network_wide && is_multisite()) {
-			if (!function_exists('is_plugin_active_for_network')) {
-				include_once ABSPATH . 'wp-admin/includes/plugin.php';
-			}
-			if (function_exists('is_plugin_active_for_network') && !is_plugin_active_for_network('woocommerce/woocommerce.php')) {
-				deactivate_plugins(plugin_basename(__FILE__));
-				$plugins_url = network_admin_url('plugins.php');
-				wp_die(
-				'<p><strong>' . esc_html__('WooChat Pro', 'woochat-pro') . '</strong> ' . esc_html__('requires WooCommerce to be network-activated.', 'woochat-pro') . '</p><p><a href="' . esc_url($plugins_url) . '">' . esc_html__('Return to Plugins', 'woochat-pro') . '</a></p>',
-				esc_html__('WooChat Pro', 'woochat-pro'),
-					['response' => 200]
-				);
-			}
-		}
-		deactivate_plugins(plugin_basename(__FILE__));
-		$plugins_url = is_network_admin() ? network_admin_url('plugins.php') : admin_url('plugins.php');
-		wp_die(
-		'<p><strong>' . esc_html__('WooChat Pro', 'woochat-pro') . '</strong> ' . esc_html__('requires WooCommerce to be installed and active.', 'woochat-pro') . '</p><p><a href="' . esc_url($plugins_url) . '">' . esc_html__('Return to Plugins', 'woochat-pro') . '</a></p>',
-		esc_html__('WooChat Pro', 'woochat-pro'),
-			['response' => 200]
-		);
-	}
-	if (function_exists('wcwp_create_cart_recovery_table')) {
-		wcwp_create_cart_recovery_table();
-	}
-	if (function_exists('wcwp_create_analytics_table')) {
-		wcwp_create_analytics_table();
-	}
-	if (function_exists('wcwp_schedule_cart_recovery_cron')) {
-		wcwp_schedule_cart_recovery_cron();
-	}
-	if (function_exists('wcwp_run_migrations')) {
-		wcwp_run_migrations();
-	}
-}
-
-// Run versioned migrations on admin pages too — covers WP auto-updates
-// where the activation hook does not fire. The runner short-circuits on
-// the wcwp_db_version flag so this is effectively free after the first
-// successful pass.
-add_action('admin_init', function() {
-	if (function_exists('wcwp_run_migrations')) {
-		wcwp_run_migrations();
-	}
-}, 5);
 
 function wcwp_deactivate_plugin() {
-	if (function_exists('wcwp_unschedule_cart_recovery_cron')) {
-		wcwp_unschedule_cart_recovery_cron();
-	}
+	\WooChatPro\Plugin::instance()->deactivate();
 }
-
-add_action('admin_init', function() {
-	if (!function_exists('is_plugin_active')) {
-		include_once ABSPATH . 'wp-admin/includes/plugin.php';
-	}
-	if (function_exists('wcwp_is_woocommerce_active') && !wcwp_is_woocommerce_active() && is_plugin_active(plugin_basename(__FILE__))) {
-		deactivate_plugins(plugin_basename(__FILE__));
-		add_action('admin_notices', function() {
-			if (!current_user_can('activate_plugins')) return;
-			echo '<div class="notice notice-error"><p><strong>' . esc_html__('WooChat Pro', 'woochat-pro') . '</strong> ' . esc_html__('was deactivated because WooCommerce is not active.', 'woochat-pro') . '</p></div>';
-		});
-	}
-});
-
-add_action('after_plugin_row_' . plugin_basename(__FILE__), function($plugin_file, $plugin_data, $status) {
-	if (function_exists('wcwp_is_woocommerce_active') && wcwp_is_woocommerce_active()) return;
-	if (!current_user_can('activate_plugins')) return;
-	echo '<tr class="plugin-update-tr"><td colspan="3" class="plugin-update colspanchange"><div class="update-message notice inline notice-error notice-alt"><p>' . wcwp_wc_dependency_notice_message() . '</p></div></td></tr>';
-}, 10, 3);
-
-// Browser polyfill — only when chatbot or cart recovery is active.
-// Enqueued at wp_enqueue_scripts priority 1 with in_footer=false so it
-// renders in <head> before any consumer scripts. Loading as a real asset
-// (rather than an inline <script>) keeps the page CSP-friendly and avoids
-// shipping bytes to visitors when both features are off.
-add_action('wp_enqueue_scripts', function() {
-	$chatbot_on = get_option( 'wcwp_chatbot_enabled', 'no' ) === 'yes';
-	$cart_on    = get_option( 'wcwp_cart_recovery_enabled', 'no' ) === 'yes';
-	if ( ! $chatbot_on && ! $cart_on ) {
-		return;
-	}
-	wp_enqueue_script(
-		'wcwp-uuid-polyfill',
-		WCWP_URL . 'assets/js/uuid-polyfill.js',
-		[],
-		WCWP_VERSION,
-		false // load in <head>, ahead of any consumer.
-	);
-}, 1);
-


### PR DESCRIPTION
## Summary

Audit point #13 — establish a namespaced entry-point class and slim `woochat-pro.php` to a thin shim. The broader "procedural → namespaced classes" arc happens incrementally over later audit points; this PR covers **bootstrap orchestration only**. Procedural function bodies in `includes/*.php` remain the implementation surface and are untouched.

## Why now

`woochat-pro.php` had grown to 199 lines of loose top-level statements: HPOS declaration, text domain, WC dependency gate, module require chain, activation/deactivation logic, two `admin_init` runners, an `after_plugin_row` notice, and the front-end UUID polyfill. Following the boot order required scrolling past unrelated concerns. A class with named methods makes the structure scan-readable in one screen and gives future audit points a home for class-based modules.

## What changed

**`includes/class-wcwp-plugin.php`** (new, 248 lines)
Final class `WooChatPro\Plugin` singleton owning bootstrap orchestration:
- `init()` — wires every top-level `add_action` and gates module loading on WooCommerce active.
- `boot_modules()` — module require chain (formerly the procedural `wcwp_bootstrap()`).
- `activate(\$network_wide)` — formerly `wcwp_activate_plugin`'s body. Calls a private `die_missing_woocommerce()` helper for the two WC-missing branches.
- `deactivate()` — formerly `wcwp_deactivate_plugin`'s body.
- `declare_hpos_compat()`, `load_textdomain()` — formerly inline anonymous functions.
- `run_migrations()` — wraps `wcwp_run_migrations()` for the priority-5 `admin_init` hook.
- `enforce_woocommerce_dependency()` — self-deactivate when WC vanishes.
- `render_wc_admin_notice()`, `render_wc_network_admin_notice()`, `render_plugin_row_notice()` — admin notices for missing WC.
- `enqueue_uuid_polyfill()` — front-end polyfill, only when chatbot or cart-recovery is on.

Internalized the previously-global `wcwp_wc_dependency_link()` and `wcwp_wc_dependency_notice_message()` helpers as private methods — grep confirmed they had no callers outside the bootstrap file.

**`woochat-pro.php`** (199 → 49 lines)
Now: plugin header, constants, `require_once` helpers + class file, calls `\WooChatPro\Plugin::instance()->init()`, registers activation/deactivation hooks pointing to two thin global shims that delegate to the singleton.

## Why activation/deactivation stay as global function shims

WordPress invokes `register_activation_hook` / `register_deactivation_hook` callbacks by **name** (string lookup) at the time the hook fires, so we keep `wcwp_activate_plugin` / `wcwp_deactivate_plugin` as named global functions to preserve the contract. Both are one-line shims that delegate to `Plugin::instance()->activate()` / `->deactivate()`.

## What stays the same

- **Boot order** — modules still load synchronously during `WP -> require plugin file -> Plugin::instance()->init() -> boot_modules()`, gated on `wcwp_is_woocommerce_active()`.
- **Hook firing order** — every `add_action` / `register_activation_hook` is registered at the same execution point.
- **Every `wcwp_*` function body in `includes/*.php`** — untouched.
- **All option keys, all REST routes, all cron schedules.**
- HPOS compat declaration, i18n load, dependency notices, polyfill enqueue conditions.
- Public function signatures `wcwp_activate_plugin(\$network_wide)` and `wcwp_deactivate_plugin()` still exist as global functions.

## Test plan

- [x] Activate plugin on a fresh install with WC active → modules load, tables created, `wcwp_db_version` reaches 2.
- [x] Activate plugin without WC → activation aborts with the standard "requires WooCommerce" wp_die screen.
- [x] Network-activate without WC → multisite branch fires.
- [x] Deactivate WC after WooChat Pro is active → `enforce_woocommerce_dependency` self-deactivates with admin notice on next admin page load.
- [x] Visit Plugins screen with WC inactive → `after_plugin_row` notice renders under the WooChat Pro row.
- [x] Visit any admin page → `wcwp_run_migrations` runs at priority 5 (short-circuits after first pass).
- [x] Front-end with both chatbot and cart-recovery off → `wcwp-uuid-polyfill` is **not** enqueued.
- [x] Front-end with chatbot or cart-recovery on → polyfill enqueued in `<head>` at priority 1.
- [x] WooChat Settings page renders identically; all 7 tabs work; settings save.
- [x] Send a test order → order-hooks fires, message dispatched, analytics row inserted.
- [x] Trigger cart-recovery cron → queue processes, status flips appropriately.

## Risk / rollback

Low — pure orchestration refactor. No schema changes, no public function signature changes, no hook re-registration order shifts. Rollback is `git revert`. The new class file uses PHP 7.4+ features (typed properties not used; nullable types not used) — well within the plugin's PHP 7.4 minimum from `Requires PHP: 7.4`.