### PR TITLE
Add minimal PHPUnit test harness + smoke tests (audit #28)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,12 @@ Thumbs.db
 *.swp
 *.tmp
 
+# Ignore PHP tooling
+vendor/
+composer.lock
+phpunit.xml
+.phpunit.result.cache
+
 # Ignore Node tooling — the plugin has no build step and ships hand-written
 # JS, so package.json (and its lockfile + install dir) are dev-only artifacts
 # that should never enter the repo.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "zignite/woochat-pro",
+    "description": "WooChat Pro — WhatsApp for WooCommerce. Composer is dev-only here (PHPUnit harness); the plugin itself is shipped as a plain WordPress plugin zip.",
+    "type": "wordpress-plugin",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "php": ">=7.4"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.6"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "WooChatPro\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit"
+    },
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         cacheResultFile=".phpunit.result.cache">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+    <coverage processUncoveredFiles="false">
+        <include>
+            <directory suffix=".php">includes</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/tests/Unit/CartRecoveryTest.php
+++ b/tests/Unit/CartRecoveryTest.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace WooChatPro\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class CartRecoveryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['wcwp_test_options'] = [];
+        // WC normally returns HTML entities like `&#36;`; the plugin's helper
+        // decodes to `$` for plain-text WhatsApp output.
+        $GLOBALS['wcwp_test_currency_symbol'] = '&#36;';
+    }
+
+    public function test_render_substitutes_default_template_placeholders(): void
+    {
+        $items = ['• Widget × 2', '• Gadget × 1'];
+        $total = '49.99';
+        $cart_url = 'https://example.com/cart';
+
+        $result = \wcwp_render_cart_recovery_message($items, $total, $cart_url);
+
+        $this->assertStringContainsString('• Widget × 2', $result);
+        $this->assertStringContainsString('• Gadget × 1', $result);
+        $this->assertStringContainsString('49.99', $result);
+        $this->assertStringContainsString('https://example.com/cart', $result);
+        // Currency symbol decoded by wcwp_currency_symbol_text():
+        $this->assertStringContainsString('$', $result);
+
+        // No placeholder leaks through:
+        $this->assertStringNotContainsString('{items}', $result);
+        $this->assertStringNotContainsString('{total}', $result);
+        $this->assertStringNotContainsString('{cart_url}', $result);
+        $this->assertStringNotContainsString('{currency_symbol}', $result);
+    }
+
+    public function test_render_uses_custom_template_from_option(): void
+    {
+        $GLOBALS['wcwp_test_options']['wcwp_cart_recovery_message'] =
+            'Items: {items}; Total: {total} {currency_symbol}; URL: {cart_url}';
+
+        $result = \wcwp_render_cart_recovery_message(['•Foo'], '99.50', 'https://shop.test/c');
+
+        $this->assertSame(
+            'Items: •Foo; Total: 99.50 $; URL: https://shop.test/c',
+            $result
+        );
+    }
+}

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace WooChatPro\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class HelpersTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['wcwp_test_options'] = [];
+    }
+
+    public function test_normalize_phone_strips_non_digits(): void
+    {
+        $this->assertSame('15551234567', \wcwp_normalize_phone('+1 (555) 123-4567'));
+    }
+
+    public function test_normalize_phone_handles_no_digits(): void
+    {
+        $this->assertSame('', \wcwp_normalize_phone('abc'));
+    }
+
+    public function test_normalize_phone_handles_null_and_empty(): void
+    {
+        $this->assertSame('', \wcwp_normalize_phone(null));
+        $this->assertSame('', \wcwp_normalize_phone(''));
+    }
+
+    public function test_normalize_phone_preserves_pure_digits(): void
+    {
+        $this->assertSame('923001234567', \wcwp_normalize_phone('923001234567'));
+    }
+
+    public function test_optout_keyword_match_default_stop(): void
+    {
+        $this->assertTrue(\wcwp_optout_keyword_match('STOP'));
+    }
+
+    public function test_optout_keyword_match_default_unsubscribe(): void
+    {
+        $this->assertTrue(\wcwp_optout_keyword_match('please unsubscribe me'));
+    }
+
+    public function test_optout_keyword_match_no_match(): void
+    {
+        $this->assertFalse(\wcwp_optout_keyword_match('hello there'));
+    }
+
+    public function test_optout_keyword_match_case_insensitive(): void
+    {
+        $this->assertTrue(\wcwp_optout_keyword_match('Stop'));
+        $this->assertTrue(\wcwp_optout_keyword_match('UNSUBSCRIBE'));
+    }
+
+    public function test_optout_keyword_match_custom_keywords(): void
+    {
+        $GLOBALS['wcwp_test_options']['wcwp_optout_keywords'] = 'cancel, opt out';
+        $this->assertTrue(\wcwp_optout_keyword_match('I want to cancel'));
+        // 'stop' is no longer in the configured keyword list:
+        $this->assertFalse(\wcwp_optout_keyword_match('STOP'));
+    }
+
+    public function test_optout_keyword_match_empty_input(): void
+    {
+        $this->assertFalse(\wcwp_optout_keyword_match(''));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * PHPUnit bootstrap.
+ *
+ * Tests run in isolation — no WordPress install, no database. The minimum WP
+ * API surface the helpers under test actually call is stubbed below; tests
+ * inject behaviour by writing to `$GLOBALS['wcwp_test_*']` between cases.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+
+if (!function_exists('add_action')) {
+    function add_action(...$args) { /* no-op for unit tests */ }
+}
+if (!function_exists('add_filter')) {
+    function add_filter(...$args) { /* no-op for unit tests */ }
+}
+if (!function_exists('apply_filters')) {
+    function apply_filters($tag, $value) { return $value; }
+}
+if (!function_exists('get_option')) {
+    function get_option($key, $default = false) {
+        return $GLOBALS['wcwp_test_options'][$key] ?? $default;
+    }
+}
+if (!function_exists('get_woocommerce_currency_symbol')) {
+    function get_woocommerce_currency_symbol($currency = '') {
+        return $GLOBALS['wcwp_test_currency_symbol'] ?? '&#36;';
+    }
+}
+
+require_once __DIR__ . '/../includes/helpers.php';
+require_once __DIR__ . '/../includes/cart-recovery.php';


### PR DESCRIPTION
## Summary

Audit point #28 — plugin had no test infrastructure. This PR adds the smallest useful harness: a contributor can clone the repo, run `composer install && composer test`, and get green output. No WordPress install, no database.

Verified locally: **12 tests, 23 assertions, 21ms — all green** under PHPUnit 9.6.34 / PHP 8.2.

## Approach

Pure unit tests with stubbed WP API. Considered and rejected `WP_PHPUnit` / `WP_UnitTestCase` — those require a live MySQL + WP install and would be heavy infrastructure for what the audit explicitly says: *"tests can be run by future contributors, not full coverage."*

The bootstrap stubs the small WP API surface the helpers under test actually call (`add_action`, `add_filter`, `apply_filters`, `get_option`, `get_woocommerce_currency_symbol`); tests inject behaviour through `$GLOBALS['wcwp_test_*']` between cases.

## What changed

- **`composer.json`** — dev-only `phpunit/phpunit ^9.6` (last major that supports PHP 7.4, which the plugin's `readme.txt` requires). PSR-4 `autoload-dev` maps `WooChatPro\Tests\` to `tests/`. `composer test` script wired so contributors don't need to remember the phpunit binary path.
- **`phpunit.xml.dist`** — standard PHPUnit 9 config; bootstrap + strict modes (`beStrictAboutOutputDuringTests`, etc.) so accidental warnings surface as test failures.
- **`tests/bootstrap.php`** — the WP-stub layer described above. Loads `includes/helpers.php` and `includes/cart-recovery.php` after stubs are defined.
- **`tests/Unit/HelpersTest.php`** — 8 tests:
  - `wcwp_normalize_phone`: digit-stripping (`+1 (555) 123-4567` → `15551234567`), no-digit input, `null`/empty, pure-digit pass-through.
  - `wcwp_optout_keyword_match`: default `stop`/`unsubscribe` matches, no-match, case-insensitivity, custom keywords from option, empty input.
- **`tests/Unit/CartRecoveryTest.php`** — 2 tests covering `wcwp_render_cart_recovery_message` substitution against both the default template and a custom one from the option store. Verifies all four placeholders (`{items}`, `{total}`, `{cart_url}`, `{currency_symbol}`) resolve and that the HTML-entity-decoded currency symbol shows up.
- **`.gitignore`** — new "Ignore PHP tooling" section: `vendor/`, `composer.lock`, `phpunit.xml`, `.phpunit.result.cache`. Convention: `phpunit.xml.dist` is committed (the canonical config); `phpunit.xml` is gitignored for local contributor overrides.

## What stays the same

- The plugin still ships as a plain WordPress plugin zip. Composer is **dev-only** here — no runtime dep, no production composer install required.
- No source code in `includes/` or `admin/` is touched.
- Existing JS tests (none) and CI (none) are unaffected.

## How to run

```sh
composer install
composer test
# or directly: vendor/bin/phpunit
```

## Test plan

- [x] Fresh clone: `composer install` succeeds (downloads ~24 packages — phpunit + transitive).
- [x] `composer test` produces `OK (12 tests, 23 assertions)` in <100ms.
- [x] `vendor/bin/phpunit --filter=test_normalize_phone_strips_non_digits` runs just that one test.
- [x] `git status` after install shows nothing — `vendor/`, `composer.lock`, `.phpunit.result.cache` are gitignored.
- [x] `php -l` clean on all five new PHP files.

## Follow-ups (deliberately out of scope)

- A GitHub Actions workflow that runs `composer test` on every PR would close the loop, but that's CI infrastructure, not test infrastructure. Could be a separate PR if the user wants it.
- Coverage of more helpers (`wcwp_mask_phone`, `wcwp_redact_message`, `wcwp_sanitize_*`, the migration runner) — easy to add now that the harness exists.
- Integration tests that hit a real provider in test mode — that's `WP_UnitTestCase` territory, much heavier.

## Risk / rollback

Zero runtime risk — none of the new files are loaded by WordPress at runtime. `composer.json` doesn't declare an `autoload` (only `autoload-dev`), so even if a misconfigured server installed composer deps, nothing in `vendor/` would auto-load into WP requests. Rollback by reverting the commit.