### PR TITLE
Localize currency symbol in default templates (audit #19)

### DIFF
--- a/admin/views/tab-cart-recovery.php
+++ b/admin/views/tab-cart-recovery.php
@@ -29,12 +29,12 @@ if (!defined('ABSPATH')) exit;
             </td>
         </tr>
         <tr>
-            <th scope="row"><label for="wcwp_cart_recovery_message"><?php esc_html_e('Cart Recovery Message', 'woochat-pro'); ?></label><span class="wcwp-help-icon">?<span class="wcwp-tooltip"><?php esc_html_e('Customize the WhatsApp message sent for cart recovery. Use placeholders: {items}, {total}, {cart_url}', 'woochat-pro'); ?></span></span></th>
+            <th scope="row"><label for="wcwp_cart_recovery_message"><?php esc_html_e('Cart Recovery Message', 'woochat-pro'); ?></label><span class="wcwp-help-icon">?<span class="wcwp-tooltip"><?php esc_html_e('Customize the WhatsApp message sent for cart recovery. Use placeholders: {items}, {total}, {currency_symbol}, {cart_url}', 'woochat-pro'); ?></span></span></th>
             <td>
-                <textarea name="wcwp_cart_recovery_message" id="wcwp_cart_recovery_message" rows="5" class="large-text"><?php echo esc_textarea(get_option('wcwp_cart_recovery_message', "👋 Hey! You left items in your cart:\n\n{items}\n\nTotal: {total} PKR\nClick here to complete your order: {cart_url}")); ?></textarea>
+                <textarea name="wcwp_cart_recovery_message" id="wcwp_cart_recovery_message" rows="5" class="large-text"><?php echo esc_textarea(get_option('wcwp_cart_recovery_message', "👋 Hey! You left items in your cart:\n\n{items}\n\nTotal: {total} {currency_symbol}\nClick here to complete your order: {cart_url}")); ?></textarea>
                 <p class="description"><?php
                     /* translators: do not translate placeholders inside curly braces */
-                    esc_html_e('Use placeholders: {items}, {total}, {cart_url}', 'woochat-pro');
+                    esc_html_e('Use placeholders: {items}, {total}, {currency_symbol}, {cart_url}', 'woochat-pro');
                 ?></p>
             </td>
         </tr>

--- a/admin/views/tab-messaging.php
+++ b/admin/views/tab-messaging.php
@@ -18,12 +18,12 @@ if (!defined('ABSPATH')) exit;
             </td>
         </tr>
         <tr>
-            <th scope="row"><label for="wcwp_order_message_template"><?php esc_html_e('Order Message Template', 'woochat-pro'); ?></label><span class="wcwp-help-icon">?<span class="wcwp-tooltip"><?php esc_html_e('Customize the WhatsApp message sent for new orders. Use placeholders: {name}, {order_id}, {total}', 'woochat-pro'); ?></span></span></th>
+            <th scope="row"><label for="wcwp_order_message_template"><?php esc_html_e('Order Message Template', 'woochat-pro'); ?></label><span class="wcwp-help-icon">?<span class="wcwp-tooltip"><?php esc_html_e('Customize the WhatsApp message sent for new orders. Use placeholders: {name}, {order_id}, {total}, {currency_symbol}', 'woochat-pro'); ?></span></span></th>
             <td>
-                <textarea name="wcwp_order_message_template" rows="5" class="large-text"><?php echo esc_textarea(get_option('wcwp_order_message_template', 'Hi {name}, thanks for your order #{order_id}! Total: {total} PKR.')); ?></textarea>
+                <textarea name="wcwp_order_message_template" rows="5" class="large-text"><?php echo esc_textarea(get_option('wcwp_order_message_template', 'Hi {name}, thanks for your order #{order_id}! Total: {total} {currency_symbol}.')); ?></textarea>
                 <p class="description"><?php
                     /* translators: do not translate placeholders inside curly braces */
-                    esc_html_e('Use placeholders: {name}, {order_id}, {total}', 'woochat-pro');
+                    esc_html_e('Use placeholders: {name}, {order_id}, {total}, {currency_symbol}', 'woochat-pro');
                 ?></p>
             </td>
         </tr>

--- a/admin/views/tab-scheduler.php
+++ b/admin/views/tab-scheduler.php
@@ -25,7 +25,7 @@ if (!defined('ABSPATH')) exit;
             </td>
         </tr>
         <tr>
-            <th scope="row"><label for="wcwp_followup_template"><?php esc_html_e('Follow-up Template', 'woochat-pro'); ?></label><span class="wcwp-help-icon">?<span class="wcwp-tooltip"><?php esc_html_e('Placeholders: {name}, {order_id}, {total}, {status}, {date}', 'woochat-pro'); ?></span></span></th>
+            <th scope="row"><label for="wcwp_followup_template"><?php esc_html_e('Follow-up Template', 'woochat-pro'); ?></label><span class="wcwp-help-icon">?<span class="wcwp-tooltip"><?php esc_html_e('Placeholders: {name}, {order_id}, {total}, {currency_symbol}, {status}, {date}', 'woochat-pro'); ?></span></span></th>
             <td>
                 <textarea name="wcwp_followup_template" id="wcwp_followup_template" rows="5" class="large-text" <?php disabled(!$is_pro); ?>><?php echo esc_textarea(get_option('wcwp_followup_template', "Hi {name}, thanks again for your order #{order_id}! Reply if you have any questions.")); ?></textarea>
                 <p class="description"><?php esc_html_e('Sent once per order after the delay.', 'woochat-pro'); ?></p>

--- a/includes/cart-recovery.php
+++ b/includes/cart-recovery.php
@@ -405,10 +405,10 @@ function wcwp_sum_cart_items_total($cart_items) {
  * the bare cart URL).
  */
 function wcwp_render_cart_recovery_message($items, $total, $cart_url) {
-    $template = get_option('wcwp_cart_recovery_message', "👋 Hey! You left items in your cart:\n\n{items}\n\nTotal: {total} PKR\nClick here to complete your order: {cart_url}");
+    $template = get_option('wcwp_cart_recovery_message', "👋 Hey! You left items in your cart:\n\n{items}\n\nTotal: {total} {currency_symbol}\nClick here to complete your order: {cart_url}");
     return str_replace(
-        ['{items}', '{total}', '{cart_url}'],
-        [implode("\n", $items), $total, $cart_url],
+        ['{items}', '{total}', '{cart_url}', '{currency_symbol}'],
+        [implode("\n", $items), $total, $cart_url, wcwp_currency_symbol_text()],
         $template
     );
 }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -223,6 +223,14 @@ function wcwp_is_woocommerce_active() {
     return false;
 }
 
+// WC returns HTML entities (e.g. `&#36;` for USD) — decode for plain-text WhatsApp output.
+function wcwp_currency_symbol_text() {
+    if (!function_exists('get_woocommerce_currency_symbol')) {
+        return '';
+    }
+    return html_entity_decode(get_woocommerce_currency_symbol(), ENT_QUOTES, 'UTF-8');
+}
+
 function wcwp_sanitize_json_faq($value) {
     $decoded = json_decode($value, true);
     if (!is_array($decoded)) {

--- a/includes/order-hooks.php
+++ b/includes/order-hooks.php
@@ -17,10 +17,10 @@ function wcwp_send_whatsapp_on_order_complete($order_id) {
     $name = $order->get_billing_first_name();
     $total = $order->get_total();
 
-    $template = get_option('wcwp_order_message_template', 'Hi {name}, thanks for your order #{order_id}! Total: {total} PKR.');
+    $template = get_option('wcwp_order_message_template', 'Hi {name}, thanks for your order #{order_id}! Total: {total} {currency_symbol}.');
     $message = str_replace(
-        ['{name}', '{order_id}', '{total}'],
-        [$name, $order_id, $total],
+        ['{name}', '{order_id}', '{total}', '{currency_symbol}'],
+        [$name, $order_id, $total, wcwp_currency_symbol_text()],
         $template
     );
 
@@ -83,8 +83,8 @@ add_action('wp_ajax_wcwp_send_manual_whatsapp', function() {
     $to       = sanitize_text_field($order->get_billing_phone());
     $name     = $order->get_billing_first_name();
     $total    = $order->get_total();
-    $template = get_option('wcwp_order_message_template', 'Hi {name}, thanks for your order #{order_id}! Total: {total} PKR.');
-    $message  = str_replace(['{name}', '{order_id}', '{total}'], [$name, $order_id, $total], $template);
+    $template = get_option('wcwp_order_message_template', 'Hi {name}, thanks for your order #{order_id}! Total: {total} {currency_symbol}.');
+    $message  = str_replace(['{name}', '{order_id}', '{total}', '{currency_symbol}'], [$name, $order_id, $total, wcwp_currency_symbol_text()], $template);
     $result   = wcwp_send_whatsapp_message($to, $message, true, ['type' => 'order', 'order_id' => $order_id]);
 
     $redirect = add_query_arg(

--- a/includes/scheduler.php
+++ b/includes/scheduler.php
@@ -61,13 +61,14 @@ function wcwp_send_followup_message_handler($order_id) {
 function wcwp_build_followup_message($order) {
     $template = get_option('wcwp_followup_template', "Hi {name}, thanks again for your order #{order_id}! Reply if you have any questions.");
     return str_replace(
-        ['{name}', '{order_id}', '{total}', '{status}', '{date}'],
+        ['{name}', '{order_id}', '{total}', '{status}', '{date}', '{currency_symbol}'],
         [
             $order->get_billing_first_name(),
             $order->get_id(),
             $order->get_total(),
             $order->get_status(),
-            $order->get_date_created() ? $order->get_date_created()->date_i18n(get_option('date_format')) : ''
+            $order->get_date_created() ? $order->get_date_created()->date_i18n(get_option('date_format')) : '',
+            wcwp_currency_symbol_text()
         ],
         $template
     );


### PR DESCRIPTION
## Summary

Audit point #19 — replace hardcoded `PKR` in default WhatsApp message templates with a WC-aware `{currency_symbol}` placeholder so stores running other WooCommerce currencies don't ship messages like `Total: 49.99 PKR` regardless of their actual currency.

## What changed

- New helper `wcwp_currency_symbol_text()` in `includes/helpers.php`. Wraps `get_woocommerce_currency_symbol()` and pipes the result through `html_entity_decode(..., ENT_QUOTES, 'UTF-8')` — WC returns HTML entities (`&#36;`, `&#8377;`, etc.) which would otherwise leak verbatim into plain-text WhatsApp output.
- `{currency_symbol}` added as a recognised placeholder in all four substitution sites for consistency:
  - `wcwp_render_cart_recovery_message()` — `includes/cart-recovery.php`
  - Order-complete handler — `includes/order-hooks.php`
  - Manual-send AJAX handler — `includes/order-hooks.php`
  - `wcwp_build_followup_message()` — `includes/scheduler.php`
- Default templates updated: the three strings that previously contained the literal `PKR` (cart-recovery default in code + admin view, order-message default in code + admin view) now use `{currency_symbol}` instead.
- Admin tooltips + "Use placeholders" descriptions in `admin/views/tab-messaging.php`, `tab-cart-recovery.php`, and `tab-scheduler.php` updated to advertise the new placeholder.

## What stays the same

- Public function signatures: `wcwp_render_cart_recovery_message()`, `wcwp_build_followup_message()`, and the order-message handlers keep the same arguments and return shape.
- All other placeholders (`{name}`, `{order_id}`, `{total}`, `{items}`, `{cart_url}`, `{status}`, `{date}`) behave identically.
- Existing installs that already saved a custom template are not migrated — the `get_option(key, $default)` default only fires on first read. Sites that want WC-aware currency just add `{currency_symbol}` to their saved template.
- `helpers.php` is required from `woochat-pro.php:28` before any consumer module loads, so the new helper is always available where it's called.

## Test plan

- [ ] Fresh install with WC currency = USD: confirm the default order/cart-recovery message renders `Total: 49.99 $` (decoded from `&#36;`) instead of `49.99 PKR`.
- [ ] Switch WC currency to INR (`₹`) and resend: confirm the symbol updates without code changes.
- [ ] Switch WC currency to PKR: confirm the literal `Rs` symbol still appears (no regression for PKR-configured stores).
- [ ] Existing install with a saved template containing `PKR`: confirm the saved template is unchanged and still sends with the literal `PKR` (no surprise migration).
- [ ] Manually add `{currency_symbol}` to a saved template: confirm it now resolves at substitution time.
- [ ] `php -l` clean on all 7 touched files.

## Risk / rollback

Low risk. The helper only activates when a template contains `{currency_symbol}` (new) or when a fresh install reads the new defaults; behaviour for stores running an older saved template is byte-identical to master. Rollback by reverting the commit.