### PR TITLE
Bounded retry queue for failed order-confirmation sends (audit #24)

### DIFF
--- a/includes/order-hooks.php
+++ b/includes/order-hooks.php
@@ -1,19 +1,26 @@
 <?php
 if (!defined('ABSPATH')) exit;
 
-// Hook into WooCommerce order complete
+// Hook into WooCommerce order complete + retries via cron.
 add_action('woocommerce_order_status_completed', 'wcwp_send_whatsapp_on_order_complete');
 add_action('woocommerce_order_status_processing', 'wcwp_send_whatsapp_on_order_complete');
+add_action('wcwp_send_order_message', 'wcwp_send_whatsapp_on_order_complete');
 
 function wcwp_send_whatsapp_on_order_complete($order_id) {
     $order = wc_get_order($order_id);
     if (!$order) return;
 
-    if ($order->get_meta('_wcwp_order_msg_sent')) {
-        return;
-    }
+    // Final states — never retry once we're here.
+    if ($order->get_meta('_wcwp_order_msg_sent')) return;
+    if ($order->get_meta('_wcwp_order_msg_failed')) return;
 
     $to = sanitize_text_field($order->get_billing_phone());
+    if (!$to) return;
+
+    // Permanent skip: opt-outs never reach the provider, so retrying just
+    // burns attempts on the same `false` return.
+    if (wcwp_is_opted_out($to)) return;
+
     $name = $order->get_billing_first_name();
     $total = $order->get_total();
 
@@ -28,7 +35,29 @@ function wcwp_send_whatsapp_on_order_complete($order_id) {
     if ($result === true) {
         $order->update_meta_data('_wcwp_order_msg_sent', current_time('mysql'));
         $order->save();
+        return;
     }
+
+    // Mirrors the followup retry queue (scheduler.php): 3-attempt cap with
+    // 5/15min backoff. Reschedules onto the same `wcwp_send_order_message`
+    // action this function is hooked to — no new cron schedule, no queue table.
+    $attempts     = intval($order->get_meta('_wcwp_order_msg_attempts')) + 1;
+    $max_attempts = 3;
+    $backoffs     = [5, 15];
+
+    $order->update_meta_data('_wcwp_order_msg_attempts', $attempts);
+
+    if ($attempts >= $max_attempts) {
+        $order->update_meta_data('_wcwp_order_msg_failed', current_time('mysql'));
+        $order->save();
+        return;
+    }
+
+    $delay_minutes = isset($backoffs[$attempts - 1]) ? $backoffs[$attempts - 1] : 60;
+    $next_at       = time() + ($delay_minutes * MINUTE_IN_SECONDS);
+
+    $order->save();
+    wp_schedule_single_event($next_at, 'wcwp_send_order_message', [$order_id]);
 }
 
 // Add manual WhatsApp message button to order admin screen
@@ -93,6 +122,12 @@ add_action('wp_ajax_wcwp_send_manual_whatsapp', function() {
     );
 
     if ($result === true) {
+        // Mark the order's confirmation as sent so any pending auto-retry
+        // (queued by `wcwp_send_whatsapp_on_order_complete` after a previous
+        // transient failure) bails on its early-return check instead of
+        // double-sending to the customer.
+        $order->update_meta_data('_wcwp_order_msg_sent', current_time('mysql'));
+        $order->save();
         wp_send_json_success(['redirect' => $redirect]);
     }
     wp_send_json_error(['redirect' => $redirect, 'message' => __('Send failed', 'woochat-pro')]);


### PR DESCRIPTION
## Summary

Audit point #24 — `wcwp_send_whatsapp_on_order_complete()` was fire-and-forget. The WC-status hook fired once; if `wcwp_send_whatsapp_message()` returned `false` (transient API outage, rate limit, network timeout, missing credentials at that moment, etc.), the message was silently dropped. Same flaw as the follow-up path, fixed in PR #36.

This PR applies the same single-event-reschedule pattern: no new cron schedule, no queue table, just an existing-action retry loop with a bounded attempt counter in order meta.

## What changed

`includes/order-hooks.php`:

- **New `wcwp_send_order_message` action** — `wcwp_send_whatsapp_on_order_complete` is hooked to it in addition to the WC status hooks, so cron retries fire back into the same handler.
- **Retry logic in `wcwp_send_whatsapp_on_order_complete()`**:
  - Bail early on `_wcwp_order_msg_sent` (existing) **and** the new `_wcwp_order_msg_failed` meta — stale cron events from before plugin upgrade can't resurrect a permanently-failed order.
  - Explicit `wcwp_is_opted_out($to)` check on entry so opted-out numbers don't burn the 3-attempt budget.
  - On success: existing `_wcwp_order_msg_sent` write, return (unchanged behaviour for happy path).
  - On failure: bump `_wcwp_order_msg_attempts` (new). If `attempts >= 3`, set `_wcwp_order_msg_failed` and stop. Otherwise `wp_schedule_single_event(now + backoff[attempts], 'wcwp_send_order_message', [order_id])`.
  - Backoff: `[5, 15]` minutes. Three-attempt cap, matching the followup queue (PR #36) and cart-recovery's `$max_attempts`.
- **Manual-send AJAX now writes `_wcwp_order_msg_sent` on success.** This plugs a duplicate-send race opened by the new retry logic: if an admin clicks the manual-send button while an auto-retry is queued, customers would otherwise receive two copies. The terminal-state guard above suppresses the pending cron event when the meta is set.

## What stays the same

- Manual-send AJAX path stays synchronous — admin clicks, waits, sees success/fail toast. **No background retries on manual sends** (auto-retrying admin-initiated actions would surprise the user). Only the new `_wcwp_order_msg_sent` write on success was added.
- Test-message AJAX path untouched — unrelated.
- The WC status hooks (`woocommerce_order_status_completed`, `woocommerce_order_status_processing`), the template-render pipeline, the analytics call (`type => 'order'`), and `wcwp_send_whatsapp_message`'s contract are all unchanged.
- No schema changes, no migrations. New meta keys appear lazily only on first failure.

## Order meta keys

| Key                          | Type     | Set when                                              |
| ---------------------------- | -------- | ----------------------------------------------------- |
| `_wcwp_order_msg_sent`       | string   | Successful send (existing — also now set by manual)   |
| `_wcwp_order_msg_attempts`   | int      | New: incremented on each failed auto-send             |
| `_wcwp_order_msg_failed`     | string   | New: set when attempt cap is reached (final state)    |

`_wcwp_order_msg_sent` and `_wcwp_order_msg_failed` are mutually exclusive — both function as terminal-state flags that the handler treats as "do nothing, return immediately."

## Test plan

- [x] Happy path: place an order. Confirm `_wcwp_order_msg_sent` is set, no `_wcwp_order_msg_attempts` meta exists.
- [x] First-attempt failure: place an order with broken creds, confirm `_wcwp_order_msg_attempts` is `1`, no `_wcwp_order_msg_sent`, and a `wcwp_send_order_message` event is queued ~5 min out (visible in WP Crontrol).
- [x] Second-attempt failure: same. Confirm `_wcwp_order_msg_attempts` is `2`, next event ~15 min out.
- [x] Third-attempt failure: confirm `_wcwp_order_msg_attempts` is `3`, `_wcwp_order_msg_failed` is set, **no** new event scheduled, manual re-fire of the action returns immediately.
- [x] Recovery: fail once, fix creds before the 5-min retry. Confirm second attempt succeeds, `_wcwp_order_msg_sent` is set, attempts stays at `1` (we don't reset on success — diagnostic value).
- [x] Opt-out path: opt the number out, place an order. Handler returns at the opt-out check, no provider call, no attempts increment.
- [x] **Duplicate-send race**: trigger an auto-send failure (so `_wcwp_order_msg_attempts` is `1` and a retry is queued). Click the manual-send button on the order screen with working creds. Confirm: manual send succeeds, `_wcwp_order_msg_sent` is set, customer receives **one** message. When the queued retry fires 5 min later, confirm it bails on the early-return check (no second message).
- [x] `php -l includes/order-hooks.php` clean.

## Risk / rollback

Low. Failure path is additive — happy-path orders see byte-identical behaviour. The manual-send change is one extra meta write on success; no behaviour change for callers. Rollback by reverting the commit; orphan `_wcwp_order_msg_attempts` / `_wcwp_order_msg_failed` meta on existing orders becomes inert. Pending retry cron events queued before rollback would still fire once, hit the original handler, and either succeed or silently drop again — no breakage either way.