### PR TITLE
Add GPT fallback to chatbot when FAQ matcher misses

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -24,6 +24,7 @@ function wcwp_register_settings() {
     register_setting('wcwp_settings_group', 'wcwp_order_message_template', ['sanitize_callback' => 'wcwp_sanitize_textarea']);
     register_setting('wcwp_settings_group', 'wcwp_cart_recovery_enabled', ['sanitize_callback' => 'wcwp_sanitize_yes_no']);
     register_setting('wcwp_settings_group', 'wcwp_chatbot_enabled', ['sanitize_callback' => 'wcwp_sanitize_yes_no']);
+    register_setting('wcwp_settings_group', 'wcwp_chatbot_gpt_enabled', ['sanitize_callback' => 'wcwp_sanitize_yes_no']);
     register_setting('wcwp_settings_group', 'wcwp_faq_pairs', ['sanitize_callback' => 'wcwp_sanitize_json_faq']);
     register_setting('wcwp_settings_group', 'wcwp_license_key', ['sanitize_callback' => 'wcwp_sanitize_text']);
     register_setting('wcwp_settings_group', 'wcwp_test_mode_enabled', ['sanitize_callback' => 'wcwp_sanitize_yes_no']);

--- a/admin/views/tab-chatbot.php
+++ b/admin/views/tab-chatbot.php
@@ -45,5 +45,15 @@ if (!defined('ABSPATH')) exit;
                 <p class="description"><?php esc_html_e('Enter question/answer pairs as JSON array.', 'woochat-pro'); ?></p>
             </td>
         </tr>
+        <tr>
+            <th scope="row"><label for="wcwp_chatbot_gpt_enabled"><?php esc_html_e('GPT Fallback', 'woochat-pro'); ?></label><span class="wcwp-help-icon">?<span class="wcwp-tooltip"><?php esc_html_e('When the FAQ matcher finds no answer, ask the configured GPT endpoint for a reply. Requires GPT API endpoint and key set under the Scheduler tab.', 'woochat-pro'); ?></span></span></th>
+            <td>
+                <select name="wcwp_chatbot_gpt_enabled" id="wcwp_chatbot_gpt_enabled">
+                    <option value="no" <?php selected(get_option('wcwp_chatbot_gpt_enabled', 'no'), 'no'); ?>><?php esc_html_e('No', 'woochat-pro'); ?></option>
+                    <option value="yes" <?php selected(get_option('wcwp_chatbot_gpt_enabled', 'no'), 'yes'); ?>><?php esc_html_e('Yes', 'woochat-pro'); ?></option>
+                </select>
+                <p class="description"><?php esc_html_e('Each call costs your GPT account. Rate-limited to 10 requests per hour per visitor IP.', 'woochat-pro'); ?></p>
+            </td>
+        </tr>
     </table>
 </div>

--- a/assets/js/chatbot.js
+++ b/assets/js/chatbot.js
@@ -24,6 +24,12 @@ jQuery(document).ready(function ($) {
         return { score: hits / faqTokens.length, hits: hits };
     }
 
+    function wcwpRenderChatReply(text) {
+        $('#wcwp-chat-response').text(text);
+        var encoded = encodeURIComponent(text);
+        $('#wcwp-send-wa').attr('href', 'https://wa.me/?text=' + encoded).show();
+    }
+
     // 0.6 keeps obvious matches while rejecting single-token coincidences
     // against long FAQs ("shipping" alone shouldn't pick up "how long does
     // international shipping take").
@@ -51,11 +57,37 @@ jQuery(document).ready(function ($) {
             }
         }
 
-        var reply = (best.score >= WCWP_MATCH_THRESHOLD && best.answer) ? best.answer : noAnswer;
+        if (best.score >= WCWP_MATCH_THRESHOLD && best.answer) {
+            wcwpRenderChatReply(best.answer);
+            return;
+        }
 
-        $('#wcwp-chat-response').text(reply);
+        var gpt = wcwp_chatbot_obj.gpt;
+        if (gpt && gpt.enabled && question) {
+            // Show transient placeholder while GPT call is in flight; the
+            // WhatsApp send button is hidden so users don't share the
+            // placeholder text.
+            $('#wcwp-chat-response').text(gpt.thinking || 'Thinking…');
+            $('#wcwp-send-wa').hide();
 
-        var encoded = encodeURIComponent(reply);
-        $('#wcwp-send-wa').attr('href', 'https://wa.me/?text=' + encoded).show();
+            $.ajax({
+                url: gpt.url,
+                method: 'POST',
+                dataType: 'json',
+                data: {
+                    action: gpt.action,
+                    nonce: gpt.nonce,
+                    question: question
+                }
+            }).done(function (res) {
+                var reply = (res && res.success && res.data && res.data.reply) ? res.data.reply : noAnswer;
+                wcwpRenderChatReply(reply);
+            }).fail(function () {
+                wcwpRenderChatReply(noAnswer);
+            });
+            return;
+        }
+
+        wcwpRenderChatReply(noAnswer);
     });
 });

--- a/includes/chatbot-engine.php
+++ b/includes/chatbot-engine.php
@@ -24,14 +24,7 @@ function wcwp_render_chatbot_widget() {
     }
 
     wp_enqueue_script('wcwp-chatbot-js', WCWP_URL . 'assets/js/chatbot.js', ['jquery'], WCWP_VERSION, true);
-
-    $faq_pairs = json_decode(get_option('wcwp_faq_pairs', '[]'), true);
-    if (!is_array($faq_pairs)) $faq_pairs = [];
-
-    wp_localize_script('wcwp-chatbot-js', 'wcwp_chatbot_obj', [
-        'faq_pairs'    => $faq_pairs,
-        'noAnswerText' => __( "Sorry, I don't have an answer for that.", 'woochat-pro' ),
-    ]);
+    wp_localize_script('wcwp-chatbot-js', 'wcwp_chatbot_obj', wcwp_chatbot_localized_data());
 }
 
 function wcwp_chatbot_shortcode() {
@@ -43,16 +36,34 @@ function wcwp_chatbot_shortcode() {
     $settings = wcwp_get_chatbot_settings();
     include WCWP_PATH . 'templates/chatbot-widget.php';
     wp_enqueue_script('wcwp-chatbot-js', WCWP_URL . 'assets/js/chatbot.js', ['jquery'], WCWP_VERSION, true);
-    $faq_pairs = json_decode(get_option('wcwp_faq_pairs', '[]'), true);
-    if (!is_array($faq_pairs)) $faq_pairs = [];
-    wp_localize_script('wcwp-chatbot-js', 'wcwp_chatbot_obj', [
-        'faq_pairs'    => $faq_pairs,
-        'noAnswerText' => __( "Sorry, I don't have an answer for that.", 'woochat-pro' ),
-    ]);
+    wp_localize_script('wcwp-chatbot-js', 'wcwp_chatbot_obj', wcwp_chatbot_localized_data());
     if (!defined('WCWP_CHATBOT_RENDERED')) {
         define('WCWP_CHATBOT_RENDERED', true);
     }
     return ob_get_clean();
+}
+
+/**
+ * Single source of truth for the wcwp_chatbot_obj payload.
+ *
+ * Both the auto-render and shortcode paths call this so a new key
+ * (e.g. the GPT-fallback wiring) can't go to one but not the other.
+ */
+function wcwp_chatbot_localized_data() {
+    $faq_pairs = json_decode(get_option('wcwp_faq_pairs', '[]'), true);
+    if (!is_array($faq_pairs)) $faq_pairs = [];
+
+    return [
+        'faq_pairs'    => $faq_pairs,
+        'noAnswerText' => __( "Sorry, I don't have an answer for that.", 'woochat-pro' ),
+        'gpt'          => [
+            'enabled'  => get_option('wcwp_chatbot_gpt_enabled', 'no') === 'yes',
+            'url'      => admin_url('admin-ajax.php'),
+            'nonce'    => wp_create_nonce('wcwp_chatbot_gpt'),
+            'action'   => 'wcwp_chatbot_gpt',
+            'thinking' => __('Thinking…', 'woochat-pro'),
+        ],
+    ];
 }
 
 function wcwp_get_chatbot_settings() {
@@ -67,4 +78,139 @@ function wcwp_get_chatbot_settings() {
         'icon'         => get_option('wcwp_chatbot_icon', '💬'),
         'welcome'      => get_option('wcwp_chatbot_welcome', 'Hi! How can I help you?'),
     ];
+}
+
+add_action('wp_ajax_wcwp_chatbot_gpt', 'wcwp_ajax_chatbot_gpt');
+add_action('wp_ajax_nopriv_wcwp_chatbot_gpt', 'wcwp_ajax_chatbot_gpt');
+function wcwp_ajax_chatbot_gpt() {
+    if (!check_ajax_referer('wcwp_chatbot_gpt', 'nonce', false)) {
+        wp_send_json_error(['message' => __('Bad nonce', 'woochat-pro')], 400);
+    }
+
+    if (get_option('wcwp_chatbot_gpt_enabled', 'no') !== 'yes') {
+        wp_send_json_error(['message' => __('GPT fallback disabled', 'woochat-pro')], 403);
+    }
+
+    // Defense in depth: the widget render paths already gate on Pro, but a
+    // direct admin-ajax call would otherwise sail past the front-end gate.
+    if (!wcwp_is_pro_active()) {
+        wp_send_json_error(['message' => __('Pro license required', 'woochat-pro')], 403);
+    }
+
+    $ip = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field(wp_unslash($_SERVER['REMOTE_ADDR'])) : '';
+    if (!wcwp_chatbot_gpt_rate_limit_ok($ip)) {
+        wp_send_json_error(['message' => __('Too many requests', 'woochat-pro')], 429);
+    }
+
+    $question = isset($_POST['question']) ? sanitize_text_field(wp_unslash($_POST['question'])) : '';
+    if ($question === '') {
+        wp_send_json_error(['message' => __('Empty question', 'woochat-pro')], 400);
+    }
+
+    // Cap input length: keeps the upstream prompt bounded and curbs misuse.
+    if (function_exists('mb_substr')) {
+        $question = mb_substr($question, 0, 500);
+    } else {
+        $question = substr($question, 0, 500);
+    }
+
+    $reply = wcwp_generate_chatbot_reply($question);
+    if ($reply === '') {
+        wp_send_json_error(['message' => __('No reply available', 'woochat-pro')], 502);
+    }
+
+    wp_send_json_success(['reply' => $reply]);
+}
+
+/**
+ * Per-IP rate limit for the chatbot GPT fallback.
+ *
+ * Default is tighter than the opt-out limiter (10/hour vs 30) because each
+ * call here costs the site owner real money at the GPT endpoint.
+ *
+ * @param string $ip Caller's IP.
+ * @return bool True if within the limit, false if blocked.
+ */
+function wcwp_chatbot_gpt_rate_limit_ok($ip) {
+    if (!$ip) return true;
+
+    $limit  = (int) apply_filters('wcwp_chatbot_gpt_rate_limit', 10);
+    $window = (int) apply_filters('wcwp_chatbot_gpt_rate_window', HOUR_IN_SECONDS);
+
+    if ($limit < 1 || $window < 1) return true;
+
+    $key  = 'wcwp_chatbot_gpt_rate_' . md5($ip);
+    $data = get_transient($key);
+
+    if (!is_array($data) || !isset($data['count'], $data['start'])) {
+        set_transient($key, ['count' => 1, 'start' => time()], $window);
+        return true;
+    }
+
+    if ((time() - (int) $data['start']) > $window) {
+        set_transient($key, ['count' => 1, 'start' => time()], $window);
+        return true;
+    }
+
+    if ((int) $data['count'] >= $limit) {
+        return false;
+    }
+
+    $data['count'] = (int) $data['count'] + 1;
+    set_transient($key, $data, $window);
+    return true;
+}
+
+/**
+ * Single-turn GPT reply for the chatbot.
+ *
+ * Mirrors the shape of wcwp_generate_gpt_followup() in scheduler.php but
+ * with a chatbot-appropriate system prompt and a string input rather than
+ * a WC_Order. Returns '' on any failure path so the JS can fall back to
+ * noAnswerText without the user seeing an error.
+ *
+ * @param string $user_message
+ * @return string
+ */
+function wcwp_generate_chatbot_reply($user_message) {
+    $endpoint = trim(get_option('wcwp_gpt_api_endpoint', ''));
+    $api_key  = trim(get_option('wcwp_gpt_api_key', ''));
+    $model    = trim(get_option('wcwp_gpt_model', 'gpt-3.5-turbo'));
+    if ($model === '') $model = 'gpt-3.5-turbo';
+
+    if ($endpoint === '' || $api_key === '') return '';
+
+    $system_prompt = apply_filters(
+        'wcwp_chatbot_gpt_system_prompt',
+        "You are a helpful customer-support assistant for an online store. Keep replies under 280 characters, friendly and direct. If the question is outside store/product/order topics or you don't know the answer, say so briefly and suggest the customer contact human support."
+    );
+
+    $body = [
+        'model'    => $model,
+        'messages' => [
+            ['role' => 'system', 'content' => $system_prompt],
+            ['role' => 'user',   'content' => $user_message],
+        ],
+        'max_tokens'  => 150,
+        'temperature' => 0.5,
+    ];
+
+    $response = wp_remote_post($endpoint, [
+        'timeout' => 20,
+        'headers' => [
+            'Content-Type'  => 'application/json',
+            'Authorization' => 'Bearer ' . $api_key,
+        ],
+        'body' => wp_json_encode($body),
+    ]);
+
+    if (is_wp_error($response)) return '';
+
+    $code = wp_remote_retrieve_response_code($response);
+    if ($code !== 200) return '';
+
+    $data = json_decode(wp_remote_retrieve_body($response), true);
+    if (!isset($data['choices'][0]['message']['content'])) return '';
+
+    return trim($data['choices'][0]['message']['content']);
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -24,6 +24,7 @@ $option_keys = [
     'wcwp_order_message_template',
     'wcwp_cart_recovery_enabled',
     'wcwp_chatbot_enabled',
+    'wcwp_chatbot_gpt_enabled',
     'wcwp_faq_pairs',
     'wcwp_license_key',
     'wcwp_license_status',


### PR DESCRIPTION
When the token-overlap FAQ matcher finds no answer, optionally hand the question off to the configured GPT endpoint and render its reply instead of "Sorry, I don't have an answer for that." Closes the half-shipped chatbot-AI piece (the order-followup half already shipped via wcwp_generate_gpt_followup).

What changed
- New `wcwp_generate_chatbot_reply($message)` in chatbot-engine.php mirrors the shape of `wcwp_generate_gpt_followup()` but with a chatbot-appropriate system prompt and a string input. Returns '' on any failure path so the JS can silently fall back to noAnswer.
- New `wp_ajax_*_wcwp_chatbot_gpt` handler (logged-in + nopriv) validates the nonce, checks the feature flag, gates on `wcwp_is_pro_active()`, applies a per-IP rate limit, caps input to 500 chars, and returns `{success, data: {reply}}`.
- New per-IP limiter `wcwp_chatbot_gpt_rate_limit_ok()` defaults to 10/hour (tighter than the opt-out limiter's 30/hour because each call costs the site owner real money). Filterable via `wcwp_chatbot_gpt_rate_limit` and `_window`.
- New `wcwp_chatbot_gpt_enabled` option (default 'no') with a Yes/No toggle in the Chatbot tab. Registered with `wcwp_sanitize_yes_no` and added to uninstall.php $option_keys.
- Localize-script extracted into `wcwp_chatbot_localized_data()` so both render paths (footer auto-render and shortcode) carry the same payload — adding new keys can no longer drift between them.
- chatbot.js: when no FAQ match and `gpt.enabled`, show a Thinking… placeholder, hide the WhatsApp send button to prevent users sharing the placeholder, AJAX to the handler, render the reply on success, fall back to noAnswer on any error.

What stays the same
- Token-overlap FAQ matcher (PR #35) is still the first-pass matcher; GPT only runs when the matcher returns below threshold.
- noAnswerText still used when GPT is disabled, the AJAX call fails, or the endpoint returns nothing useful.
- WhatsApp send link wiring (`#wcwp-send-wa`) is preserved on successful replies so users can still escalate to chat.
- Reuses the existing `wcwp_gpt_api_endpoint` / `_key` / `_model` options — no new credentials to configure.
- Pro-gated, defaults to off — sites without a GPT key see byte-identical behaviour.

Test plan
- 12 PHPUnit smoke tests still pass (`composer test`).
- `php -l` clean on all modified PHP files.