### PR TITLE
Tighten .gitignore Node-tooling patterns (audit #27)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ Thumbs.db
 *.bak
 *.swp
 *.tmp
-*node_modules/
-*package-lock.json
-*package.json
+
+# Ignore Node tooling — the plugin has no build step and ships hand-written
+# JS, so package.json (and its lockfile + install dir) are dev-only artifacts
+# that should never enter the repo.
+node_modules/
+package.json
+package-lock.json


### PR DESCRIPTION
## Summary

Audit point #27 — "Drop committed `package-lock.json` + decide on `package.json` (codex dep unused at runtime)."

Investigation: `package.json`, `package-lock.json`, and `node_modules/` are **already untracked** — `git ls-files` confirms none of them have ever been committed. The existing `.gitignore` patterns were keeping them out, just with overly-broad `*`-prefixed glob syntax. So the audit's "drop the committed file" half is a no-op; the actually-useful work is gitignore hygiene + an explicit decision on whether the npm topic belongs here at all.

## What changed

`.gitignore`:

- Replaced `*node_modules/`, `*package-lock.json`, `*package.json` (leading-`*` versions matched extra junk like `xnode_modules/`, `mypackage-lock.json`) with the conventional plain basenames `node_modules/`, `package.json`, `package-lock.json`.
- Moved the three lines into their own section with a header that documents the audit-#27 decision: the plugin has no build step (no webpack/vite/rollup/eslint configs, no `npm run` scripts, no source imports from `node_modules`) and ships hand-written JS in `assets/js/*.js`. The local `package.json` is a single unused `codex` dep — a stray dev artifact. Files stay gitignored so a future `git add .` from the plugin root can't surface them.

## What stays the same

- `*.log`, `*.bak`, `*.swp`, `*.tmp`, `.DS_Store`, `Thumbs.db` patterns are unchanged.
- No tracked files added or removed. `git ls-files` output is byte-identical before and after.
- No source code, no build step, no test infra touched. PHP, JS, CSS untouched.
- If a future contributor wants to legitimately add a build step, removing the `package.json` line from `.gitignore` is one line — the policy is documented, not locked.

## Test plan

- [x] `git status` is clean other than this PR's `.gitignore` change.
- [x] `cd` into the plugin root, run `git add .` (with the local `package.json`, `package-lock.json`, `node_modules/` still present from previous npm experimentation) — confirm none of them get staged.
- [x] Search the codebase for `codex`, `node_modules`, or any npm-package import — confirm zero references in source (only the gitignore line itself matches).
- [x] Render the file in the GitHub UI to confirm the new comment block reads well.

## Why this PR is small

The audit memo was based on an earlier snapshot — by the time we got to point #27, the gitignore was already keeping the dev-only artifacts out. The remaining value was: (1) clean up the non-conventional `*`-prefix syntax, and (2) write down the "no, this plugin doesn't use npm" decision so it doesn't get re-litigated.