### PR TITLE
Convert migration runner to a versioned registry (audit #15)

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -88,25 +88,62 @@ function wcwp_ensure_secret_option_rows() {
 }
 
 /**
+ * Registry of versioned migration callables keyed by target version.
+ *
+ * Each callable runs at most once per install: when wcwp_run_migrations()
+ * sees a version greater than the stored wcwp_db_version, it invokes the
+ * callable and bumps the version. Adding a new migration is a one-line
+ * addition here plus a matching wcwp_migration_v<N>_* function.
+ *
+ * Keep entries sorted by version key. The runner sorts numerically before
+ * iterating, so order in the array literal is for human readability only.
+ *
+ * @return array<int, callable> Map of target_version => callable.
+ */
+function wcwp_get_migrations() {
+    return [
+        1 => 'wcwp_migration_v1_secrets_autoload',
+        2 => 'wcwp_migration_v2_analytics_to_table',
+    ];
+}
+
+/**
  * Versioned, run-once migration runner. Safe to invoke on every admin
- * request — the version flag short-circuits after the migration has
- * been applied.
+ * request — the version flag short-circuits after each migration has
+ * been applied. The version is bumped inline after each successful
+ * step, so a partial failure (one step throws) leaves the install at
+ * the highest fully-applied version, not stranded at the original.
  */
 function wcwp_run_migrations() {
     $stored = (int) get_option('wcwp_db_version', 0);
+    $migrations = wcwp_get_migrations();
+    ksort($migrations, SORT_NUMERIC);
 
-    if ($stored < 1) {
-        wcwp_ensure_secret_option_rows();
-        wcwp_set_secrets_autoload_no();
-        update_option('wcwp_db_version', 1, false);
-        $stored = 1;
+    foreach ($migrations as $version => $callable) {
+        $version = (int) $version;
+        if ($version <= $stored) continue;
+        if (!is_callable($callable)) continue;
+        call_user_func($callable);
+        update_option('wcwp_db_version', $version, false);
+        $stored = $version;
     }
+}
 
-    if ($stored < 2) {
-        wcwp_migrate_analytics_options_to_table();
-        update_option('wcwp_db_version', 2, false);
-        $stored = 2;
-    }
+/**
+ * v1 (PR #20): create secret option rows with autoload=no on fresh
+ * installs and flip autoload to 'no' for any existing rows.
+ */
+function wcwp_migration_v1_secrets_autoload() {
+    wcwp_ensure_secret_option_rows();
+    wcwp_set_secrets_autoload_no();
+}
+
+/**
+ * v2 (PR #23): copy any legacy wcwp_analytics_events option rows into
+ * the {prefix}wcwp_analytics_events table and delete the legacy options.
+ */
+function wcwp_migration_v2_analytics_to_table() {
+    wcwp_migrate_analytics_options_to_table();
 }
 
 /**


### PR DESCRIPTION
## Summary

Audit point #15. `wcwp_run_migrations()` has lived in `includes/helpers.php` since PR #20 (secrets-autoload flip) and was extended in PR #23 (analytics options → table), but each new migration meant copy-pasting an `if (\$stored < N) { …; update_option(…); \$stored = N; }` block and bumping the version number in three places. Fine for two migrations, brittle by ten.

This PR factors the runner into a **registry pattern**: a single `wcwp_get_migrations()` function returns a `version => callable` map, and the runner iterates once. Adding migration v3 is now one line in the map plus a `wcwp_migration_v3_*` function definition.

## What changed

**`includes/helpers.php`**
- **New** `wcwp_get_migrations()` — returns the versioned callable map. Today: v1 secrets-autoload, v2 analytics-to-table.
- `wcwp_run_migrations()` simplified to a single loop: `ksort` by numeric key, skip versions `<= \$stored`, invoke callable, `update_option`, advance `\$stored`. Same **inline-bump-on-success** semantics so a partial failure (one step throws) leaves the install at the highest fully-applied version.
- `is_callable()` guard on each entry — defensive against typos / refactor windows where the named function may be missing.
- **Extracted** `wcwp_migration_v1_secrets_autoload()` and `wcwp_migration_v2_analytics_to_table()` as the v1/v2 callables. Both are thin wrappers that delegate to the existing public helpers (`wcwp_ensure_secret_option_rows` + `wcwp_set_secrets_autoload_no` for v1; `wcwp_migrate_analytics_options_to_table` for v2). Wrappers rather than direct callables in the map so the migration name documents what the version did.

## Behavior preservation

- Fresh install (`\$stored = 0`): runner runs v1 → sets to 1, runs v2 → sets to 2. Identical to before.
- Already at v1: runner skips v1 (1 <= 1), runs v2 → sets to 2.
- Already at v2: both versions `<= \$stored`, both skipped — no-op.
- Order: `ksort` guarantees ascending numeric key.

## What stays the same

- `wcwp_run_migrations()` — same name, same signature, called from the same places (`Plugin::activate()`, `Plugin::run_migrations()` on the `admin_init` priority-5 hook).
- All public helpers (`wcwp_ensure_secret_option_rows`, `wcwp_set_secrets_autoload_no`, `wcwp_migrate_analytics_options_to_table`, `wcwp_get_secret_option_keys`) — untouched, all still callable.
- `wcwp_db_version` semantics: monotonic counter, bumped to the version of each successfully-run migration, never decremented.
- No DB / option key changes.

## Test plan

- [x] Fresh install: activation runs both migrations, `wcwp_db_version` ends at 2, secret options have `autoload=no`, analytics events table exists.
- [x] Existing install at `wcwp_db_version = 1`: visit any admin page → migration v2 runs (analytics options removed if present, table populated, version bumps to 2).
- [x] Existing install at `wcwp_db_version = 2`: visit any admin page → no work done, no DB writes from the runner.
- [x] Spot-check `is_callable` guard: temporarily rename one of the migration functions and reload — the runner skips the unknown callable instead of fataling, and `wcwp_db_version` stays at the prior version.

## Risk / rollback

Low — pure refactor of a single function in `helpers.php`. No schema changes, no option key changes, no callers updated. Rollback is `git revert`.

## Why this scope

The audit notes that PRs #20/#23 had already laid the groundwork; this point's job was to formalize what's there. A registry over a filter (e.g. `apply_filters('wcwp_migrations', \$migrations)` for third-party plugins) was deliberately deferred — exposing migration callables as a public extension point is a larger surface-area decision and not necessary for the in-tree migrations the audit covers.