### PR TITLE
Add multi-agent routing for chatbot widget

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -25,6 +25,8 @@ function wcwp_register_settings() {
     register_setting('wcwp_settings_group', 'wcwp_cart_recovery_enabled', ['sanitize_callback' => 'wcwp_sanitize_yes_no']);
     register_setting('wcwp_settings_group', 'wcwp_chatbot_enabled', ['sanitize_callback' => 'wcwp_sanitize_yes_no']);
     register_setting('wcwp_settings_group', 'wcwp_chatbot_gpt_enabled', ['sanitize_callback' => 'wcwp_sanitize_yes_no']);
+    register_setting('wcwp_settings_group', 'wcwp_agents', ['sanitize_callback' => 'wcwp_sanitize_agents_json']);
+    register_setting('wcwp_settings_group', 'wcwp_agent_routing_mode', ['sanitize_callback' => 'wcwp_sanitize_agent_routing_mode']);
     register_setting('wcwp_settings_group', 'wcwp_faq_pairs', ['sanitize_callback' => 'wcwp_sanitize_json_faq']);
     register_setting('wcwp_settings_group', 'wcwp_license_key', ['sanitize_callback' => 'wcwp_sanitize_text']);
     register_setting('wcwp_settings_group', 'wcwp_test_mode_enabled', ['sanitize_callback' => 'wcwp_sanitize_yes_no']);

--- a/admin/views/tab-chatbot.php
+++ b/admin/views/tab-chatbot.php
@@ -56,4 +56,52 @@ if (!defined('ABSPATH')) exit;
             </td>
         </tr>
     </table>
+
+    <h3><?php esc_html_e('Agents (multi-agent routing)', 'woochat-pro'); ?></h3>
+    <p class="description"><?php esc_html_e('Add the team members who can receive customer chats. The chatbot widget routes "Send via WhatsApp" clicks to one of these numbers using the routing mode below.', 'woochat-pro'); ?></p>
+    <table class="form-table">
+        <tr>
+            <th scope="row"><label for="wcwp_agent_routing_mode"><?php esc_html_e('Routing mode', 'woochat-pro'); ?></label></th>
+            <td>
+                <?php $wcwp_routing_mode = get_option('wcwp_agent_routing_mode', 'single'); ?>
+                <select name="wcwp_agent_routing_mode" id="wcwp_agent_routing_mode">
+                    <option value="single" <?php selected($wcwp_routing_mode, 'single'); ?>><?php esc_html_e('Single — first agent only', 'woochat-pro'); ?></option>
+                    <option value="random" <?php selected($wcwp_routing_mode, 'random'); ?>><?php esc_html_e('Random — load-balance across agents', 'woochat-pro'); ?></option>
+                </select>
+                <p class="description"><?php esc_html_e('Random is chosen client-side per page load so a full-page cache does not pin every visitor to the same agent.', 'woochat-pro'); ?></p>
+            </td>
+        </tr>
+    </table>
+
+    <table class="widefat striped" id="wcwp-agents-table">
+        <thead>
+            <tr>
+                <th><?php esc_html_e('Agent name', 'woochat-pro'); ?></th>
+                <th><?php esc_html_e('WhatsApp number', 'woochat-pro'); ?></th>
+                <th class="wcwp-agents-row-actions"></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php
+            $wcwp_agents = wcwp_get_agents();
+            if (empty($wcwp_agents)) :
+                ?>
+                <tr class="wcwp-agent-row">
+                    <td><input type="text" class="wcwp-agent-name regular-text" placeholder="<?php esc_attr_e('e.g. Sales', 'woochat-pro'); ?>" value="" /></td>
+                    <td><input type="text" class="wcwp-agent-phone regular-text" placeholder="<?php esc_attr_e('e.g. +14155550100', 'woochat-pro'); ?>" value="" /></td>
+                    <td><button type="button" class="button-link wcwp-agent-remove" aria-label="<?php esc_attr_e('Remove agent', 'woochat-pro'); ?>">&times;</button></td>
+                </tr>
+            <?php else : foreach ($wcwp_agents as $wcwp_agent) : ?>
+                <tr class="wcwp-agent-row">
+                    <td><input type="text" class="wcwp-agent-name regular-text" placeholder="<?php esc_attr_e('e.g. Sales', 'woochat-pro'); ?>" value="<?php echo esc_attr($wcwp_agent['name']); ?>" /></td>
+                    <td><input type="text" class="wcwp-agent-phone regular-text" placeholder="<?php esc_attr_e('e.g. +14155550100', 'woochat-pro'); ?>" value="<?php echo esc_attr($wcwp_agent['phone']); ?>" /></td>
+                    <td><button type="button" class="button-link wcwp-agent-remove" aria-label="<?php esc_attr_e('Remove agent', 'woochat-pro'); ?>">&times;</button></td>
+                </tr>
+            <?php endforeach; endif; ?>
+        </tbody>
+    </table>
+    <p>
+        <button type="button" class="button" id="wcwp-agent-add">+ <?php esc_html_e('Add agent', 'woochat-pro'); ?></button>
+    </p>
+    <input type="hidden" name="wcwp_agents" id="wcwp_agents_input" value="<?php echo esc_attr(get_option('wcwp_agents', '[]')); ?>" />
 </div>

--- a/assets/css/admin-premium.css
+++ b/assets/css/admin-premium.css
@@ -479,6 +479,29 @@
   color: #b2f7ef !important;
 }
 
+/* Agents (multi-agent routing) */
+#wcwp-agents-table {
+  margin-top: 8px;
+  max-width: 720px;
+}
+#wcwp-agents-table th,
+#wcwp-agents-table td {
+  vertical-align: middle;
+}
+#wcwp-agents-table .wcwp-agents-row-actions {
+  width: 40px;
+}
+.wcwp-agent-remove {
+  color: #c0392b;
+  font-size: 1.2rem;
+  text-decoration: none;
+  cursor: pointer;
+  background: none;
+  border: 0;
+  padding: 0 4px;
+}
+.wcwp-agent-remove:hover { color: #922b21; }
+
 /* Campaigns tab */
 .wcwp-campaign-create {
   background: #f8f9fa;

--- a/assets/js/admin-premium.js
+++ b/assets/js/admin-premium.js
@@ -62,6 +62,67 @@ document.addEventListener('DOMContentLoaded', function () {
     updatePreview();
 });
 
+// Multi-agent routing: agents table add/remove + serialize-on-change
+
+document.addEventListener('DOMContentLoaded', function () {
+    const table = document.getElementById('wcwp-agents-table');
+    const hidden = document.getElementById('wcwp_agents_input');
+    const addBtn = document.getElementById('wcwp-agent-add');
+    if (!table || !hidden) return;
+
+    const tbody = table.querySelector('tbody');
+
+    function serialize() {
+        const rows = tbody.querySelectorAll('.wcwp-agent-row');
+        const list = [];
+        rows.forEach(function (row) {
+            const name  = (row.querySelector('.wcwp-agent-name')  || {}).value || '';
+            const phone = (row.querySelector('.wcwp-agent-phone') || {}).value || '';
+            if (!name.trim() || !phone.trim()) return;
+            list.push({ name: name.trim(), phone: phone.trim() });
+        });
+        hidden.value = JSON.stringify(list);
+    }
+
+    function newRow() {
+        const tr = document.createElement('tr');
+        tr.className = 'wcwp-agent-row';
+        tr.innerHTML =
+            '<td><input type="text" class="wcwp-agent-name regular-text" /></td>' +
+            '<td><input type="text" class="wcwp-agent-phone regular-text" /></td>' +
+            '<td><button type="button" class="button-link wcwp-agent-remove" aria-label="Remove agent">&times;</button></td>';
+        tbody.appendChild(tr);
+    }
+
+    if (addBtn) {
+        addBtn.addEventListener('click', function () {
+            newRow();
+        });
+    }
+
+    // Event delegation: input change anywhere in the table re-serializes;
+    // remove-button clicks delete the row then re-serialize.
+    table.addEventListener('input', function (e) {
+        if (e.target.classList.contains('wcwp-agent-name') || e.target.classList.contains('wcwp-agent-phone')) {
+            serialize();
+        }
+    });
+    table.addEventListener('click', function (e) {
+        if (e.target.classList.contains('wcwp-agent-remove')) {
+            const row = e.target.closest('.wcwp-agent-row');
+            if (row) row.parentNode.removeChild(row);
+            // Always keep at least one empty row visible so the admin can re-add.
+            if (!tbody.querySelector('.wcwp-agent-row')) newRow();
+            serialize();
+        }
+    });
+
+    // Capture-phase form submit listener so the hidden input is current
+    // even if the admin clicks Save without first blurring an input.
+    const form = hidden.closest('form');
+    if (form) form.addEventListener('submit', serialize, true);
+});
+
 // Upgrade Modal Logic
 
 document.addEventListener('DOMContentLoaded', function () {

--- a/assets/js/chatbot.js
+++ b/assets/js/chatbot.js
@@ -24,10 +24,25 @@ jQuery(document).ready(function ($) {
         return { score: hits / faqTokens.length, hits: hits };
     }
 
+    function wcwpPickAgentPhone() {
+        var agents = wcwp_chatbot_obj.agents;
+        if (!Array.isArray(agents) || agents.length === 0) return '';
+        var mode = wcwp_chatbot_obj.routing_mode;
+        if (mode === 'random' && agents.length > 1) {
+            return String(agents[Math.floor(Math.random() * agents.length)].phone || '');
+        }
+        return String(agents[0].phone || '');
+    }
+
     function wcwpRenderChatReply(text) {
         $('#wcwp-chat-response').text(text);
         var encoded = encodeURIComponent(text);
-        $('#wcwp-send-wa').attr('href', 'https://wa.me/?text=' + encoded).show();
+        // Routes the click straight to the chosen agent's WhatsApp when one
+        // is configured; falls back to the empty wa.me picker otherwise so
+        // sites that haven't set up agents keep the legacy behaviour.
+        var phone = wcwpPickAgentPhone();
+        var url = 'https://wa.me/' + (phone || '') + '?text=' + encoded;
+        $('#wcwp-send-wa').attr('href', url).show();
     }
 
     // 0.6 keeps obvious matches while rejecting single-token coincidences

--- a/includes/chatbot-engine.php
+++ b/includes/chatbot-engine.php
@@ -63,6 +63,10 @@ function wcwp_chatbot_localized_data() {
             'action'   => 'wcwp_chatbot_gpt',
             'thinking' => __('Thinking…', 'woochat-pro'),
         ],
+        // Agents are picked client-side so a full-page cache can't pin every
+        // visitor to the same agent under 'random' mode.
+        'agents'        => wcwp_get_agents(),
+        'routing_mode'  => get_option('wcwp_agent_routing_mode', 'single') === 'random' ? 'random' : 'single',
     ];
 }
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -246,6 +246,50 @@ function wcwp_currency_symbol_text() {
     return html_entity_decode(get_woocommerce_currency_symbol(), ENT_QUOTES, 'UTF-8');
 }
 
+/**
+ * Sanitize a JSON-encoded list of {name, phone} agents.
+ *
+ * Drops rows where either field is empty (a half-filled agent breaks
+ * the chatbot routing — better to lose the row than ship a broken
+ * wa.me link). Phone is normalized to digits only via
+ * wcwp_normalize_phone(); name is run through sanitize_text_field.
+ * Stored shape matches what the chatbot localizer reads back.
+ */
+function wcwp_sanitize_agents_json($value) {
+    $decoded = is_array($value) ? $value : json_decode((string) $value, true);
+    if (!is_array($decoded)) return '[]';
+
+    $sanitized = [];
+    foreach ($decoded as $agent) {
+        if (!is_array($agent)) continue;
+        $name  = isset($agent['name'])  ? sanitize_text_field($agent['name'])  : '';
+        $phone = isset($agent['phone']) ? wcwp_normalize_phone($agent['phone']) : '';
+        if ($name === '' || $phone === '') continue;
+        $sanitized[] = ['name' => $name, 'phone' => $phone];
+    }
+    return wp_json_encode($sanitized, JSON_UNESCAPED_UNICODE);
+}
+
+function wcwp_get_agents() {
+    $raw = get_option('wcwp_agents', '[]');
+    $list = is_array($raw) ? $raw : json_decode((string) $raw, true);
+    if (!is_array($list)) return [];
+
+    $clean = [];
+    foreach ($list as $agent) {
+        if (!is_array($agent)) continue;
+        $name  = isset($agent['name'])  ? (string) $agent['name']  : '';
+        $phone = isset($agent['phone']) ? (string) $agent['phone'] : '';
+        if ($name === '' || $phone === '') continue;
+        $clean[] = ['name' => $name, 'phone' => $phone];
+    }
+    return $clean;
+}
+
+function wcwp_sanitize_agent_routing_mode($value) {
+    return in_array($value, ['single', 'random'], true) ? $value : 'single';
+}
+
 function wcwp_sanitize_json_faq($value) {
     $decoded = json_decode($value, true);
     if (!is_array($decoded)) {

--- a/tests/Unit/AgentsTest.php
+++ b/tests/Unit/AgentsTest.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+namespace WooChatPro\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class AgentsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['wcwp_test_options'] = [];
+    }
+
+    public function test_sanitize_drops_rows_with_blank_name_or_phone(): void
+    {
+        $input = wp_json_encode([
+            ['name' => 'Sales',   'phone' => '+1 (415) 555-0100'],
+            ['name' => '',        'phone' => '+14155550101'],   // blank name → drop
+            ['name' => 'Returns', 'phone' => ''],                // blank phone → drop
+            ['name' => '',        'phone' => ''],                // both blank → drop
+        ]);
+
+        $sanitized = json_decode(\wcwp_sanitize_agents_json($input), true);
+
+        $this->assertCount(1, $sanitized);
+        $this->assertSame('Sales', $sanitized[0]['name']);
+        // Phone normalized to digits only — wa.me does not want punctuation.
+        $this->assertSame('14155550100', $sanitized[0]['phone']);
+    }
+
+    public function test_sanitize_returns_empty_array_for_garbage(): void
+    {
+        $this->assertSame('[]', \wcwp_sanitize_agents_json('not json'));
+        $this->assertSame('[]', \wcwp_sanitize_agents_json(null));
+        $this->assertSame('[]', \wcwp_sanitize_agents_json(['not', 'a', 'list', 'of', 'agents']));
+    }
+
+    public function test_get_agents_drops_malformed_persisted_rows(): void
+    {
+        // Defense in depth: even if something hand-edited the option to a
+        // partly-valid shape, the read accessor only returns clean rows.
+        $GLOBALS['wcwp_test_options']['wcwp_agents'] = wp_json_encode([
+            ['name' => 'OK',   'phone' => '14155550100'],
+            ['name' => 'Half', 'phone' => ''],
+            'not an object',
+        ]);
+
+        $agents = \wcwp_get_agents();
+        $this->assertCount(1, $agents);
+        $this->assertSame('OK', $agents[0]['name']);
+    }
+
+    public function test_routing_mode_sanitizer_pins_to_valid_values(): void
+    {
+        $this->assertSame('single', \wcwp_sanitize_agent_routing_mode('single'));
+        $this->assertSame('random', \wcwp_sanitize_agent_routing_mode('random'));
+        $this->assertSame('single', \wcwp_sanitize_agent_routing_mode('rotation'));
+        $this->assertSame('single', \wcwp_sanitize_agent_routing_mode(''));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -48,6 +48,11 @@ if (!function_exists('sanitize_text_field')) {
 if (!function_exists('sanitize_textarea_field')) {
     function sanitize_textarea_field($value) { return is_string($value) ? trim($value) : ''; }
 }
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($data, $options = 0, $depth = 512) {
+        return json_encode($data, $options, $depth);
+    }
+}
 
 require_once __DIR__ . '/../includes/helpers.php';
 require_once __DIR__ . '/../includes/cart-recovery.php';

--- a/uninstall.php
+++ b/uninstall.php
@@ -25,6 +25,8 @@ $option_keys = [
     'wcwp_cart_recovery_enabled',
     'wcwp_chatbot_enabled',
     'wcwp_chatbot_gpt_enabled',
+    'wcwp_agents',
+    'wcwp_agent_routing_mode',
     'wcwp_faq_pairs',
     'wcwp_license_key',
     'wcwp_license_status',


### PR DESCRIPTION
Closes the second-half of the chatbot story: the "Send via WhatsApp" button was opening wa.me with no destination phone, dumping every visitor into an empty WhatsApp picker. Now the click routes to a configured agent number.

What changed
- New `wcwp_agents` option storing a JSON array of {name, phone} agents, sanitized via `wcwp_sanitize_agents_json`. Rows missing either field are dropped — half-filled agents would otherwise ship a broken wa.me link.
- New `wcwp_agent_routing_mode` option ('single' | 'random', defaults to 'single'). 'single' always uses the first agent; 'random' picks client-side per page load so a full-page cache cannot pin every visitor to the same agent.
- New `wcwp_get_agents()` read accessor returns only well-formed rows (defense in depth: even if the option was hand-edited).
- Chatbot tab gains an Agents section under the GPT toggle: a routing-mode dropdown, a dynamic-row table (Name | Phone | Remove), and an "+ Add agent" button. Empty rows are filtered on submit by the JS serializer; the same filter is reapplied server-side by the sanitize callback.
- admin-premium.js handles row add/remove + serialize-on-input into the hidden `wcwp_agents` field. Capture-phase form-submit listener guarantees the hidden value is current even when the admin clicks Save without blurring an input.
- chatbot.js's `wa.me` URL builder now picks a phone via `wcwpPickAgentPhone()` and emits `wa.me/{phone}?text=...` when agents are configured. Sites with zero configured agents keep the legacy `wa.me/?text=...` (empty picker) behaviour.
- chatbot-engine.php's localizer now passes `agents` (array) and `routing_mode` ('single' | 'random') alongside the existing FAQ
  + GPT payload.
- 4 new PHPUnit tests cover the sanitizer's drop rules, the `[]` fallback for garbage input, the `wcwp_get_agents()` read filter, and the routing-mode pinning. Test bootstrap gains a `wp_json_encode` shim.
- uninstall.php drops the two new option keys when `wcwp_delete_data_on_uninstall` is enabled.

What stays the same
- Existing FAQ matcher + GPT fallback paths (PR #35, PR #44) are untouched — agent routing only affects the wa.me URL the user clicks after they get a reply.
- `wp_localize_script` payload is still produced by the single `wcwp_chatbot_localized_data()` source so the auto-render and shortcode paths get the same agents data.
- Sites that have not configured agents see byte-identical behaviour (empty picker, no other UX change).

Test plan
- 20 PHPUnit tests pass (16 prior + 4 new), 40 assertions.
- php -l clean on all modified PHP files.