### PR TITLE
Make update-checker URL configurable in production (audit #18)

### DIFF
--- a/docs/update-manifest.md
+++ b/docs/update-manifest.md
@@ -1,0 +1,58 @@
+# Update manifest
+
+WooChat Pro's in-plugin updater (`includes/update-checker.php`) fetches a JSON
+manifest from the URL returned by `wcwp_update_api_url()` and offers an update
+when its `version` is greater than the installed `WCWP_VERSION`.
+
+## Configuring the URL
+
+The updater resolves the manifest URL in this order:
+
+1. **`WCWP_UPDATE_API_URL` constant** — define in `wp-config.php` to point all
+   sites at a real production endpoint:
+
+   ```php
+   define( 'WCWP_UPDATE_API_URL', 'https://example.com/woochat-pro/update.json' );
+   ```
+
+2. **`.local` short-circuit** — when no constant is set and the site is detected
+   as local (`wp_get_environment_type() === 'local'` or hostname contains
+   `.local`), the updater fetches `home_url('/woochat-pro-update.json')` so
+   developers can drop a manifest at the site root for testing.
+
+3. **`wcwp_update_api_url` filter** — wraps the resolved URL. Site/theme code
+   can override or clear it programmatically:
+
+   ```php
+   add_filter( 'wcwp_update_api_url', function ( $url ) {
+       return 'https://staging.example.com/woochat-pro/update.json';
+   } );
+   ```
+
+If none of these yield a non-empty URL the updater is a no-op (no HTTP
+request, no update offered).
+
+## Manifest schema
+
+See `update-manifest.sample.json`. Required fields:
+
+| Field          | Type   | Notes                                                       |
+| -------------- | ------ | ----------------------------------------------------------- |
+| `version`      | string | Compared against `WCWP_VERSION` with `version_compare`.     |
+| `download_url` | string | Direct ZIP URL passed to WordPress's plugin installer.      |
+
+Optional fields surfaced in the "View details" modal via `plugins_api`:
+
+| Field      | Type   | Notes                                                |
+| ---------- | ------ | ---------------------------------------------------- |
+| `name`     | string | Defaults to `WooChat Pro`.                           |
+| `author`   | string | Defaults to `Zignite`.                               |
+| `homepage` | string | Plugin homepage link.                                |
+| `requires` | string | Minimum WordPress version.                           |
+| `tested`   | string | Tested-up-to WordPress version.                      |
+| `sections` | object | HTML strings keyed by tab name (`description`, etc). |
+
+## Caching
+
+Successful responses are cached in the `wcwp_update_info` transient for 6
+hours. Clear it (or define `WP_DEBUG`) when iterating on the manifest.

--- a/docs/update-manifest.sample.json
+++ b/docs/update-manifest.sample.json
@@ -1,0 +1,14 @@
+{
+  "name": "WooChat Pro",
+  "slug": "woochat-pro",
+  "version": "1.0.2",
+  "author": "Zignite",
+  "homepage": "https://zignites.com/woochat-pro",
+  "requires": "6.0",
+  "tested": "6.7",
+  "download_url": "https://zignites.com/downloads/woochat-pro-1.0.2.zip",
+  "sections": {
+    "description": "WooChat Pro adds WhatsApp messaging, cart recovery, and a chatbot widget to WooCommerce.",
+    "changelog": "<h4>1.0.2</h4><ul><li>Example release notes go here.</li></ul>"
+  }
+}

--- a/includes/update-checker.php
+++ b/includes/update-checker.php
@@ -5,13 +5,17 @@ add_filter('pre_set_site_transient_update_plugins', 'wcwp_update_check');
 add_filter('plugins_api', 'wcwp_update_plugin_info', 10, 3);
 
 function wcwp_update_api_url() {
-    $default = '';
-    $env = function_exists('wp_get_environment_type') ? wp_get_environment_type() : '';
-    $site_url = home_url();
-    $is_local = ($env === 'local') || (strpos($site_url, '.local') !== false);
+    if (defined('WCWP_UPDATE_API_URL') && is_string(WCWP_UPDATE_API_URL) && WCWP_UPDATE_API_URL !== '') {
+        $default = WCWP_UPDATE_API_URL;
+    } else {
+        $default = '';
+        $env = function_exists('wp_get_environment_type') ? wp_get_environment_type() : '';
+        $site_url = home_url();
+        $is_local = ($env === 'local') || (strpos($site_url, '.local') !== false);
 
-    if ($is_local) {
-        $default = home_url('/woochat-pro-update.json');
+        if ($is_local) {
+            $default = home_url('/woochat-pro-update.json');
+        }
     }
 
     return apply_filters('wcwp_update_api_url', $default);


### PR DESCRIPTION
## Summary

Audit point #18 — replace the `.local`-only stub in `includes/update-checker.php` with a real configuration knob so the in-plugin updater can run on production sites. No production URL is baked in: sites opt in by setting a constant or filter.

## What changed

- `wcwp_update_api_url()` now checks a `WCWP_UPDATE_API_URL` constant first. When defined and non-empty, it wins over the local-environment detection. Add the line to `wp-config.php`:

  ```php
  define( 'WCWP_UPDATE_API_URL', 'https://example.com/woochat-pro/update.json' );
  ```

- Added `docs/update-manifest.md` documenting the resolution order (constant → `.local` short-circuit → `wcwp_update_api_url` filter) and the JSON schema consumed by `wcwp_fetch_update_info()` / `wcwp_update_plugin_info()`.
- Added `docs/update-manifest.sample.json` as a concrete reference manifest covering required fields (`version`, `download_url`) and optional ones (`name`, `author`, `homepage`, `requires`, `tested`, `sections`).

## What stays the same

- `.local` host detection still falls back to `home_url('/woochat-pro-update.json')` for developer workflows.
- The `wcwp_update_api_url` filter still wraps the resolved URL — programmatic overrides keep working.
- `wcwp_fetch_update_info()`, `wcwp_update_check()`, and `wcwp_update_plugin_info()` are untouched. The 6-hour `wcwp_update_info` transient cache, the `version_compare` gate, and the `plugins_api` modal data shape are all unchanged.
- When no constant, no `.local` match, and no filter override are present, the URL resolves to `''` and the updater is a silent no-op (same as before on production).

## Test plan

- [x] On a `*.local` site with no constant: visit Dashboard → Updates and confirm the plugin still picks up `home_url('/woochat-pro-update.json')` (regression check).
- [x] On a non-local site without the constant: confirm no HTTP request is made (existing no-op behaviour preserved).
- [x] On a non-local site with `define('WCWP_UPDATE_API_URL', 'https://...');` in `wp-config.php`: confirm the manifest is fetched, cached in the `wcwp_update_info` transient, and an update offer appears when `version` exceeds `WCWP_VERSION`.
- [x] Confirm `add_filter('wcwp_update_api_url', ...)` still overrides whichever default was selected.
- [x] `php -l includes/update-checker.php` passes.
- [x] `docs/update-manifest.sample.json` parses as valid JSON.

## Risk / rollback

Minimal risk. The new code path only activates when an admin explicitly defines `WCWP_UPDATE_API_URL`; otherwise behaviour is byte-identical to master. Rollback by reverting the commit.