### PR TITLE
Bounded retry queue for failed follow-up sends (audit #23)

### DIFF
--- a/includes/scheduler.php
+++ b/includes/scheduler.php
@@ -33,11 +33,16 @@ function wcwp_send_followup_message_handler($order_id) {
     $order = wc_get_order($order_id);
     if (!$order) return;
 
-    // Prevent repeat sends
+    // Final states — never retry once we're here.
     if ($order->get_meta('_wcwp_followup_sent')) return;
+    if ($order->get_meta('_wcwp_followup_failed')) return;
 
     $to = sanitize_text_field($order->get_billing_phone());
     if (!$to) return;
+
+    // Permanent skip: opt-outs never reach the provider, so retrying just
+    // burns attempts on the same `false` return.
+    if (wcwp_is_opted_out($to)) return;
 
     $message = wcwp_build_followup_message($order);
 
@@ -55,7 +60,29 @@ function wcwp_send_followup_message_handler($order_id) {
     if ($result === true) {
         $order->update_meta_data('_wcwp_followup_sent', current_time('mysql'));
         $order->save();
+        return;
     }
+
+    // 3-attempt cap mirrors the cart-recovery queue. Backoff steps are
+    // shorter (5/15 vs the cart queue's 15min) because the value of a
+    // followup decays fast — a 4h-old "thanks for your order" is awkward.
+    $attempts     = intval($order->get_meta('_wcwp_followup_attempts')) + 1;
+    $max_attempts = 3;
+    $backoffs     = [5, 15];
+
+    $order->update_meta_data('_wcwp_followup_attempts', $attempts);
+
+    if ($attempts >= $max_attempts) {
+        $order->update_meta_data('_wcwp_followup_failed', current_time('mysql'));
+        $order->save();
+        return;
+    }
+
+    $delay_minutes = isset($backoffs[$attempts - 1]) ? $backoffs[$attempts - 1] : 60;
+    $next_at       = time() + ($delay_minutes * MINUTE_IN_SECONDS);
+
+    $order->save();
+    wp_schedule_single_event($next_at, 'wcwp_send_followup_message', [$order_id]);
 }
 
 function wcwp_build_followup_message($order) {


### PR DESCRIPTION
## Summary

Audit point #23 — `wcwp_send_followup_message_handler()` was fire-and-forget. The WP-Cron event fired once at `order_completed + delay_minutes`; if `wcwp_send_whatsapp_message()` returned `false` (transient API outage, rate limit, network timeout, missing credentials at send time, etc.), the message was silently dropped and `_wcwp_followup_sent` was never set, so there was no record of why.

This PR adds a bounded retry loop that reuses the existing `wcwp_send_followup_message` action. **No new cron schedule, no queue table.** Cart-recovery has a table because it fans out one row per phone+cart; follow-ups have at most one pending event per order, so single-event rescheduling is the right primitive.

## What changed

`includes/scheduler.php` — `wcwp_send_followup_message_handler()`:

- Bail early if `_wcwp_followup_sent` **or** the new `_wcwp_followup_failed` meta is set (final states).
- Explicit `wcwp_is_opted_out($to)` check before send. The provider already returns `false` for opted-out numbers, but catching it here avoids burning the 3-attempt budget on a permanently unsendable address.
- On send success — set `_wcwp_followup_sent`, save, return (unchanged from before).
- On send failure — bump `_wcwp_followup_attempts` (new order meta). If `attempts >= 3`, set `_wcwp_followup_failed` and stop. Otherwise `wp_schedule_single_event(now + backoff[attempts], 'wcwp_send_followup_message', [order_id])`.
- Backoff: `[5, 15]` minutes — 5 min between attempts 1→2, 15 min between 2→3. Three attempts total (mirrors cart-recovery's `$max_attempts = 3`); shorter steps than the cart queue's 15-min fixed retry because a 4h-old "thanks for your order" follow-up is awkward.

## Order meta keys

| Key                            | Type     | Set when                                              |
| ------------------------------ | -------- | ----------------------------------------------------- |
| `_wcwp_followup_scheduled`     | int (ts) | Initial scheduling (existing — unchanged)             |
| `_wcwp_followup_sent`          | string   | Successful send (existing — unchanged)                |
| `_wcwp_followup_attempts`      | int      | New: incremented on each send failure                 |
| `_wcwp_followup_failed`        | string   | New: set when attempt cap is reached (final state)    |

`_wcwp_followup_sent` and `_wcwp_followup_failed` are mutually exclusive — both function as terminal-state flags that the handler treats as "do nothing, return immediately."

## What stays the same

- `wcwp_maybe_schedule_followup()` — initial scheduling untouched.
- The action hook `wcwp_send_followup_message`, the GPT/template message-build pipeline, and the analytics call (`type => 'followup'`) inside `wcwp_send_whatsapp_message()` are all unchanged.
- No schema changes, no migrations. Orders that never fail carry the same meta footprint as before; the new keys appear lazily only on first failure.
- No new cron schedules — only `wp_schedule_single_event` calls onto an action that already existed.

## Test plan

- [x] Happy path: enable follow-ups, place an order, let it process. After `delay_minutes`, confirm `_wcwp_followup_sent` is set and no `_wcwp_followup_attempts` meta exists.
- [x] First-attempt failure: in test mode, force `wcwp_send_whatsapp_message` to return `false` (e.g., temporarily clear Twilio creds at the moment of send). Confirm `_wcwp_followup_attempts` is `1`, no `_wcwp_followup_sent`, and a new event for `wcwp_send_followup_message` is queued ~5 min in the future (visible in WP Crontrol or `wp_get_scheduled_event`).
- [x] Second-attempt failure: same. Confirm `_wcwp_followup_attempts` is `2`, next event scheduled ~15 min out.
- [x] Third-attempt failure: confirm `_wcwp_followup_attempts` is `3`, `_wcwp_followup_failed` is set to a `current_time('mysql')` value, **no** new event is scheduled, and re-firing the action manually returns immediately (no fourth attempt, no provider call).
- [x] Recovery: fail once, then fix creds before the 5-min retry fires. Confirm the second attempt succeeds, `_wcwp_followup_sent` is set, attempts stays at `1` (we don't reset on success — diagnostic value).
- [x] Opt-out path: opt the customer's number out, place an order, wait for delay. Confirm the handler returns immediately at the opt-out check, no provider call, no attempts increment.
- [x] `php -l includes/scheduler.php` clean.

## Risk / rollback

Low. Failure path is additive — happy-path orders see byte-identical behaviour. The new meta keys are private (`_` prefix) and won't collide with anything outside the plugin. Rollback by reverting the commit; orphan `_wcwp_followup_attempts` / `_wcwp_followup_failed` meta on existing orders becomes inert. Pending retry cron events queued before rollback would still fire once, hit the original handler, and either succeed or silently drop again — no breakage either way.