### PR TITLE
Drop the fake Contact Support form (audit #20)

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -169,19 +169,16 @@ function wcwp_render_settings_page() {
     </div>
     <div class="wcwp-support-form" id="wcwp-support-form">
         <h2><?php esc_html_e('Contact Support', 'woochat-pro'); ?></h2>
-        <form id="wcwp-support-contact-form" method="post" action="#" onsubmit="event.preventDefault();document.getElementById('wcwp-support-success').style.display='block';">
-            <label for="wcwp-support-name"><?php esc_html_e('Your Name', 'woochat-pro'); ?></label>
-            <input type="text" id="wcwp-support-name" name="wcwp-support-name" required>
-            <label for="wcwp-support-email"><?php esc_html_e('Your Email', 'woochat-pro'); ?></label>
-            <input type="email" id="wcwp-support-email" name="wcwp-support-email" required>
-            <label for="wcwp-support-message"><?php esc_html_e('Message', 'woochat-pro'); ?></label>
-            <textarea id="wcwp-support-message" name="wcwp-support-message" rows="4" required></textarea>
-            <button type="submit" class="button"><?php esc_html_e('Send Message', 'woochat-pro'); ?></button>
-            <div class="wcwp-support-success" id="wcwp-support-success" style="display:none;"><?php esc_html_e('Thank you! Your message has been sent. Our team will get back to you soon.', 'woochat-pro'); ?></div>
-        </form>
+        <p><?php esc_html_e('Reach our team using one of the channels below.', 'woochat-pro'); ?></p>
         <div style="margin-top:12px;font-size:0.97rem;color:#888;">
-            Or email us at <a href="mailto:support@zignites.com"><?php esc_html_e('support@zignites.com', 'woochat-pro'); ?></a><br>
-            <a href="https://zignites.com/feature-request" target="_blank"><?php esc_html_e('Suggest a Feature', 'woochat-pro'); ?></a> &nbsp;|&nbsp; <a href="https://zignites.com/bug-report" target="_blank"><?php esc_html_e('Report a Bug', 'woochat-pro'); ?></a>
+            <?php
+            printf(
+                /* translators: %s: support email link */
+                esc_html__('Email us at %s', 'woochat-pro'),
+                '<a href="mailto:support@zignites.com">support@zignites.com</a>'
+            );
+            ?><br>
+            <a href="https://zignites.com/feature-request" target="_blank" rel="noopener"><?php esc_html_e('Suggest a Feature', 'woochat-pro'); ?></a> &nbsp;|&nbsp; <a href="https://zignites.com/bug-report" target="_blank" rel="noopener"><?php esc_html_e('Report a Bug', 'woochat-pro'); ?></a>
         </div>
     </div>
     <?php

--- a/assets/css/admin-premium.css
+++ b/assets/css/admin-premium.css
@@ -479,7 +479,7 @@
   color: #b2f7ef !important;
 }
 
-/* Support/Contact Form */
+/* Support/Contact card */
 .wcwp-support-form {
   background: #f8f9fa;
   border-radius: 10px;
@@ -492,59 +492,6 @@
 .wcwp-support-form:hover {
   box-shadow: 0 4px 24px rgba(44,62,80,0.13);
   transform: translateY(-2px) scale(1.01);
-}
-.wcwp-support-form label {
-  font-weight: 500;
-  color: #1c7c54;
-  margin-bottom: 6px;
-  display: block;
-}
-.wcwp-support-form input[type="text"],
-.wcwp-support-form input[type="email"],
-.wcwp-support-form textarea {
-  width: 100%;
-  padding: 10px 12px;
-  border: 1px solid #d1e7dd;
-  border-radius: 6px;
-  font-size: 1rem;
-  background: #fff;
-  margin-bottom: 12px;
-  transition: border 0.2s;
-}
-.wcwp-support-form input[type="text"]:focus,
-.wcwp-support-form input[type="email"]:focus,
-.wcwp-support-form textarea:focus {
-  border-color: #1c7c54;
-  background: #f8f9fa;
-}
-.wcwp-support-form .button {
-  background: linear-gradient(90deg, #1c7c54 60%, #2ec4b6 100%);
-  color: #fff;
-  border: none;
-  border-radius: 6px;
-  padding: 10px 22px;
-  font-size: 1rem;
-  cursor: pointer;
-  transition: background 0.2s;
-}
-.wcwp-support-form .button:hover {
-  background: linear-gradient(90deg, #2ec4b6 0%, #1c7c54 100%);
-}
-.wcwp-support-form .wcwp-support-success {
-  color: #1c7c54;
-  background: #e5f7f6;
-  border-radius: 6px;
-  padding: 10px 14px;
-  margin-bottom: 10px;
-  font-size: 1rem;
-}
-.wcwp-support-form .wcwp-support-error {
-  color: #fff;
-  background: #e74c3c;
-  border-radius: 6px;
-  padding: 10px 14px;
-  margin-bottom: 10px;
-  font-size: 1rem;
 }
 
 /* Microinteractions & Branding */


### PR DESCRIPTION
## Summary

Audit point #20 — remove the bogus "Contact Support" form on the settings page. The form's inline `onsubmit` handler called `event.preventDefault()` and unconditionally revealed a "Thank you! Your message has been sent" banner without sending anything anywhere. Users were lied to about delivery.

The same section already lists real support channels (`mailto:support@zignites.com` plus feature-request and bug-report links on zignites.com), so the fix is removal — wiring up real submission (`wp_mail`, external form provider, etc.) is out of scope for this audit pass.

## What changed

- `admin/settings-page.php` — drop the `<form>` element, the success banner, and the inline JS handler. Keep the "Contact Support" heading, add a one-line lead-in (`Reach our team using one of the channels below.`), and keep the existing email + feature-request + bug-report link block.
- `admin/settings-page.php` — small bonus while editing the same lines: rebuild the email link via `printf( esc_html__('Email us at %s', ...), '<a ...>...</a>' )` so the translatable copy stays escaped, and add `rel="noopener"` to the two external `target="_blank"` links (tabnabbing hardening on links that are otherwise being touched).
- `assets/css/admin-premium.css` — drop the form-specific selectors (`label`, `input[type="text"]`, `input[type="email"]`, `textarea`, `:focus`, `.button`, `.button:hover`, `.wcwp-support-success`, `.wcwp-support-error`). Nothing references those classes anymore. The `.wcwp-support-form` card rule and the shared `.wcwp-dashboard-widget, .wcwp-chatbot-customizer, .wcwp-support-form` hover-transition rule stay — the wrapping div is still in place.

## What stays the same

- The "Contact Support" heading and the email/feature-request/bug-report links keep their content and copy.
- The `.wcwp-support-form` card styling (background, border-radius, shadow, hover lift) is unchanged.
- No PHP function signatures changed; no settings/option keys were touched.
- `php -l admin/settings-page.php` clean.

## Test plan

- [x] Visit Settings → Support area and confirm the form is gone but the heading, lead-in sentence, mailto link, and feature-request / bug-report links all render correctly.
- [x] Confirm the support card retains its background, rounded corners, drop-shadow, and hover lift effect.
- [x] Click the `support@zignites.com` link and confirm it opens the user's mail client.
- [x] Click the feature-request and bug-report links and confirm they open in a new tab (with `rel="noopener"` set in the inspector).
- [x] Search the codebase for `wcwp-support-success`, `wcwp-support-error`, `wcwp-support-name`, `wcwp-support-email`, `wcwp-support-message`, `wcwp-support-contact-form` — all dead references.
- [x] `php -l` clean on the touched file.

## Risk / rollback

Very low. The removed form had no backing endpoint, so deleting it eliminates a misleading UI with zero functional regression. Rollback by reverting the commit.