### PR TITLE
Localize license status labels across admin UI and JS (audit #25)

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -78,6 +78,15 @@ function wcwp_render_settings_page() {
         'resendNonce' => wp_create_nonce('wcwp_resend_cart'),
         'licenseNonce' => wp_create_nonce('wcwp_license_nonce'),
         'testNonce' => wp_create_nonce('wcwp_test_message'),
+        'licenseLabels' => [
+            'keyRequired'        => __('Key required', 'woochat-pro'),
+            'activating'         => __('Activating…', 'woochat-pro'),
+            'active'             => __('Active', 'woochat-pro'),
+            'activationFailed'   => __('Activation failed', 'woochat-pro'),
+            'deactivating'       => __('Deactivating…', 'woochat-pro'),
+            'inactive'           => __('Inactive', 'woochat-pro'),
+            'deactivationFailed' => __('Deactivation failed', 'woochat-pro'),
+        ],
     ]);
     // Onboarding wizard renders once per install — Skip/Finish persists the
     // dismissal flag via admin-ajax, after which the modal stops re-mounting.
@@ -132,7 +141,7 @@ function wcwp_render_settings_page() {
                 </div>
                 <div class="wcwp-dashboard-widget-stat">
                     <span class="dashicons dashicons-admin-network"></span>
-                    <div class="wcwp-stat-value"><?php echo esc_html(ucfirst($dash_license)); ?></div>
+                    <div class="wcwp-stat-value"><?php echo esc_html(wcwp_license_status_label($dash_license)); ?></div>
                     <div class="wcwp-stat-label"><?php esc_html_e('License Status', 'woochat-pro'); ?></div>
                 </div>
             </div>

--- a/admin/views/tab-license.php
+++ b/admin/views/tab-license.php
@@ -10,7 +10,7 @@ if (!defined('ABSPATH')) exit;
                 <div style="margin-top:8px; display:flex; align-items:center; gap:12px;">
                     <?php $status = get_option('wcwp_license_status', 'inactive'); ?>
                     <span id="wcwp-license-status" class="wcwp-badge <?php echo $status === 'valid' ? 'wcwp-badge-success' : 'wcwp-badge-muted'; ?>">
-                        <?php echo $status === 'valid' ? 'Active' : ucfirst($status); ?>
+                        <?php echo esc_html(wcwp_license_status_label($status)); ?>
                     </span>
                     <button type="button" class="button button-primary" id="wcwp-activate-license"><?php esc_html_e('Activate', 'woochat-pro'); ?></button>
                     <button type="button" class="button" id="wcwp-deactivate-license"><?php esc_html_e('Deactivate', 'woochat-pro'); ?></button>
@@ -19,7 +19,10 @@ if (!defined('ABSPATH')) exit;
                 $expires = get_option('wcwp_license_expires');
                 $message = get_option('wcwp_license_message');
                 if ($expires) {
-                    echo '<p class="description">Expires: ' . esc_html($expires) . '</p>';
+                    printf(
+                        '<p class="description">%s</p>',
+                        esc_html( sprintf( /* translators: %s: license expiry date */ __( 'Expires: %s', 'woochat-pro' ), $expires ) )
+                    );
                 }
                 if ($message) {
                     echo '<p class="description">' . esc_html($message) . '</p>';

--- a/assets/js/admin-premium.js
+++ b/assets/js/admin-premium.js
@@ -149,21 +149,26 @@ document.addEventListener('DOMContentLoaded', function () {
         }).then(res => res.json());
     }
 
+    // English fallbacks keep the UI working if the localization payload is
+    // ever missing — degrades to English instead of "undefined".
+    const labels = (window.wcwpAdminData && wcwpAdminData.licenseLabels) || {};
+    const t = (key, fallback) => labels[key] || fallback;
+
     if (activateBtn) {
         activateBtn.addEventListener('click', function () {
             if (!keyField || !keyField.value) {
-                setStatus('Key required', false);
+                setStatus(t('keyRequired', 'Key required'), false);
                 return;
             }
-            setStatus('Activating…', false);
+            setStatus(t('activating', 'Activating…'), false);
             activateBtn.disabled = true;
             postLicense('wcwp_activate_license', keyField.value).then(data => {
                 if (data && data.success) {
-                    setStatus('Active', true);
+                    setStatus(t('active', 'Active'), true);
                 } else {
-                    setStatus((data && data.data && data.data.message) ? data.data.message : 'Activation failed', false);
+                    setStatus((data && data.data && data.data.message) ? data.data.message : t('activationFailed', 'Activation failed'), false);
                 }
-            }).catch(() => setStatus('Activation failed', false)).finally(() => {
+            }).catch(() => setStatus(t('activationFailed', 'Activation failed'), false)).finally(() => {
                 activateBtn.disabled = false;
             });
         });
@@ -171,15 +176,15 @@ document.addEventListener('DOMContentLoaded', function () {
 
     if (deactivateBtn) {
         deactivateBtn.addEventListener('click', function () {
-            setStatus('Deactivating…', false);
+            setStatus(t('deactivating', 'Deactivating…'), false);
             deactivateBtn.disabled = true;
             postLicense('wcwp_deactivate_license').then(data => {
                 if (data && data.success) {
-                    setStatus('Inactive', false);
+                    setStatus(t('inactive', 'Inactive'), false);
                 } else {
-                    setStatus('Deactivation failed', false);
+                    setStatus(t('deactivationFailed', 'Deactivation failed'), false);
                 }
-            }).catch(() => setStatus('Deactivation failed', false)).finally(() => {
+            }).catch(() => setStatus(t('deactivationFailed', 'Deactivation failed'), false)).finally(() => {
                 deactivateBtn.disabled = false;
             });
         });

--- a/includes/license-manager.php
+++ b/includes/license-manager.php
@@ -109,3 +109,19 @@ function wcwp_deactivate_license_ajax() {
 function wcwp_is_pro_active() {
     return get_option('wcwp_license_status') === 'valid';
 }
+
+function wcwp_license_status_label($status) {
+    // Known statuses get translated labels. Unknown values fall back to
+    // ucfirst() so a new server-side status string still renders something
+    // human-readable (just untranslated) instead of breaking the UI.
+    $labels = [
+        'valid'    => __('Active', 'woochat-pro'),
+        'inactive' => __('Inactive', 'woochat-pro'),
+        'expired'  => __('Expired', 'woochat-pro'),
+        'invalid'  => __('Invalid', 'woochat-pro'),
+    ];
+    if (isset($labels[$status])) {
+        return $labels[$status];
+    }
+    return ucfirst((string) $status);
+}


### PR DESCRIPTION
## Summary

Audit point #25 — license-status display strings hardcoded English across multiple sites. The audit memo flagged `Active`/`Inactive`, but the same flow had several other untranslated literals: `Expired` / `Invalid` / `Activating…` / `Deactivating…` / `Activation failed` / `Deactivation failed` / `Key required` and the `Expires:` description prefix. Localizing only `Active` while leaving the rest hardcoded would leave non-English admins seeing a half-translated license tab. Fixed all of them as one coherent unit.

## What changed

### New helper
- **`includes/license-manager.php`** — `wcwp_license_status_label($status)`. Maps the four known statuses (`valid`, `inactive`, `expired`, `invalid`) to translated strings via `__()`. Unknown values fall back to `ucfirst((string) $status)` so a new server-side status string still renders something human-readable rather than breaking the UI — graceful degradation for forward-compat.

### PHP display sites
- **`admin/views/tab-license.php`** — replaced the inline ternary `$status === 'valid' ? 'Active' : ucfirst($status)` with the helper. Wrapped output in `esc_html()` (the original was unescaped — minor hygiene win on a sanitized option, but the rest of the file uses `esc_html_e()` consistently).
- **`admin/views/tab-license.php`** — translated the `Expires:` description prefix via `printf` + `/* translators: %s: license expiry date */` so the date stays in the same string for locales where the colon-date pairing matters.
- **`admin/settings-page.php`** dashboard widget — replaced `ucfirst($dash_license)` with the helper.

### JS feedback strings
- **`admin/settings-page.php`** — extended the existing `wcwpAdminData` localization payload with a new `licenseLabels` object keyed by stable identifiers (`keyRequired`, `activating`, `active`, `activationFailed`, `deactivating`, `inactive`, `deactivationFailed`).
- **`assets/js/admin-premium.js`** — reads through a small `t(key, fallback)` helper. Each call hardcodes the English literal as the fallback so the UI degrades to English (not `undefined`) if the localization payload is ever missing.

## What stays the same

- Server-side message strings already translatable (`license-manager.php` returns `__('Activated', ...)` / `__('Deactivated', ...)`) keep flowing through unchanged. JS renders those values verbatim when present, so they're already locale-aware.
- The raw `wcwp_license_status` option value (`valid` / `inactive` / etc.) is unchanged — it stays English because it's a key, not a label. `wcwp_is_pro_active()` still does `=== 'valid'`.
- No new options, no migrations. Existing translations of `Active`, `Inactive`, etc., that already exist in the .pot/.po files (or any third-party language packs) auto-pick-up via the standard `__()` lookup.
- Public function signatures unchanged.

## Test plan

- [x] Switch site language to a non-English locale that has WooChat Pro translations (or temporarily add some test strings to the .po file). Visit the License tab and confirm the status badge renders the translated label.
- [x] Visit the dashboard widget on the WooChat settings page and confirm the License Status stat shows the translated label.
- [x] Click Activate without a key — confirm the badge updates to the translated "Key required" string.
- [x] Click Activate with a valid key — confirm "Activating…" then "Active" both render in the active locale.
- [x] Click Deactivate — confirm "Deactivating…" then "Inactive" both render in the active locale.
- [x] Trigger an activation/deactivation failure (e.g., bad nonce) — confirm "Activation failed"/"Deactivation failed" render in the active locale, but a server-returned error message (when present in `data.data.message`) still flows through verbatim.
- [x] Set `wcwp_license_status` to a value the helper doesn't know (e.g., `'pending'` via `wp option update`). Confirm the badge renders `Pending` (ucfirst fallback) without throwing an error.
- [x] In devtools, set `wcwpAdminData = undefined` then click Activate — confirm the JS still produces the English fallback strings instead of "undefined".
- [x] `php -l` clean on all three touched PHP files.

## Risk / rollback

Very low. All changes are display-layer only; no schema, network, option keys, or function signatures touched. The new helper is additive. Rollback by reverting the commit.