### PR TITLE
Drop brittle 'reply exactly with' line from GPT follow-up prompt (audit #17)

### DIFF
--- a/includes/scheduler.php
+++ b/includes/scheduler.php
@@ -41,9 +41,11 @@ function wcwp_send_followup_message_handler($order_id) {
 
     $message = wcwp_build_followup_message($order);
 
-    // Optional GPT-generated content
+    // Optional GPT-generated content. Falls back to the templated $message
+    // when the helper returns '' (missing creds, network error, non-200,
+    // or empty response).
     if (get_option('wcwp_followup_use_gpt', 'no') === 'yes') {
-        $maybe_ai = wcwp_generate_gpt_followup($order, $message);
+        $maybe_ai = wcwp_generate_gpt_followup($order);
         if (!empty($maybe_ai)) {
             $message = $maybe_ai;
         }
@@ -71,7 +73,7 @@ function wcwp_build_followup_message($order) {
     );
 }
 
-function wcwp_generate_gpt_followup($order, $fallback_message) {
+function wcwp_generate_gpt_followup($order) {
     $endpoint = trim(get_option('wcwp_gpt_api_endpoint', ''));
     $api_key = trim(get_option('wcwp_gpt_api_key', ''));
     $model = trim(get_option('wcwp_gpt_model', 'gpt-3.5-turbo')) ?: 'gpt-3.5-turbo';
@@ -91,7 +93,6 @@ function wcwp_generate_gpt_followup($order, $fallback_message) {
         'messages' => [
             ['role' => 'system', 'content' => 'You craft concise WhatsApp follow-ups for customers. Keep it friendly, short, and actionable.'],
             ['role' => 'user', 'content' => $user_prompt],
-            ['role' => 'user', 'content' => 'If unsure, reply exactly with: ' . $fallback_message]
         ],
         'max_tokens' => 120,
         'temperature' => 0.7,


### PR DESCRIPTION
## Summary

Audit point #17. `wcwp_generate_gpt_followup()` built a 3-message chat-completions payload where the third message was:

```
'If unsure, reply exactly with: ' . \$fallback_message
```

This is the kind of instruction LLMs routinely paraphrase, wrap in extra prose, or quietly ignore — so it cannot be relied on as a fallback path in the first place. Worse, when the model *does* obey, the dispatcher sends back what looks like a "real" AI response that happens to be a verbatim copy of the templated text, with no signal that the AI added no value. The codepath was redundant safety theater on top of a working deterministic fallback one level up:

```php
if (get_option('wcwp_followup_use_gpt', 'no') === 'yes') {
    \$maybe_ai = wcwp_generate_gpt_followup(\$order);
    if (!empty(\$maybe_ai)) {
        \$message = \$maybe_ai;
    }
}
```

If the GPT helper returns `''` for any reason (missing creds, `wp_error` network failure, non-200 status, missing `choices[0].message.content`), the caller keeps the templated `\$message` it already built from `wcwp_build_followup_message()`. That is the real fallback.

## What changed

**`includes/scheduler.php`**
- Removed the third `user` role message from the `chat/completions` body.
- Dropped the now-unused `\$fallback_message` parameter from `wcwp_generate_gpt_followup(\$order)` — internal helper, single caller in the same file (`wcwp_send_followup_message_handler`), no external binding via `add_action` / `add_filter` / cron callback name.
- Updated the call site to match.
- One-line comment at the call site documenting that `''` from the helper means "use the templated message", since the deterministic fallback is now the only fallback.

## What stays the same

- Hook registration: `woocommerce_order_status_completed/processing` → `wcwp_maybe_schedule_followup` → single-event cron → `wcwp_send_followup_message_handler`. Unchanged.
- Templated message (`wcwp_build_followup_message`) and its placeholders (`{name}`, `{order_id}`, `{total}`, `{status}`, `{date}`). Unchanged.
- GPT settings: endpoint, API key, model option keys. Unchanged.
- `_wcwp_followup_sent` order-meta key. Unchanged.

## Test plan

- [x] Order completes with `wcwp_followup_use_gpt = no`: scheduled cron sends the templated message — same as before.
- [x] Order completes with GPT enabled and valid creds: AI message used; no "reply exactly with" line in the request body.
- [x] Order completes with GPT enabled but creds missing: helper returns `''`, dispatcher falls back to templated message — same as before.
- [x] GPT endpoint returns 500: helper returns `''`, dispatcher falls back — same as before.
- [x] `_wcwp_followup_sent` only set when `wcwp_send_whatsapp_message` returns true — same as before.

## Risk / rollback

Low — single-file change, internal helper signature, deterministic fallback unchanged. Rollback is `git revert`.