### PR TITLE
Add bulk-messaging campaigns feature

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -69,6 +69,61 @@ function wcwp_ajax_dismiss_onboarding() {
     wp_send_json_success();
 }
 
+add_action('wp_ajax_wcwp_create_campaign', 'wcwp_ajax_create_campaign');
+function wcwp_ajax_create_campaign() {
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error(['message' => __('Unauthorized', 'woochat-pro')], 403);
+    }
+    if (!check_ajax_referer('wcwp_campaigns', 'nonce', false)) {
+        wp_send_json_error(['message' => __('Bad nonce', 'woochat-pro')], 400);
+    }
+
+    $name         = isset($_POST['name']) ? wcwp_sanitize_text(wp_unslash($_POST['name'])) : '';
+    $template     = isset($_POST['template']) ? wcwp_sanitize_textarea(wp_unslash($_POST['template'])) : '';
+    $segment_type = isset($_POST['segment_type']) ? sanitize_key(wp_unslash($_POST['segment_type'])) : '';
+    $days         = isset($_POST['segment_days']) ? max(1, (int) $_POST['segment_days']) : 30;
+
+    $segment_meta = $segment_type === 'recent_orders' ? ['days' => $days] : [];
+
+    $result = wcwp_campaign_create([
+        'name'         => $name,
+        'template'     => $template,
+        'segment_type' => $segment_type,
+        'segment_meta' => $segment_meta,
+    ]);
+
+    if (is_wp_error($result)) {
+        wp_send_json_error(['message' => $result->get_error_message()], 422);
+    }
+
+    wp_send_json_success(['campaign_id' => (int) $result]);
+}
+
+add_action('wp_ajax_wcwp_campaign_status', 'wcwp_ajax_campaign_status');
+function wcwp_ajax_campaign_status() {
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error(['message' => __('Unauthorized', 'woochat-pro')], 403);
+    }
+    if (!check_ajax_referer('wcwp_campaigns', 'nonce', false)) {
+        wp_send_json_error(['message' => __('Bad nonce', 'woochat-pro')], 400);
+    }
+
+    $id = isset($_GET['campaign_id']) ? (int) $_GET['campaign_id'] : 0;
+    $campaign = wcwp_campaign_get($id);
+    if (!$campaign) {
+        wp_send_json_error(['message' => __('Not found', 'woochat-pro')], 404);
+    }
+
+    wp_send_json_success([
+        'id'            => (int) $campaign['id'],
+        'status'        => $campaign['status'],
+        'total_count'   => (int) $campaign['total_count'],
+        'sent_count'    => (int) $campaign['sent_count'],
+        'failed_count'  => (int) $campaign['failed_count'],
+        'skipped_count' => (int) $campaign['skipped_count'],
+    ]);
+}
+
 add_action('wp_ajax_wcwp_save_onboarding_credentials', 'wcwp_ajax_save_onboarding_credentials');
 function wcwp_ajax_save_onboarding_credentials() {
     if (!current_user_can('manage_options')) {
@@ -129,6 +184,19 @@ function wcwp_render_settings_page() {
     wp_enqueue_style('wcwp-admin-premium-css', WCWP_URL . 'assets/css/admin-premium.css', [], WCWP_VERSION);
     // Enqueue premium admin JS
     wp_enqueue_script('wcwp-admin-premium-js', WCWP_URL . 'assets/js/admin-premium.js', [], WCWP_VERSION, true);
+    wp_enqueue_script('wcwp-campaigns-js', WCWP_URL . 'assets/js/campaigns.js', [], WCWP_VERSION, true);
+    wp_localize_script('wcwp-campaigns-js', 'wcwpCampaigns', [
+        'ajaxUrl' => admin_url('admin-ajax.php'),
+        'nonce'   => wp_create_nonce('wcwp_campaigns'),
+        'i18n'    => [
+            'submitting'   => __('Creating campaign…', 'woochat-pro'),
+            'create'       => __('Create campaign', 'woochat-pro'),
+            'genericError' => __('Could not create campaign. Please try again.', 'woochat-pro'),
+            'completed'    => __('Completed', 'woochat-pro'),
+            'running'      => __('Running', 'woochat-pro'),
+            'queued'       => __('Queued', 'woochat-pro'),
+        ],
+    ]);
     wp_localize_script('wcwp-admin-premium-js', 'wcwpAdminData', [
         'ajaxUrl' => admin_url('admin-ajax.php'),
         'resendNonce' => wp_create_nonce('wcwp_resend_cart'),
@@ -297,6 +365,7 @@ function wcwp_render_settings_page() {
             <button type="button" class="wcwp-tab" data-tab="chatbot"><?php esc_html_e('Chatbot', 'woochat-pro'); ?></button>
             <button type="button" class="wcwp-tab" data-tab="cart-recovery"><?php esc_html_e('Cart Recovery', 'woochat-pro'); ?></button>
             <button type="button" class="wcwp-tab" data-tab="scheduler"><?php esc_html_e('Scheduler', 'woochat-pro'); ?></button>
+            <button type="button" class="wcwp-tab" data-tab="campaigns"><?php esc_html_e('Campaigns', 'woochat-pro'); ?></button>
             <button type="button" class="wcwp-tab" data-tab="analytics"><?php esc_html_e('Analytics', 'woochat-pro'); ?></button>
             <button type="button" class="wcwp-tab" data-tab="license"><?php esc_html_e('License', 'woochat-pro'); ?></button>
         </div>
@@ -313,6 +382,7 @@ function wcwp_render_settings_page() {
             <?php require $views . '/tab-cart-recovery.php'; ?>
             <?php require $views . '/tab-analytics.php'; ?>
             <?php require $views . '/tab-scheduler.php'; ?>
+            <?php require $views . '/tab-campaigns.php'; ?>
             <?php require $views . '/tab-license.php'; ?>
             <?php submit_button(); ?>
         </form>

--- a/admin/views/tab-campaigns.php
+++ b/admin/views/tab-campaigns.php
@@ -1,0 +1,85 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+$wcwp_segment_types = wcwp_campaign_segment_types();
+$wcwp_recent_campaigns = wcwp_campaign_list(20);
+?>
+<div id="wcwp-tab-content-campaigns" class="wcwp-tab-content" style="display:none;">
+    <h2><?php esc_html_e('Bulk Campaigns', 'woochat-pro'); ?></h2>
+    <p class="description">
+        <?php esc_html_e('Send a one-shot WhatsApp message to a customer segment. Sends are throttled to 10 per minute by default and skip anyone on the suppression list.', 'woochat-pro'); ?>
+    </p>
+
+    <div class="wcwp-campaign-create" id="wcwp-campaign-create">
+        <h3><?php esc_html_e('New campaign', 'woochat-pro'); ?></h3>
+        <table class="form-table">
+            <tr>
+                <th scope="row"><label for="wcwp-campaign-name"><?php esc_html_e('Campaign name', 'woochat-pro'); ?></label></th>
+                <td><input type="text" id="wcwp-campaign-name" class="regular-text" placeholder="<?php esc_attr_e('e.g. April promo blast', 'woochat-pro'); ?>" /></td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="wcwp-campaign-segment"><?php esc_html_e('Segment', 'woochat-pro'); ?></label></th>
+                <td>
+                    <select id="wcwp-campaign-segment">
+                        <?php foreach ($wcwp_segment_types as $value => $label) : ?>
+                            <option value="<?php echo esc_attr($value); ?>"><?php echo esc_html($label); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                    <span id="wcwp-campaign-days-wrap" style="display:none; margin-left:8px;">
+                        <?php esc_html_e('Last', 'woochat-pro'); ?>
+                        <input type="number" id="wcwp-campaign-days" min="1" max="3650" value="30" class="small-text" />
+                        <?php esc_html_e('days', 'woochat-pro'); ?>
+                    </span>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="wcwp-campaign-template"><?php esc_html_e('Message template', 'woochat-pro'); ?></label></th>
+                <td>
+                    <textarea id="wcwp-campaign-template" rows="4" class="large-text" placeholder="<?php esc_attr_e('Hi {name}, big news from {site}…', 'woochat-pro'); ?>"></textarea>
+                    <p class="description">
+                        <?php esc_html_e('Placeholders:', 'woochat-pro'); ?>
+                        <code>{name}</code>, <code>{site}</code>, <code>{currency_symbol}</code>
+                    </p>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <button type="button" class="button button-primary" id="wcwp-campaign-submit"><?php esc_html_e('Create campaign', 'woochat-pro'); ?></button>
+                    <span class="wcwp-campaign-feedback" id="wcwp-campaign-feedback" role="status"></span>
+                </td>
+            </tr>
+        </table>
+    </div>
+
+    <h3><?php esc_html_e('Recent campaigns', 'woochat-pro'); ?></h3>
+    <?php if (empty($wcwp_recent_campaigns)) : ?>
+        <p><em><?php esc_html_e('No campaigns yet.', 'woochat-pro'); ?></em></p>
+    <?php else : ?>
+        <table class="widefat striped wcwp-campaigns-list" id="wcwp-campaigns-list">
+            <thead>
+                <tr>
+                    <th><?php esc_html_e('Name', 'woochat-pro'); ?></th>
+                    <th><?php esc_html_e('Status', 'woochat-pro'); ?></th>
+                    <th><?php esc_html_e('Sent', 'woochat-pro'); ?></th>
+                    <th><?php esc_html_e('Failed', 'woochat-pro'); ?></th>
+                    <th><?php esc_html_e('Skipped', 'woochat-pro'); ?></th>
+                    <th><?php esc_html_e('Total', 'woochat-pro'); ?></th>
+                    <th><?php esc_html_e('Created', 'woochat-pro'); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($wcwp_recent_campaigns as $c) : ?>
+                    <tr data-campaign-id="<?php echo esc_attr($c['id']); ?>">
+                        <td><?php echo esc_html($c['name']); ?></td>
+                        <td class="wcwp-campaign-status"><?php echo esc_html(ucfirst($c['status'])); ?></td>
+                        <td class="wcwp-campaign-sent"><?php echo esc_html(number_format_i18n((int) $c['sent_count'])); ?></td>
+                        <td class="wcwp-campaign-failed"><?php echo esc_html(number_format_i18n((int) $c['failed_count'])); ?></td>
+                        <td class="wcwp-campaign-skipped"><?php echo esc_html(number_format_i18n((int) $c['skipped_count'])); ?></td>
+                        <td class="wcwp-campaign-total"><?php echo esc_html(number_format_i18n((int) $c['total_count'])); ?></td>
+                        <td><?php echo esc_html(mysql2date(get_option('date_format') . ' ' . get_option('time_format'), $c['created_at'])); ?></td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    <?php endif; ?>
+</div>

--- a/assets/css/admin-premium.css
+++ b/assets/css/admin-premium.css
@@ -479,6 +479,31 @@
   color: #b2f7ef !important;
 }
 
+/* Campaigns tab */
+.wcwp-campaign-create {
+  background: #f8f9fa;
+  border-radius: 10px;
+  padding: 18px 22px;
+  margin: 18px 0 24px;
+  box-shadow: 0 1px 8px rgba(44,62,80,0.05);
+}
+.wcwp-campaign-create h3 {
+  margin-top: 0;
+}
+.wcwp-campaign-feedback {
+  display: inline-block;
+  margin-left: 12px;
+  font-size: 0.95rem;
+  color: #1c7c54;
+}
+.wcwp-campaign-feedback.is-error {
+  color: #c0392b;
+}
+.wcwp-campaigns-list .wcwp-campaign-status {
+  text-transform: capitalize;
+  font-weight: 600;
+}
+
 /* Support/Contact card */
 .wcwp-support-form {
   background: #f8f9fa;

--- a/assets/js/campaigns.js
+++ b/assets/js/campaigns.js
@@ -1,0 +1,154 @@
+// WooChat Pro – Campaigns admin tab.
+
+(function () {
+    document.addEventListener('DOMContentLoaded', function () {
+        var root = document.getElementById('wcwp-tab-content-campaigns');
+        if (!root) return;
+        var config = (typeof wcwpCampaigns !== 'undefined') ? wcwpCampaigns : {};
+        var i18n = config.i18n || {};
+
+        var segmentEl = document.getElementById('wcwp-campaign-segment');
+        var daysWrap  = document.getElementById('wcwp-campaign-days-wrap');
+        var nameEl    = document.getElementById('wcwp-campaign-name');
+        var tmplEl    = document.getElementById('wcwp-campaign-template');
+        var daysEl    = document.getElementById('wcwp-campaign-days');
+        var submit    = document.getElementById('wcwp-campaign-submit');
+        var feedback  = document.getElementById('wcwp-campaign-feedback');
+
+        function updateDaysVisibility() {
+            if (!segmentEl || !daysWrap) return;
+            daysWrap.style.display = segmentEl.value === 'recent_orders' ? 'inline-block' : 'none';
+        }
+
+        if (segmentEl) {
+            segmentEl.addEventListener('change', updateDaysVisibility);
+            updateDaysVisibility();
+        }
+
+        if (submit) {
+            submit.addEventListener('click', createCampaign);
+        }
+
+        function createCampaign() {
+            if (!config.ajaxUrl || !config.nonce) return;
+            if (submit.disabled) return;
+
+            feedback.textContent = '';
+            feedback.classList.remove('is-error');
+
+            var name = (nameEl && nameEl.value || '').trim();
+            var template = (tmplEl && tmplEl.value || '').trim();
+            if (!name || !template) {
+                feedback.textContent = i18n.genericError || 'Please fill in name and template.';
+                feedback.classList.add('is-error');
+                return;
+            }
+
+            submit.disabled = true;
+            var originalLabel = submit.textContent;
+            submit.textContent = i18n.submitting || 'Creating campaign…';
+
+            var body = new URLSearchParams();
+            body.append('action', 'wcwp_create_campaign');
+            body.append('nonce', config.nonce);
+            body.append('name', name);
+            body.append('template', template);
+            body.append('segment_type', segmentEl.value);
+            if (segmentEl.value === 'recent_orders') {
+                body.append('segment_days', daysEl.value || '30');
+            }
+
+            fetch(config.ajaxUrl, {
+                method: 'POST',
+                credentials: 'same-origin',
+                body: body
+            }).then(function (res) {
+                return res.json().then(function (data) { return { ok: res.ok, data: data }; });
+            }).then(function (result) {
+                submit.disabled = false;
+                submit.textContent = originalLabel;
+
+                if (result.ok && result.data && result.data.success) {
+                    // Reload to render the new row in the recent-campaigns table;
+                    // simpler than client-side row insertion and matches the existing
+                    // settings-page pattern (no SPA wiring elsewhere).
+                    window.location.reload();
+                    return;
+                }
+                var msg = (result.data && result.data.data && result.data.data.message) || i18n.genericError;
+                feedback.textContent = msg || 'Could not create campaign.';
+                feedback.classList.add('is-error');
+            }).catch(function () {
+                submit.disabled = false;
+                submit.textContent = originalLabel;
+                feedback.textContent = i18n.genericError || 'Network error.';
+                feedback.classList.add('is-error');
+            });
+        }
+
+        // Live-poll any rows that aren't yet completed so the admin sees
+        // sent/failed counters tick up without reloading. Stops polling
+        // once every visible row reaches a terminal state.
+        var rows = root.querySelectorAll('#wcwp-campaigns-list tbody tr');
+        var active = [];
+        rows.forEach(function (row) {
+            var status = (row.querySelector('.wcwp-campaign-status') || {}).textContent || '';
+            if (/^(queued|running)$/i.test(status.trim())) {
+                active.push(row);
+            }
+        });
+        if (active.length && config.ajaxUrl && config.nonce) {
+            pollActive();
+        }
+
+        function pollActive() {
+            var stillActive = [];
+            var pending = active.length;
+            if (!pending) return;
+
+            active.forEach(function (row) {
+                var id = row.getAttribute('data-campaign-id');
+                var url = config.ajaxUrl + '?action=wcwp_campaign_status&nonce=' + encodeURIComponent(config.nonce) + '&campaign_id=' + encodeURIComponent(id);
+                fetch(url, { credentials: 'same-origin' })
+                    .then(function (res) { return res.json(); })
+                    .then(function (data) {
+                        if (data && data.success && data.data) {
+                            updateRow(row, data.data);
+                            if (/^(queued|running)$/i.test(data.data.status)) {
+                                stillActive.push(row);
+                            }
+                        }
+                    })
+                    .catch(function () { /* swallow; next tick may succeed */ })
+                    .then(function () {
+                        pending--;
+                        if (pending === 0) {
+                            active = stillActive;
+                            if (active.length) setTimeout(pollActive, 5000);
+                        }
+                    });
+            });
+        }
+
+        function updateRow(row, data) {
+            var statusCell = row.querySelector('.wcwp-campaign-status');
+            if (statusCell) {
+                var label = data.status;
+                if (label === 'completed' && i18n.completed) label = i18n.completed;
+                else if (label === 'running' && i18n.running) label = i18n.running;
+                else if (label === 'queued' && i18n.queued) label = i18n.queued;
+                else label = label.charAt(0).toUpperCase() + label.slice(1);
+                statusCell.textContent = label;
+            }
+            setCell(row, '.wcwp-campaign-sent',    data.sent_count);
+            setCell(row, '.wcwp-campaign-failed',  data.failed_count);
+            setCell(row, '.wcwp-campaign-skipped', data.skipped_count);
+            setCell(row, '.wcwp-campaign-total',   data.total_count);
+        }
+
+        function setCell(row, sel, n) {
+            var el = row.querySelector(sel);
+            if (el) el.textContent = String(n);
+        }
+    });
+})();

--- a/includes/campaigns.php
+++ b/includes/campaigns.php
@@ -1,0 +1,366 @@
+<?php
+/**
+ * Bulk-messaging campaigns.
+ *
+ * One-shot bulk WhatsApp send to a customer segment, throttled via
+ * WP-Cron. Each recipient is persisted as its own row in
+ * {prefix}wcwp_campaign_recipients so progress survives crashes,
+ * page reloads, and concurrent admin sessions. The dispatcher
+ * (wcwp_send_whatsapp_message) is reused per recipient so opt-out,
+ * test mode, analytics, and provider routing are handled centrally.
+ */
+
+if (!defined('ABSPATH')) exit;
+
+add_action('wcwp_process_campaign', 'wcwp_campaign_process_chunk');
+
+/* -------------------------------------------------------------------------
+ * Schema
+ * ----------------------------------------------------------------------- */
+
+function wcwp_campaigns_table_name() {
+    global $wpdb;
+    return $wpdb->prefix . 'wcwp_campaigns';
+}
+
+function wcwp_campaign_recipients_table_name() {
+    global $wpdb;
+    return $wpdb->prefix . 'wcwp_campaign_recipients';
+}
+
+/**
+ * dbDelta-based, idempotent. Called from migration v3 and from the
+ * activation hook so a fresh install lands the tables before the first
+ * admin_init migration tick.
+ */
+function wcwp_create_campaign_tables() {
+    global $wpdb;
+    $charset_collate = $wpdb->get_charset_collate();
+    $campaigns       = wcwp_campaigns_table_name();
+    $recipients      = wcwp_campaign_recipients_table_name();
+
+    $sql_campaigns = "CREATE TABLE {$campaigns} (
+        id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+        name VARCHAR(190) NOT NULL,
+        template TEXT NOT NULL,
+        segment_type VARCHAR(40) NOT NULL,
+        segment_meta TEXT NULL,
+        status VARCHAR(20) NOT NULL DEFAULT 'queued',
+        total_count INT UNSIGNED NOT NULL DEFAULT 0,
+        sent_count INT UNSIGNED NOT NULL DEFAULT 0,
+        failed_count INT UNSIGNED NOT NULL DEFAULT 0,
+        skipped_count INT UNSIGNED NOT NULL DEFAULT 0,
+        created_at DATETIME NOT NULL,
+        completed_at DATETIME NULL,
+        PRIMARY KEY  (id),
+        KEY status (status)
+    ) {$charset_collate};";
+
+    $sql_recipients = "CREATE TABLE {$recipients} (
+        id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+        campaign_id BIGINT UNSIGNED NOT NULL,
+        phone VARCHAR(40) NOT NULL,
+        customer_name VARCHAR(190) NULL DEFAULT '',
+        status VARCHAR(20) NOT NULL DEFAULT 'pending',
+        attempt_count TINYINT UNSIGNED NOT NULL DEFAULT 0,
+        last_error VARCHAR(255) NULL DEFAULT '',
+        sent_at DATETIME NULL,
+        PRIMARY KEY  (id),
+        KEY campaign_status (campaign_id, status)
+    ) {$charset_collate};";
+
+    require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+    dbDelta($sql_campaigns);
+    dbDelta($sql_recipients);
+}
+
+/* -------------------------------------------------------------------------
+ * Campaign CRUD
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Create a campaign and enqueue its recipients.
+ *
+ * @param array $args {
+ *   @type string $name         Required.
+ *   @type string $template     Required. Body with {name}/{site}/{currency_symbol} placeholders.
+ *   @type string $segment_type Required. One of the keys returned by wcwp_campaign_segment_types().
+ *   @type array  $segment_meta Optional. Segment-specific filters (e.g. {days: 30}).
+ * }
+ * @return int|WP_Error Campaign id, or WP_Error on validation failure.
+ */
+function wcwp_campaign_create($args) {
+    global $wpdb;
+
+    $name         = isset($args['name']) ? sanitize_text_field($args['name']) : '';
+    $template     = isset($args['template']) ? wcwp_sanitize_textarea($args['template']) : '';
+    $segment_type = isset($args['segment_type']) ? sanitize_key($args['segment_type']) : '';
+    $segment_meta = isset($args['segment_meta']) && is_array($args['segment_meta']) ? $args['segment_meta'] : [];
+
+    if ($name === '')     return new WP_Error('wcwp_campaign_name_required', __('Campaign name is required.', 'woochat-pro'));
+    if ($template === '') return new WP_Error('wcwp_campaign_template_required', __('Message template is required.', 'woochat-pro'));
+    if (!array_key_exists($segment_type, wcwp_campaign_segment_types())) {
+        return new WP_Error('wcwp_campaign_segment_invalid', __('Unknown segment.', 'woochat-pro'));
+    }
+
+    $recipients = wcwp_campaign_resolve_segment($segment_type, $segment_meta);
+    if (empty($recipients)) {
+        return new WP_Error('wcwp_campaign_no_recipients', __('No matching customers — campaign not created.', 'woochat-pro'));
+    }
+
+    $now = current_time('mysql');
+    $wpdb->insert(wcwp_campaigns_table_name(), [
+        'name'         => $name,
+        'template'     => $template,
+        'segment_type' => $segment_type,
+        'segment_meta' => wp_json_encode($segment_meta),
+        'status'       => 'queued',
+        'total_count'  => count($recipients),
+        'created_at'   => $now,
+    ], ['%s', '%s', '%s', '%s', '%s', '%d', '%s']);
+
+    $campaign_id = (int) $wpdb->insert_id;
+    if ($campaign_id <= 0) {
+        return new WP_Error('wcwp_campaign_insert_failed', __('Could not create campaign.', 'woochat-pro'));
+    }
+
+    $rt = wcwp_campaign_recipients_table_name();
+    foreach ($recipients as $r) {
+        $wpdb->insert($rt, [
+            'campaign_id'   => $campaign_id,
+            'phone'         => $r['phone'],
+            'customer_name' => isset($r['name']) ? $r['name'] : '',
+            'status'        => 'pending',
+            'attempt_count' => 0,
+        ], ['%d', '%s', '%s', '%s', '%d']);
+    }
+
+    // Kick off the first chunk shortly after return so the admin sees
+    // immediate progress without sitting through an HTTP fan-out.
+    wp_schedule_single_event(time() + 5, 'wcwp_process_campaign', [$campaign_id]);
+
+    return $campaign_id;
+}
+
+function wcwp_campaign_get($campaign_id) {
+    global $wpdb;
+    $campaign_id = (int) $campaign_id;
+    if ($campaign_id <= 0) return null;
+    $row = $wpdb->get_row(
+        $wpdb->prepare("SELECT * FROM " . wcwp_campaigns_table_name() . " WHERE id = %d", $campaign_id),
+        ARRAY_A
+    );
+    return $row ?: null;
+}
+
+function wcwp_campaign_list($limit = 20) {
+    global $wpdb;
+    $limit = max(1, min(200, (int) $limit));
+    return $wpdb->get_results(
+        "SELECT * FROM " . wcwp_campaigns_table_name() . " ORDER BY id DESC LIMIT " . $limit,
+        ARRAY_A
+    ) ?: [];
+}
+
+/* -------------------------------------------------------------------------
+ * Segments
+ * ----------------------------------------------------------------------- */
+
+function wcwp_campaign_segment_types() {
+    return [
+        'all_customers' => __('All customers with phone', 'woochat-pro'),
+        'recent_orders' => __('Customers who ordered recently', 'woochat-pro'),
+    ];
+}
+
+/**
+ * Walk WC orders in pages, dedupe by normalized phone, drop opt-outs.
+ *
+ * @return array<int, array{phone:string, name:string}>
+ */
+function wcwp_campaign_resolve_segment($segment_type, $segment_meta = []) {
+    if (!function_exists('wc_get_orders')) return [];
+
+    $query = [
+        'limit'  => 500,
+        'paged'  => 1,
+        'return' => 'objects',
+    ];
+
+    if ($segment_type === 'recent_orders') {
+        $days = isset($segment_meta['days']) ? max(1, (int) $segment_meta['days']) : 30;
+        $cutoff = gmdate('Y-m-d 00:00:00', time() - ($days * DAY_IN_SECONDS));
+        $query['date_created'] = '>=' . $cutoff;
+    }
+
+    $seen = [];
+    $recipients = [];
+    while (true) {
+        $orders = wc_get_orders($query);
+        if (empty($orders) || !is_array($orders)) break;
+
+        foreach ($orders as $order) {
+            $phone = wcwp_normalize_phone($order->get_billing_phone());
+            if (!$phone || isset($seen[$phone])) continue;
+            if (wcwp_is_opted_out($phone)) continue;
+            $seen[$phone] = true;
+            $recipients[] = [
+                'phone' => $phone,
+                'name'  => sanitize_text_field($order->get_billing_first_name()),
+            ];
+        }
+
+        if (count($orders) < $query['limit']) break;
+        $query['paged']++;
+
+        // Hard cap to prevent runaway memory on giant stores; campaigns
+        // with > 25k recipients are out of scope for this UI.
+        if (count($recipients) >= 25000) break;
+    }
+
+    return $recipients;
+}
+
+/* -------------------------------------------------------------------------
+ * Template
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Substitute the campaign-supported placeholders in a template.
+ *
+ * Available: {name}, {site}, {currency_symbol}. No order/cart context
+ * is available for bulk sends, so the order-related placeholders that
+ * scheduler.php and cart-recovery.php support are deliberately absent.
+ */
+function wcwp_campaign_render_message($template, $name = '') {
+    $site = function_exists('get_bloginfo') ? get_bloginfo('name') : '';
+    $currency = function_exists('wcwp_currency_symbol_text') ? wcwp_currency_symbol_text() : '';
+    return str_replace(
+        ['{name}', '{site}', '{currency_symbol}'],
+        [(string) $name, (string) $site, (string) $currency],
+        (string) $template
+    );
+}
+
+/* -------------------------------------------------------------------------
+ * Cron-driven sender
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Process one chunk of pending recipients for a campaign and reschedule
+ * if more remain.
+ *
+ * Chunk size and inter-chunk delay are filterable so high-volume sites
+ * can throttle harder; low-volume sites can burst. Defaults sized for
+ * a typical Twilio rate limit (~1 msg/sec) — 10 per minute is safe.
+ *
+ * @param int $campaign_id
+ */
+function wcwp_campaign_process_chunk($campaign_id) {
+    global $wpdb;
+    $campaign_id = (int) $campaign_id;
+    if ($campaign_id <= 0) return;
+
+    $campaign = wcwp_campaign_get($campaign_id);
+    if (!$campaign) return;
+    if (in_array($campaign['status'], ['completed', 'failed'], true)) return;
+
+    $chunk_size = (int) apply_filters('wcwp_campaign_chunk_size', 10);
+    $chunk_size = max(1, min(100, $chunk_size));
+
+    $rt = wcwp_campaign_recipients_table_name();
+    $rows = $wpdb->get_results($wpdb->prepare(
+        "SELECT id, phone, customer_name FROM {$rt} WHERE campaign_id = %d AND status = 'pending' ORDER BY id ASC LIMIT %d",
+        $campaign_id,
+        $chunk_size
+    ), ARRAY_A);
+
+    if (!$rows) {
+        wcwp_campaign_finalize($campaign_id);
+        return;
+    }
+
+    if ($campaign['status'] !== 'running') {
+        $wpdb->update(
+            wcwp_campaigns_table_name(),
+            ['status' => 'running'],
+            ['id' => $campaign_id],
+            ['%s'], ['%d']
+        );
+    }
+
+    $sent = $failed = $skipped = 0;
+    foreach ($rows as $row) {
+        $phone = $row['phone'];
+
+        if (wcwp_is_opted_out($phone)) {
+            $wpdb->update($rt, [
+                'status'  => 'skipped',
+                'sent_at' => current_time('mysql'),
+            ], ['id' => $row['id']], ['%s', '%s'], ['%d']);
+            $skipped++;
+            continue;
+        }
+
+        $message = wcwp_campaign_render_message($campaign['template'], $row['customer_name']);
+
+        $ok = wcwp_send_whatsapp_message($phone, $message, false, [
+            'type' => 'bulk',
+            'campaign_id' => $campaign_id,
+        ]);
+
+        if ($ok === true) {
+            $wpdb->update($rt, [
+                'status'        => 'sent',
+                'attempt_count' => (int) $row['attempt_count'] + 1,
+                'sent_at'       => current_time('mysql'),
+            ], ['id' => $row['id']], ['%s', '%d', '%s'], ['%d']);
+            $sent++;
+        } else {
+            $wpdb->update($rt, [
+                'status'        => 'failed',
+                'attempt_count' => (int) $row['attempt_count'] + 1,
+                'last_error'    => __('Provider returned failure.', 'woochat-pro'),
+            ], ['id' => $row['id']], ['%s', '%d', '%s'], ['%d']);
+            $failed++;
+        }
+    }
+
+    if ($sent || $failed || $skipped) {
+        $wpdb->query($wpdb->prepare(
+            "UPDATE " . wcwp_campaigns_table_name() . "
+             SET sent_count = sent_count + %d,
+                 failed_count = failed_count + %d,
+                 skipped_count = skipped_count + %d
+             WHERE id = %d",
+            $sent, $failed, $skipped, $campaign_id
+        ));
+    }
+
+    $remaining = (int) $wpdb->get_var($wpdb->prepare(
+        "SELECT COUNT(*) FROM {$rt} WHERE campaign_id = %d AND status = 'pending'",
+        $campaign_id
+    ));
+
+    if ($remaining > 0) {
+        $delay = (int) apply_filters('wcwp_campaign_chunk_interval', MINUTE_IN_SECONDS);
+        $delay = max(10, min(HOUR_IN_SECONDS, $delay));
+        wp_schedule_single_event(time() + $delay, 'wcwp_process_campaign', [$campaign_id]);
+    } else {
+        wcwp_campaign_finalize($campaign_id);
+    }
+}
+
+function wcwp_campaign_finalize($campaign_id) {
+    global $wpdb;
+    $wpdb->update(
+        wcwp_campaigns_table_name(),
+        [
+            'status'       => 'completed',
+            'completed_at' => current_time('mysql'),
+        ],
+        ['id' => (int) $campaign_id],
+        ['%s', '%s'],
+        ['%d']
+    );
+}

--- a/includes/class-wcwp-plugin.php
+++ b/includes/class-wcwp-plugin.php
@@ -89,6 +89,7 @@ final class Plugin {
         require_once WCWP_PATH . 'includes/order-hooks.php';
         require_once WCWP_PATH . 'includes/cart-recovery.php';
         require_once WCWP_PATH . 'includes/scheduler.php';
+        require_once WCWP_PATH . 'includes/campaigns.php';
     }
 
     public function run_migrations() {
@@ -101,6 +102,8 @@ final class Plugin {
         }
         wcwp_create_cart_recovery_table();
         wcwp_create_analytics_table();
+        require_once WCWP_PATH . 'includes/campaigns.php';
+        wcwp_create_campaign_tables();
         wcwp_schedule_cart_recovery_cron();
         wcwp_run_migrations();
     }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -104,6 +104,7 @@ function wcwp_get_migrations() {
     return [
         1 => 'wcwp_migration_v1_secrets_autoload',
         2 => 'wcwp_migration_v2_analytics_to_table',
+        3 => 'wcwp_migration_v3_campaign_tables',
     ];
 }
 
@@ -144,6 +145,20 @@ function wcwp_migration_v1_secrets_autoload() {
  */
 function wcwp_migration_v2_analytics_to_table() {
     wcwp_migrate_analytics_options_to_table();
+}
+
+/**
+ * v3: create the campaigns + campaign_recipients tables for bulk-messaging.
+ *
+ * Same guard shape as v2 — the migration runner fires on admin_init priority
+ * 5 regardless of WC state, but boot_modules() (which loads campaigns.php)
+ * only runs when WC is active. The activation hook also runs the table
+ * creator, so a re-activation rebuilds the tables if WC is added later.
+ */
+function wcwp_migration_v3_campaign_tables() {
+    if (function_exists('wcwp_create_campaign_tables')) {
+        wcwp_create_campaign_tables();
+    }
 }
 
 /**

--- a/tests/Unit/CampaignsTest.php
+++ b/tests/Unit/CampaignsTest.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace WooChatPro\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class CampaignsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['wcwp_test_options'] = [];
+        $GLOBALS['wcwp_test_currency_symbol'] = '&#36;';
+        $GLOBALS['wcwp_test_bloginfo'] = ['name' => 'Acme Store'];
+    }
+
+    public function test_render_substitutes_supported_placeholders(): void
+    {
+        $template = 'Hi {name}, big news from {site}! Save {currency_symbol}10.';
+        $result = \wcwp_campaign_render_message($template, 'Sara');
+
+        $this->assertSame('Hi Sara, big news from Acme Store! Save $10.', $result);
+    }
+
+    public function test_render_handles_blank_name_and_site(): void
+    {
+        $GLOBALS['wcwp_test_bloginfo'] = ['name' => ''];
+        $result = \wcwp_campaign_render_message('Hello {name} from {site}', '');
+        $this->assertSame('Hello  from ', $result);
+    }
+
+    public function test_render_does_not_substitute_unsupported_placeholders(): void
+    {
+        // Bulk sends have no order/cart context — order placeholders must
+        // pass through untouched rather than being silently blanked.
+        $result = \wcwp_campaign_render_message('Order {order_id} total {total}', 'X');
+        $this->assertSame('Order {order_id} total {total}', $result);
+    }
+
+    public function test_segment_types_lists_expected_segments(): void
+    {
+        $types = \wcwp_campaign_segment_types();
+        $this->assertArrayHasKey('all_customers', $types);
+        $this->assertArrayHasKey('recent_orders', $types);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -34,6 +34,21 @@ if (!function_exists('get_woocommerce_currency_symbol')) {
         return $GLOBALS['wcwp_test_currency_symbol'] ?? '&#36;';
     }
 }
+if (!function_exists('get_bloginfo')) {
+    function get_bloginfo($key = '') {
+        return $GLOBALS['wcwp_test_bloginfo'][$key] ?? '';
+    }
+}
+if (!function_exists('__')) {
+    function __($text, $domain = '') { return $text; }
+}
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field($value) { return is_string($value) ? trim($value) : ''; }
+}
+if (!function_exists('sanitize_textarea_field')) {
+    function sanitize_textarea_field($value) { return is_string($value) ? trim($value) : ''; }
+}
 
 require_once __DIR__ . '/../includes/helpers.php';
 require_once __DIR__ . '/../includes/cart-recovery.php';
+require_once __DIR__ . '/../includes/campaigns.php';

--- a/uninstall.php
+++ b/uninstall.php
@@ -74,6 +74,12 @@ $wpdb->query("DROP TABLE IF EXISTS {$table}");
 $analytics_table = $wpdb->prefix . 'wcwp_analytics_events';
 $wpdb->query("DROP TABLE IF EXISTS {$analytics_table}");
 
+$campaign_recipients = $wpdb->prefix . 'wcwp_campaign_recipients';
+$wpdb->query("DROP TABLE IF EXISTS {$campaign_recipients}");
+
+$campaigns_table = $wpdb->prefix . 'wcwp_campaigns';
+$wpdb->query("DROP TABLE IF EXISTS {$campaigns_table}");
+
 $upload_dir = wp_upload_dir();
 $plugin_log = $upload_dir['basedir'] . '/woochat-pro/woochat-pro.log';
 $plugin_log_dir = $upload_dir['basedir'] . '/woochat-pro';


### PR DESCRIPTION
First user-visible feature delivery from the post-audit roadmap. Admins can compose a WhatsApp template, pick a customer segment, and trigger a throttled bulk send that survives page reloads and respects the existing opt-out / test-mode wiring.

What changed
- includes/campaigns.php (new) — campaign storage, segment resolver, template substitution, and the WP-Cron-driven sender. Each call to wcwp_send_whatsapp_message() inherits opt-out, analytics, and test-mode handling from the dispatcher, so this layer adds no parallel implementations.
- Two new tables via migration v3: {prefix}wcwp_campaigns (metadata + counters) and {prefix}wcwp_campaign_recipients (one row per phone with status). dbDelta-based and idempotent; the activation hook also calls wcwp_create_campaign_tables() so a fresh install lands the tables immediately.
- Two segments shipped: "All customers with phone" and "Customers who ordered recently" (last N days). Resolver pages through wc_get_orders() at 500 rows per fetch, dedupes by normalized phone, drops opt-outs at enqueue time, and caps recipient lists at 25k (giant-store edge case).
- Throttled sender: wcwp_campaign_process_chunk() processes 10 recipients per WP-Cron tick, reschedules itself if more remain, and finalizes the campaign when the queue empties. Chunk size and inter-chunk delay are filterable via wcwp_campaign_chunk_size and wcwp_campaign_chunk_interval. Default ~600/hour throughput fits comfortably inside Twilio's 1 msg/sec rate limit.
- Two new AJAX endpoints: wcwp_create_campaign (form submit) and wcwp_campaign_status (live progress poll). Both manage_options + nonce gated (action: wcwp_campaigns).
- New "Campaigns" tab between Scheduler and Analytics. Form for name/segment/template + recent-campaigns table with live polling every 5s while any row is queued/running.
- Template placeholders: {name}, {site}, {currency_symbol}. Order placeholders deliberately absent — bulk sends have no per-order context.
- assets/js/campaigns.js — segment-conditional days input, AJAX submit, polling. Reload after creation matches the rest of the settings page (no SPA wiring elsewhere).
- includes/class-wcwp-plugin.php — boot_modules() now requires campaigns.php; activate() runs wcwp_create_campaign_tables() before the migration runner.
- uninstall.php drops both new tables when wcwp_delete_data_on_uninstall is enabled.
- tests/bootstrap.php gained stubs for get_bloginfo/__/sanitize_text_field/ sanitize_textarea_field and now loads campaigns.php.
- tests/Unit/CampaignsTest.php — 4 unit tests covering the template substitution and segment-types listing.

What stays the same
- Existing dispatcher (wcwp_send_whatsapp_message) and analytics events table are reused; bulk events are tagged type=bulk with campaign_id in meta.
- Cart-recovery / follow-up retry queues unchanged.
- Migration runner (PR #28) extended with one new line plus the v3 callable definition — no rewrite.
- Skipping anyone on the suppression list happens both at enqueue (resolver) and at send (process_chunk) — opt-outs added between campaign creation and send still get filtered.

Test plan
- 16 PHPUnit tests pass (12 prior + 4 new), 28 assertions.
- php -l clean on all modified PHP files.