### PR TITLE
Make onboarding wizard capture provider credentials

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -68,6 +68,61 @@ function wcwp_ajax_dismiss_onboarding() {
     wp_send_json_success();
 }
 
+add_action('wp_ajax_wcwp_save_onboarding_credentials', 'wcwp_ajax_save_onboarding_credentials');
+function wcwp_ajax_save_onboarding_credentials() {
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error(['message' => __('Unauthorized', 'woochat-pro')], 403);
+    }
+    if (!check_ajax_referer('wcwp_save_onboarding', 'nonce', false)) {
+        wp_send_json_error(['message' => __('Bad nonce', 'woochat-pro')], 400);
+    }
+
+    $provider_raw = isset($_POST['provider']) ? sanitize_text_field(wp_unslash($_POST['provider'])) : '';
+    if (!in_array($provider_raw, ['twilio', 'cloud'], true)) {
+        wp_send_json_error(['message' => __('Choose a provider before continuing.', 'woochat-pro')], 422);
+    }
+
+    $errors = [];
+
+    if ($provider_raw === 'twilio') {
+        $sid   = isset($_POST['twilio_sid'])   ? wcwp_sanitize_text(wp_unslash($_POST['twilio_sid']))   : '';
+        $token = isset($_POST['twilio_token']) ? wcwp_sanitize_text(wp_unslash($_POST['twilio_token'])) : '';
+        $from  = isset($_POST['twilio_from'])  ? wcwp_sanitize_text(wp_unslash($_POST['twilio_from']))  : '';
+
+        if ($sid === '')   { $errors['twilio_sid']   = __('Twilio Account SID is required.', 'woochat-pro'); }
+        if ($token === '') { $errors['twilio_token'] = __('Twilio Auth Token is required.', 'woochat-pro'); }
+        if ($from === '')  { $errors['twilio_from']  = __('From Number is required.', 'woochat-pro'); }
+
+        if (!empty($errors)) {
+            wp_send_json_error(['fields' => $errors], 422);
+        }
+
+        update_option('wcwp_api_provider', 'twilio', false);
+        update_option('wcwp_twilio_sid', $sid, false);
+        update_option('wcwp_twilio_auth_token', $token, false);
+        update_option('wcwp_twilio_from', $from, false);
+    } else {
+        $token = isset($_POST['cloud_token'])    ? wcwp_sanitize_text(wp_unslash($_POST['cloud_token']))    : '';
+        $phone = isset($_POST['cloud_phone_id']) ? wcwp_sanitize_text(wp_unslash($_POST['cloud_phone_id'])) : '';
+        $from  = isset($_POST['cloud_from'])     ? wcwp_sanitize_text(wp_unslash($_POST['cloud_from']))     : '';
+
+        if ($token === '') { $errors['cloud_token']    = __('Access Token is required.', 'woochat-pro'); }
+        if ($phone === '') { $errors['cloud_phone_id'] = __('Phone Number ID is required.', 'woochat-pro'); }
+        if ($from === '')  { $errors['cloud_from']     = __('From Number is required.', 'woochat-pro'); }
+
+        if (!empty($errors)) {
+            wp_send_json_error(['fields' => $errors], 422);
+        }
+
+        update_option('wcwp_api_provider', 'cloud', false);
+        update_option('wcwp_cloud_token', $token, false);
+        update_option('wcwp_cloud_phone_id', $phone, false);
+        update_option('wcwp_cloud_from', $from, false);
+    }
+
+    wp_send_json_success();
+}
+
 function wcwp_render_settings_page() {
     // Enqueue premium admin CSS
     wp_enqueue_style('wcwp-admin-premium-css', WCWP_URL . 'assets/css/admin-premium.css', [], WCWP_VERSION);
@@ -95,22 +150,107 @@ function wcwp_render_settings_page() {
         wp_enqueue_style('wcwp-onboarding-css', WCWP_URL . 'assets/css/onboarding.css', [], WCWP_VERSION);
         wp_enqueue_script('wcwp-onboarding-js', WCWP_URL . 'assets/js/onboarding.js', [], WCWP_VERSION, true);
         wp_localize_script('wcwp-onboarding-js', 'wcwpOnboarding', [
-            'ajaxUrl' => admin_url('admin-ajax.php'),
-            'nonce'   => wp_create_nonce('wcwp_dismiss_onboarding'),
+            'ajaxUrl'      => admin_url('admin-ajax.php'),
+            'dismissNonce' => wp_create_nonce('wcwp_dismiss_onboarding'),
+            'saveNonce'    => wp_create_nonce('wcwp_save_onboarding'),
+            'i18n'         => [
+                'saveError'    => __('Could not save. Please check the highlighted fields.', 'woochat-pro'),
+                'networkError' => __('Network error. Please try again.', 'woochat-pro'),
+                'saving'       => __('Saving…', 'woochat-pro'),
+                'next'         => __('Next', 'woochat-pro'),
+            ],
         ]);
     }
 
     $views = __DIR__ . '/views';
     ?>
-    <?php if (!$onboarding_done) : ?>
+    <?php if (!$onboarding_done) :
+        // Prefill from existing options so a re-run of the wizard (e.g. after a
+        // clean reinstall with kept data) doesn't force the admin to retype.
+        $ob_provider = get_option('wcwp_api_provider', 'twilio');
+        if (!in_array($ob_provider, ['twilio', 'cloud'], true)) { $ob_provider = 'twilio'; }
+        $ob_twilio_sid   = get_option('wcwp_twilio_sid', '');
+        $ob_twilio_token = get_option('wcwp_twilio_auth_token', '');
+        $ob_twilio_from  = get_option('wcwp_twilio_from', '');
+        $ob_cloud_token  = get_option('wcwp_cloud_token', '');
+        $ob_cloud_phone  = get_option('wcwp_cloud_phone_id', '');
+        $ob_cloud_from   = get_option('wcwp_cloud_from', '');
+        ?>
     <div id="wcwp-onboarding-modal">
         <div class="wcwp-onboarding-content">
             <div class="wcwp-onboarding-progress"><div class="wcwp-onboarding-progress-inner"></div></div>
-            <div class="wcwp-onboarding-step"> <h2><?php esc_html_e('Welcome to WooChat Pro!', 'woochat-pro'); ?></h2> <p><?php esc_html_e("Let's get you set up in a few easy steps.", 'woochat-pro'); ?></p> </div>
-            <div class="wcwp-onboarding-step"> <h2><?php esc_html_e('Connect WhatsApp API', 'woochat-pro'); ?></h2> <p><?php esc_html_e('Enter your Twilio/Cloud API credentials in the settings.', 'woochat-pro'); ?></p> </div>
-            <div class="wcwp-onboarding-step"> <h2><?php esc_html_e('Set Your WhatsApp Number', 'woochat-pro'); ?></h2> <p><?php esc_html_e('Configure your business WhatsApp number for sending messages.', 'woochat-pro'); ?></p> </div>
-            <div class="wcwp-onboarding-step"> <h2><?php esc_html_e('Enable Features', 'woochat-pro'); ?></h2> <p><?php esc_html_e('Choose which features to enable: order messages, cart recovery, chatbot, and more.', 'woochat-pro'); ?></p> </div>
-            <div class="wcwp-onboarding-step"> <h2><?php esc_html_e('All Set!', 'woochat-pro'); ?></h2> <p><?php esc_html_e('You\'re ready to start using WooChat Pro. Enjoy!', 'woochat-pro'); ?></p> </div>
+
+            <div class="wcwp-onboarding-step" data-step="welcome">
+                <h2><?php esc_html_e('Welcome to WooChat Pro!', 'woochat-pro'); ?></h2>
+                <p><?php esc_html_e("Let's connect your WhatsApp account in a couple of steps.", 'woochat-pro'); ?></p>
+            </div>
+
+            <div class="wcwp-onboarding-step" data-step="provider">
+                <h2><?php esc_html_e('Choose your WhatsApp provider', 'woochat-pro'); ?></h2>
+                <p><?php esc_html_e('Pick the API you have an account with. You can change this later.', 'woochat-pro'); ?></p>
+                <div class="wcwp-onboarding-provider-choices">
+                    <label class="wcwp-onboarding-provider-choice">
+                        <input type="radio" name="wcwp_ob_provider" value="twilio" <?php checked($ob_provider, 'twilio'); ?> />
+                        <span class="wcwp-onboarding-provider-title"><?php esc_html_e('Twilio', 'woochat-pro'); ?></span>
+                        <span class="wcwp-onboarding-provider-desc"><?php esc_html_e('WhatsApp via Twilio Programmable Messaging.', 'woochat-pro'); ?></span>
+                    </label>
+                    <label class="wcwp-onboarding-provider-choice">
+                        <input type="radio" name="wcwp_ob_provider" value="cloud" <?php checked($ob_provider, 'cloud'); ?> />
+                        <span class="wcwp-onboarding-provider-title"><?php esc_html_e('Meta Cloud API', 'woochat-pro'); ?></span>
+                        <span class="wcwp-onboarding-provider-desc"><?php esc_html_e('WhatsApp Business Platform direct from Meta.', 'woochat-pro'); ?></span>
+                    </label>
+                </div>
+            </div>
+
+            <div class="wcwp-onboarding-step" data-step="credentials">
+                <h2><?php esc_html_e('Enter your credentials', 'woochat-pro'); ?></h2>
+                <p class="wcwp-onboarding-step-hint" data-provider-hint="twilio"><?php esc_html_e('Find these in your Twilio Console.', 'woochat-pro'); ?></p>
+                <p class="wcwp-onboarding-step-hint" data-provider-hint="cloud"><?php esc_html_e('Find these in your Meta for Developers app.', 'woochat-pro'); ?></p>
+
+                <div class="wcwp-onboarding-fields" data-provider-fields="twilio">
+                    <div class="wcwp-onboarding-field">
+                        <label for="wcwp_ob_twilio_sid"><?php esc_html_e('Account SID', 'woochat-pro'); ?></label>
+                        <input type="text" id="wcwp_ob_twilio_sid" name="twilio_sid" value="<?php echo esc_attr($ob_twilio_sid); ?>" autocomplete="off" />
+                        <span class="wcwp-onboarding-field-error" data-error-for="twilio_sid"></span>
+                    </div>
+                    <div class="wcwp-onboarding-field">
+                        <label for="wcwp_ob_twilio_token"><?php esc_html_e('Auth Token', 'woochat-pro'); ?></label>
+                        <input type="password" id="wcwp_ob_twilio_token" name="twilio_token" value="<?php echo esc_attr($ob_twilio_token); ?>" autocomplete="off" />
+                        <span class="wcwp-onboarding-field-error" data-error-for="twilio_token"></span>
+                    </div>
+                    <div class="wcwp-onboarding-field">
+                        <label for="wcwp_ob_twilio_from"><?php esc_html_e('From Number', 'woochat-pro'); ?></label>
+                        <input type="text" id="wcwp_ob_twilio_from" name="twilio_from" value="<?php echo esc_attr($ob_twilio_from); ?>" placeholder="whatsapp:+14155238886" autocomplete="off" />
+                        <span class="wcwp-onboarding-field-error" data-error-for="twilio_from"></span>
+                    </div>
+                </div>
+
+                <div class="wcwp-onboarding-fields" data-provider-fields="cloud">
+                    <div class="wcwp-onboarding-field">
+                        <label for="wcwp_ob_cloud_token"><?php esc_html_e('Access Token', 'woochat-pro'); ?></label>
+                        <input type="password" id="wcwp_ob_cloud_token" name="cloud_token" value="<?php echo esc_attr($ob_cloud_token); ?>" autocomplete="off" />
+                        <span class="wcwp-onboarding-field-error" data-error-for="cloud_token"></span>
+                    </div>
+                    <div class="wcwp-onboarding-field">
+                        <label for="wcwp_ob_cloud_phone_id"><?php esc_html_e('Phone Number ID', 'woochat-pro'); ?></label>
+                        <input type="text" id="wcwp_ob_cloud_phone_id" name="cloud_phone_id" value="<?php echo esc_attr($ob_cloud_phone); ?>" autocomplete="off" />
+                        <span class="wcwp-onboarding-field-error" data-error-for="cloud_phone_id"></span>
+                    </div>
+                    <div class="wcwp-onboarding-field">
+                        <label for="wcwp_ob_cloud_from"><?php esc_html_e('From Number', 'woochat-pro'); ?></label>
+                        <input type="text" id="wcwp_ob_cloud_from" name="cloud_from" value="<?php echo esc_attr($ob_cloud_from); ?>" placeholder="+14155238886" autocomplete="off" />
+                        <span class="wcwp-onboarding-field-error" data-error-for="cloud_from"></span>
+                    </div>
+                </div>
+
+                <div class="wcwp-onboarding-form-error" role="alert"></div>
+            </div>
+
+            <div class="wcwp-onboarding-step" data-step="done">
+                <h2><?php esc_html_e('All set!', 'woochat-pro'); ?></h2>
+                <p><?php esc_html_e('Your provider is connected. Visit the tabs below to enable cart recovery, the chatbot, and follow-ups.', 'woochat-pro'); ?></p>
+            </div>
+
             <div class="wcwp-onboarding-buttons">
                 <button type="button" class="wcwp-onboarding-prev"><?php esc_html_e('Back', 'woochat-pro'); ?></button>
                 <button type="button" class="wcwp-onboarding-next"><?php esc_html_e('Next', 'woochat-pro'); ?></button>

--- a/assets/css/onboarding.css
+++ b/assets/css/onboarding.css
@@ -14,7 +14,7 @@
   border-radius: 14px;
   box-shadow: 0 8px 32px rgba(44,62,80,0.18);
   padding: 36px 40px 28px 40px;
-  max-width: 420px;
+  max-width: 480px;
   width: 100%;
   text-align: center;
   position: relative;
@@ -64,4 +64,99 @@
 }
 .wcwp-onboarding-skip:hover {
   background: #b2f7ef;
-} 
+}
+.wcwp-onboarding-next:disabled,
+.wcwp-onboarding-prev:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.wcwp-onboarding-provider-choices {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 18px 0 6px;
+  text-align: left;
+}
+.wcwp-onboarding-provider-choice {
+  display: block;
+  border: 1px solid #d9dee3;
+  border-radius: 8px;
+  padding: 12px 14px;
+  cursor: pointer;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.wcwp-onboarding-provider-choice:hover {
+  border-color: #1c7c54;
+}
+.wcwp-onboarding-provider-choice input[type="radio"] {
+  margin-right: 8px;
+}
+.wcwp-onboarding-provider-choice:has(input:checked) {
+  border-color: #1c7c54;
+  box-shadow: 0 0 0 2px rgba(28,124,84,0.12);
+}
+.wcwp-onboarding-provider-title {
+  font-weight: 600;
+  font-size: 1rem;
+  display: inline;
+}
+.wcwp-onboarding-provider-desc {
+  display: block;
+  margin-top: 4px;
+  margin-left: 22px;
+  font-size: 0.9rem;
+  color: #666;
+}
+
+.wcwp-onboarding-step-hint {
+  color: #555;
+  font-size: 0.95rem;
+  margin: 4px 0 14px;
+}
+.wcwp-onboarding-fields {
+  display: none;
+  text-align: left;
+  margin-top: 8px;
+}
+.wcwp-onboarding-field {
+  margin-bottom: 12px;
+}
+.wcwp-onboarding-field label {
+  display: block;
+  font-weight: 600;
+  font-size: 0.92rem;
+  margin-bottom: 4px;
+  color: #2c3e50;
+}
+.wcwp-onboarding-field input[type="text"],
+.wcwp-onboarding-field input[type="password"] {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid #c8ced4;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  box-sizing: border-box;
+}
+.wcwp-onboarding-field input:focus {
+  border-color: #1c7c54;
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(28,124,84,0.15);
+}
+.wcwp-onboarding-field.has-error input {
+  border-color: #c0392b;
+}
+.wcwp-onboarding-field-error {
+  display: block;
+  margin-top: 4px;
+  color: #c0392b;
+  font-size: 0.85rem;
+  min-height: 1em;
+}
+.wcwp-onboarding-form-error {
+  margin-top: 10px;
+  color: #c0392b;
+  font-size: 0.9rem;
+  min-height: 1em;
+  text-align: left;
+}

--- a/assets/js/onboarding.js
+++ b/assets/js/onboarding.js
@@ -3,41 +3,170 @@
 document.addEventListener('DOMContentLoaded', function () {
     const wizard = document.getElementById('wcwp-onboarding-modal');
     if (!wizard) return;
-    let step = 0;
-    const steps = wizard.querySelectorAll('.wcwp-onboarding-step');
-    const progress = wizard.querySelector('.wcwp-onboarding-progress-inner');
-    const nextBtn = wizard.querySelector('.wcwp-onboarding-next');
-    const prevBtn = wizard.querySelector('.wcwp-onboarding-prev');
-    const skipBtn = wizard.querySelector('.wcwp-onboarding-skip');
+
+    const steps     = Array.from(wizard.querySelectorAll('.wcwp-onboarding-step'));
+    const progress  = wizard.querySelector('.wcwp-onboarding-progress-inner');
+    const nextBtn   = wizard.querySelector('.wcwp-onboarding-next');
+    const prevBtn   = wizard.querySelector('.wcwp-onboarding-prev');
+    const skipBtn   = wizard.querySelector('.wcwp-onboarding-skip');
     const finishBtn = wizard.querySelector('.wcwp-onboarding-finish');
+
+    const config = (typeof wcwpOnboarding !== 'undefined') ? wcwpOnboarding : {};
+    const i18n = config.i18n || {};
+    const defaultNextLabel = nextBtn ? nextBtn.textContent : 'Next';
+
+    let step = 0;
+    let saving = false;
 
     function showStep(idx) {
         steps.forEach((s, i) => s.style.display = i === idx ? 'block' : 'none');
-        progress.style.width = ((idx + 1) / steps.length * 100) + '%';
-        prevBtn.style.display = idx === 0 ? 'none' : 'inline-block';
-        nextBtn.style.display = idx === steps.length - 1 ? 'none' : 'inline-block';
+        if (progress) progress.style.width = ((idx + 1) / steps.length * 100) + '%';
+        prevBtn.style.display   = idx === 0 ? 'none' : 'inline-block';
+        nextBtn.style.display   = idx === steps.length - 1 ? 'none' : 'inline-block';
         finishBtn.style.display = idx === steps.length - 1 ? 'inline-block' : 'none';
+
+        if (currentStepName() === 'credentials') {
+            applyProviderVisibility();
+        }
     }
-    showStep(step);
+
+    function currentStepName() {
+        const el = steps[step];
+        return el ? el.getAttribute('data-step') : '';
+    }
+
+    function selectedProvider() {
+        const checked = wizard.querySelector('input[name="wcwp_ob_provider"]:checked');
+        return checked ? checked.value : 'twilio';
+    }
+
+    function applyProviderVisibility() {
+        const provider = selectedProvider();
+        wizard.querySelectorAll('[data-provider-fields]').forEach(function (block) {
+            block.style.display = block.getAttribute('data-provider-fields') === provider ? 'block' : 'none';
+        });
+        wizard.querySelectorAll('[data-provider-hint]').forEach(function (hint) {
+            hint.style.display = hint.getAttribute('data-provider-hint') === provider ? 'block' : 'none';
+        });
+    }
+
+    wizard.querySelectorAll('input[name="wcwp_ob_provider"]').forEach(function (radio) {
+        radio.addEventListener('change', applyProviderVisibility);
+    });
+
+    function clearFieldErrors() {
+        wizard.querySelectorAll('.wcwp-onboarding-field-error').forEach(function (el) { el.textContent = ''; });
+        wizard.querySelectorAll('.wcwp-onboarding-field.has-error').forEach(function (el) { el.classList.remove('has-error'); });
+        const formErr = wizard.querySelector('.wcwp-onboarding-form-error');
+        if (formErr) formErr.textContent = '';
+    }
+
+    function showFieldErrors(fields) {
+        Object.keys(fields).forEach(function (key) {
+            const errEl = wizard.querySelector('[data-error-for="' + key + '"]');
+            if (errEl) {
+                errEl.textContent = fields[key];
+                const wrap = errEl.closest('.wcwp-onboarding-field');
+                if (wrap) wrap.classList.add('has-error');
+            }
+        });
+        const formErr = wizard.querySelector('.wcwp-onboarding-form-error');
+        if (formErr) formErr.textContent = i18n.saveError || 'Could not save. Please check the highlighted fields.';
+    }
+
+    function showFormError(message) {
+        const formErr = wizard.querySelector('.wcwp-onboarding-form-error');
+        if (formErr) formErr.textContent = message;
+    }
+
+    function setSaving(isSaving) {
+        saving = isSaving;
+        nextBtn.disabled = isSaving;
+        prevBtn.disabled = isSaving;
+        nextBtn.textContent = isSaving ? (i18n.saving || 'Saving…') : (i18n.next || defaultNextLabel);
+    }
+
+    function saveCredentials() {
+        if (!config.ajaxUrl || !config.saveNonce) {
+            // No AJAX wiring (e.g. localized data missing) — fail open so the
+            // wizard doesn't trap the admin. They can still configure via the tab.
+            return Promise.resolve();
+        }
+
+        const provider = selectedProvider();
+        const body = new URLSearchParams();
+        body.append('action', 'wcwp_save_onboarding_credentials');
+        body.append('nonce', config.saveNonce);
+        body.append('provider', provider);
+
+        const fieldNames = provider === 'twilio'
+            ? ['twilio_sid', 'twilio_token', 'twilio_from']
+            : ['cloud_token', 'cloud_phone_id', 'cloud_from'];
+
+        fieldNames.forEach(function (name) {
+            const input = wizard.querySelector('[data-provider-fields="' + provider + '"] [name="' + name + '"]');
+            body.append(name, input ? input.value : '');
+        });
+
+        return fetch(config.ajaxUrl, {
+            method: 'POST',
+            credentials: 'same-origin',
+            body: body
+        }).then(function (res) {
+            return res.json().then(function (data) { return { ok: res.ok, data: data }; });
+        });
+    }
 
     nextBtn.addEventListener('click', function () {
+        if (saving) return;
+
+        if (currentStepName() === 'credentials') {
+            clearFieldErrors();
+            setSaving(true);
+            saveCredentials().then(function (result) {
+                setSaving(false);
+                if (!result) { advance(); return; }
+                if (result.ok && result.data && result.data.success) {
+                    advance();
+                    return;
+                }
+                const payload = (result.data && result.data.data) || {};
+                if (payload.fields) {
+                    showFieldErrors(payload.fields);
+                } else {
+                    showFormError(payload.message || i18n.saveError || 'Could not save.');
+                }
+            }).catch(function () {
+                setSaving(false);
+                showFormError(i18n.networkError || 'Network error. Please try again.');
+            });
+            return;
+        }
+
+        advance();
+    });
+
+    function advance() {
         if (step < steps.length - 1) {
             step++;
             showStep(step);
         }
-    });
+    }
+
     prevBtn.addEventListener('click', function () {
+        if (saving) return;
         if (step > 0) {
             step--;
             showStep(step);
         }
     });
+
     function persistDismissal() {
-        if (typeof wcwpOnboarding === 'undefined' || !wcwpOnboarding.ajaxUrl) return;
-        var body = new URLSearchParams();
+        if (!config.ajaxUrl || !config.dismissNonce) return;
+        const body = new URLSearchParams();
         body.append('action', 'wcwp_dismiss_onboarding');
-        body.append('nonce', wcwpOnboarding.nonce);
-        fetch(wcwpOnboarding.ajaxUrl, {
+        body.append('nonce', config.dismissNonce);
+        fetch(config.ajaxUrl, {
             method: 'POST',
             credentials: 'same-origin',
             body: body
@@ -45,11 +174,15 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     skipBtn.addEventListener('click', function () {
+        if (saving) return;
         wizard.style.display = 'none';
         persistDismissal();
     });
     finishBtn.addEventListener('click', function () {
+        if (saving) return;
         wizard.style.display = 'none';
         persistDismissal();
     });
+
+    showStep(step);
 });


### PR DESCRIPTION
Replaces the 5 informational wizard steps with a 4-step functional flow: Welcome → Choose provider → Credentials → All set. Admins can now finish onboarding with a usable Twilio or Meta Cloud connection instead of being sent off to hunt down the General settings tab.

What changed
- New AJAX endpoint `wcwp_save_onboarding_credentials` in admin/settings-page.php — manage_options + nonce gated, validates required fields per selected provider, returns 422 with `fields[]` on validation errors so the JS can render inline messages. Saves into the same option keys the General tab writes (`wcwp_api_provider`, `wcwp_twilio_*`, `wcwp_cloud_*`) with autoload=false to keep them out of the alloptions cache (consistent with PR #20's secret-keys policy).
- Wizard markup: provider-chooser radios with prefilled values from any existing options, conditional Twilio/Cloud field blocks, per-field error slots, and a form-level error region.
- assets/js/onboarding.js rewrite: provider radio toggle, Saving… state on Next, AJAX submit only on the credentials step, field-level error rendering, network-error fallback. Skip/Finish dismissal flow preserved (still hits the existing dismissal handler).
- assets/css/onboarding.css: provider-card styling with `:has()` for the selected highlight, form/field/error styles, max-width bumped 420 → 480 to fit the credential form.

What stays the same
- Existing dismissal handler (`wcwp_dismiss_onboarding`) and its nonce are unchanged; only the localized field name moved from `nonce` to `dismissNonce` since the JS now needs two nonces.
- Skip still works without saving (escape hatch).
- All credential fields are also editable in the General tab post-save.
- Wizard remains gated on `wcwp_onboarding_completed === 'no'`, so it still renders once per install.
- `wcwp_onboarding_completed` is already in uninstall.php's `$option_keys`, so a clean reinstall re-shows the wizard as before.

Test plan
- 12 PHPUnit smoke tests still pass (`composer test`).
- `php -l` clean on settings-page.php.

First phase of the post-30-point premium roadmap.