### PR TITLE
Cart tracker reads cart contents from WC Store API (audit #14)

### DIFF
--- a/assets/js/cart-tracker.js
+++ b/assets/js/cart-tracker.js
@@ -2,19 +2,37 @@ jQuery(document).ready(function ($) {
     const phoneInputSelector = 'input[name=billing_phone]'; // Woo default
     const debounceMs = 5000;
 
-    function getCartData() {
-        let items = [];
-        const rows = $('.woocommerce-cart-form .cart_item, #order_review .cart_item');
-        rows.each(function () {
-            let name = $(this).find('.product-name').text().trim();
-            let price = parseFloat($(this).find('.product-price .amount').text().replace(/[^0-9.]/g, ''));
-            let qty = parseInt($(this).find('.qty').val(), 10);
-
-            if (name && !isNaN(qty) && qty > 0) {
-                items.push({ name, price: isNaN(price) ? 0 : price, qty });
-            }
+    // Fetch the current cart from the WooCommerce Store API. Returns a
+    // Promise that resolves to an array of {name, price, qty} — the shape
+    // the wcwp_save_cart AJAX endpoint expects. Theme-independent: works on
+    // cart, checkout, custom pages, and Block-based templates alike.
+    function fetchCartItems() {
+        if (!wcwp_ajax_obj || !wcwp_ajax_obj.cart_url) {
+            return Promise.resolve([]);
+        }
+        return fetch(wcwp_ajax_obj.cart_url, {
+            credentials: 'same-origin',
+            headers: { 'Accept': 'application/json' }
+        }).then(function (res) {
+            if (!res.ok) throw new Error('Store API cart fetch failed: ' + res.status);
+            return res.json();
+        }).then(function (data) {
+            if (!data || !Array.isArray(data.items)) return [];
+            return data.items.map(function (item) {
+                const qty = parseInt(item.quantity, 10) || 0;
+                const prices = item.prices || {};
+                const minor = (typeof prices.currency_minor_unit === 'number') ? prices.currency_minor_unit : 2;
+                const minorPrice = parseInt(prices.price, 10);
+                const price = isNaN(minorPrice) ? 0 : minorPrice / Math.pow(10, minor);
+                return {
+                    name: typeof item.name === 'string' ? item.name : '',
+                    price: price,
+                    qty: qty
+                };
+            }).filter(function (i) { return i.name && i.qty > 0; });
+        }).catch(function () {
+            return [];
         });
-        return items;
     }
 
     function hasConsent() {
@@ -31,10 +49,11 @@ jQuery(document).ready(function ($) {
     function scheduleSave() {
         clearTimeout(timer);
         timer = setTimeout(function () {
-            const cart = getCartData();
             const phone = $(phoneInputSelector).val();
+            if (!phone || !hasConsent()) return;
 
-            if (cart.length && phone && hasConsent()) {
+            fetchCartItems().then(function (cart) {
+                if (!cart.length) return;
                 $.post(wcwp_ajax_obj.ajax_url, {
                     action: 'wcwp_save_cart',
                     nonce: wcwp_ajax_obj.nonce,
@@ -42,7 +61,7 @@ jQuery(document).ready(function ($) {
                     cart: JSON.stringify(cart),
                     consent: hasConsent() ? 'yes' : 'no'
                 });
-            }
+            });
         }, debounceMs);
     }
 

--- a/includes/cart-recovery.php
+++ b/includes/cart-recovery.php
@@ -17,6 +17,7 @@ function wcwp_cart_recovery_script() {
     wp_localize_script('wcwp-cart-tracker', 'wcwp_ajax_obj', [
         'ajax_url' => admin_url('admin-ajax.php'),
         'nonce'    => wp_create_nonce('wcwp_cart_nonce'),
+        'cart_url' => rest_url('wc/store/v1/cart'),
     ]);
     wp_localize_script('wcwp-cart-tracker', 'wcwp_cart_recovery_delay', get_option('wcwp_cart_recovery_delay', 20));
     wp_localize_script('wcwp-cart-tracker', 'wcwp_cart_consent_required', get_option('wcwp_cart_recovery_require_consent', 'no'));


### PR DESCRIPTION
## Summary

Audit point #14. `assets/js/cart-tracker.js` was scraping cart contents out of theme HTML — `.woocommerce-cart-form .cart_item` / `#order_review .cart_item` rows, regex parsing of `.product-price .amount` for the unit price, and a jQuery `.val()` read of the qty input. That reaches into markup that is theme-specific, breaks under any non-default cart layout, and silently returns junk on **Block-based cart/checkout templates** where those selectors don't exist at all.

This PR switches the cart-data acquisition path to the WooCommerce **Store API** (`GET /wp-json/wc/store/v1/cart`) — the canonical source of truth WC ships with itself. Available on every page, theme-independent, currency-correct, locale-aware.

## What changed

**`assets/js/cart-tracker.js`**
- Replaced `getCartData()` (synchronous DOM scrape) with `fetchCartItems()` — a Promise-returning Store API fetch with `credentials: 'same-origin'` so the WC session cookie attaches for both authenticated and guest carts.
- Maps the Store API response `items[].prices.price` (minor-unit string) into the existing `{name, price, qty}` record shape that `wcwp_save_cart_ajax` already accepts. Per-item `currency_minor_unit` drives the divisor (defensive fallback: 2).
- `scheduleSave()` reorders to: read phone + consent first → fetch cart → POST. Same 5 s debounce, same triggers (`change input` on `.qty` / `billing_phone`, plus jQuery `updated_wc_div` / `updated_checkout` events from WC core).
- Network error / non-2xx response returns `[]` from `fetchCartItems()`, silently no-ops the POST — same behavior as the old "no items scraped" path.
- Kept jQuery for event binding + the AJAX save: `updated_wc_div` / `updated_checkout` are jQuery custom events on `document.body`, so vanilla `addEventListener` can't receive them.

**`includes/cart-recovery.php`**
- Extended the `wcwp_ajax_obj` `wp_localize_script` call with a `cart_url` member set to `rest_url('wc/store/v1/cart')`. Single new key; `ajax_url` / `nonce` unchanged.

## What stays the same

- AJAX save endpoint (`wcwp_save_cart_ajax`) — same action name, same nonce key (`wcwp_cart_nonce`), same `{phone, cart, consent}` POST shape, same JSON cart-item format on the wire. PHP backend untouched aside from the localized URL.
- Debounce window (5000 ms), trigger events, consent checkbox handling, phone-number selector.
- jQuery dependency on the script — kept.

## Notes on Store API access

- `GET /wc/store/v1/cart` does **not** require a nonce. The Store API reads from the WC session cookie, included automatically by `credentials: 'same-origin'`. Works for guests (WC's session cookie) and logged-in users (standard auth cookie).
- WC has shipped the Store API in core since 6.x (2022); the plugin hard-requires WC, so no version gate is needed.

## Test plan

- [x] Classic cart/checkout: change qty → 5s later, the AJAX call to `wcwp_save_cart` includes the correct items / total.
- [x] Block-based cart/checkout: same workflow now works (previously it produced empty cart payloads because `.cart_item` didn't exist).
- [x] Custom non-cart page that exposes `input[name=billing_phone]` → cart is still fetched from the Store API; AJAX fires.
- [x] Guest user (no WP login): items captured via WC session cookie.
- [x] Authenticated user: items captured normally.
- [x] Empty cart: no AJAX call (zero items).
- [x] Plugin that disables wc-blocks (and therefore the Store API) → fetch fails, AJAX silently does not fire — no console errors block the rest of the page.
- [x] Confirm `wcwp_abandoned_carts` row inserted with the correct `total` and `items_count` after the save.

## Risk / rollback

Low — only swapped the cart-data source. PHP backend (`wcwp_save_cart_ajax`, `wcwp_queue_cart_recovery`, the abandoned-carts table) is untouched. Rollback is `git revert`.