### PR TITLE
Add Gutenberg blocks for chatbot and WhatsApp button

### DIFF
--- a/assets/css/blocks.css
+++ b/assets/css/blocks.css
@@ -1,0 +1,48 @@
+/* WooChat Pro – Block frontend styles */
+
+.wcwp-whatsapp-button-block {
+    margin: 16px 0;
+}
+.wcwp-whatsapp-button-block.aligncenter { text-align: center; }
+.wcwp-whatsapp-button-block.alignright  { text-align: right; }
+.wcwp-whatsapp-button-block.alignleft   { text-align: left; }
+
+.wcwp-whatsapp-button {
+    display: inline-block;
+    background: #25d366; /* WhatsApp brand green */
+    color: #fff;
+    padding: 10px 22px;
+    border-radius: 6px;
+    text-decoration: none;
+    font-weight: 600;
+    line-height: 1.4;
+    transition: background 0.15s ease, transform 0.1s ease;
+}
+.wcwp-whatsapp-button:hover,
+.wcwp-whatsapp-button:focus {
+    background: #1da851;
+    color: #fff;
+    text-decoration: none;
+}
+.wcwp-whatsapp-button:active {
+    transform: translateY(1px);
+}
+
+/* Block editor placeholder */
+.wcwp-block-placeholder {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 18px 20px;
+    border: 1px dashed #c8ced4;
+    border-radius: 8px;
+    background: #f8f9fa;
+}
+.wcwp-block-placeholder-icon {
+    font-size: 1.6rem;
+}
+.wcwp-block-placeholder-help {
+    margin: 4px 0 0;
+    color: #555;
+    font-size: 0.9rem;
+}

--- a/blocks/chatbot/block.json
+++ b/blocks/chatbot/block.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 2,
+    "name": "woochat-pro/chatbot",
+    "title": "WooChat Chatbot",
+    "category": "widgets",
+    "icon": "format-chat",
+    "description": "Embeds the WooChat Pro floating chatbot widget on this page. The widget is also available globally via the site footer.",
+    "textdomain": "woochat-pro",
+    "supports": {
+        "html": false,
+        "multiple": false,
+        "reusable": false
+    },
+    "editorScript": "file:./index.js"
+}

--- a/blocks/chatbot/index.js
+++ b/blocks/chatbot/index.js
@@ -1,0 +1,40 @@
+/**
+ * WooChat Chatbot block.
+ *
+ * Server-rendered (PHP render_callback in includes/blocks.php), so save()
+ * returns null. The editor preview is a static placeholder card — calling
+ * the live shortcode renderer would require ServerSideRender, which adds
+ * REST + iframe overhead that is not worth it for a "chatbot lives in the
+ * footer" placeholder.
+ */
+( function ( blocks, element, i18n ) {
+    var el = element.createElement;
+    var __ = i18n.__;
+
+    blocks.registerBlockType( 'woochat-pro/chatbot', {
+        edit: function () {
+            return el(
+                'div',
+                { className: 'wcwp-block-placeholder' },
+                el(
+                    'span',
+                    { className: 'wcwp-block-placeholder-icon', 'aria-hidden': 'true' },
+                    '💬'
+                ),
+                el(
+                    'div',
+                    null,
+                    el( 'strong', null, __( 'WooChat Chatbot', 'woochat-pro' ) ),
+                    el(
+                        'p',
+                        { className: 'wcwp-block-placeholder-help' },
+                        __( 'The floating chatbot widget will render on the published page when the chatbot is enabled and a Pro license is active.', 'woochat-pro' )
+                    )
+                )
+            );
+        },
+        save: function () {
+            return null;
+        }
+    } );
+}( window.wp.blocks, window.wp.element, window.wp.i18n ) );

--- a/blocks/whatsapp-button/block.json
+++ b/blocks/whatsapp-button/block.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 2,
+    "name": "woochat-pro/whatsapp-button",
+    "title": "WhatsApp Button",
+    "category": "widgets",
+    "icon": "phone",
+    "description": "A WhatsApp call-to-action button that opens a chat with a configured phone number.",
+    "textdomain": "woochat-pro",
+    "attributes": {
+        "phone":   { "type": "string", "default": "" },
+        "text":    { "type": "string", "default": "" },
+        "message": { "type": "string", "default": "" }
+    },
+    "supports": {
+        "html": false,
+        "align": [ "left", "center", "right" ]
+    },
+    "editorScript": "file:./index.js"
+}

--- a/blocks/whatsapp-button/index.js
+++ b/blocks/whatsapp-button/index.js
@@ -1,0 +1,67 @@
+/**
+ * WhatsApp Button block.
+ *
+ * Server-rendered (PHP render_callback in includes/blocks.php). The editor
+ * gives the admin three controls — phone, text, preset message — and a
+ * static preview anchor. No JSX so the plugin can ship without a build step.
+ */
+( function ( blocks, element, blockEditor, components, i18n ) {
+    var el = element.createElement;
+    var __ = i18n.__;
+
+    var InspectorControls = blockEditor.InspectorControls;
+    var PanelBody         = components.PanelBody;
+    var TextControl       = components.TextControl;
+    var TextareaControl   = components.TextareaControl;
+
+    blocks.registerBlockType( 'woochat-pro/whatsapp-button', {
+        edit: function ( props ) {
+            var attrs = props.attributes;
+            var label = attrs.text && attrs.text.length ? attrs.text : __( 'Chat on WhatsApp', 'woochat-pro' );
+
+            return [
+                el(
+                    InspectorControls,
+                    { key: 'inspector' },
+                    el(
+                        PanelBody,
+                        { title: __( 'Button', 'woochat-pro' ), initialOpen: true },
+                        el( TextControl, {
+                            label: __( 'Phone number', 'woochat-pro' ),
+                            value: attrs.phone || '',
+                            onChange: function ( v ) { props.setAttributes( { phone: v } ); },
+                            help: __( 'Include the country code, e.g. +14155550100. Leave blank to open WhatsApp without a destination.', 'woochat-pro' )
+                        } ),
+                        el( TextControl, {
+                            label: __( 'Button text', 'woochat-pro' ),
+                            value: attrs.text || '',
+                            onChange: function ( v ) { props.setAttributes( { text: v } ); }
+                        } ),
+                        el( TextareaControl, {
+                            label: __( 'Preset message', 'woochat-pro' ),
+                            value: attrs.message || '',
+                            onChange: function ( v ) { props.setAttributes( { message: v } ); },
+                            help: __( 'Shown as the prefilled WhatsApp message body.', 'woochat-pro' )
+                        } )
+                    )
+                ),
+                el(
+                    'div',
+                    { key: 'preview', className: 'wcwp-whatsapp-button-block' },
+                    el(
+                        'a',
+                        {
+                            className: 'wcwp-whatsapp-button',
+                            // No real href in the editor — the live anchor is rendered server-side.
+                            onClick: function ( e ) { e.preventDefault(); }
+                        },
+                        label
+                    )
+                )
+            ];
+        },
+        save: function () {
+            return null;
+        }
+    } );
+}( window.wp.blocks, window.wp.element, window.wp.blockEditor, window.wp.components, window.wp.i18n ) );

--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Gutenberg block registration for the chatbot widget and the WhatsApp
+ * call-to-action button. Both blocks are server-rendered via PHP render
+ * callbacks so attribute changes are picked up without a static save().
+ */
+
+if (!defined('ABSPATH')) exit;
+
+add_action('init', 'wcwp_register_blocks');
+
+function wcwp_register_blocks() {
+    if (!function_exists('register_block_type')) return;
+
+    wp_register_style(
+        'wcwp-blocks-css',
+        WCWP_URL . 'assets/css/blocks.css',
+        [],
+        WCWP_VERSION
+    );
+
+    register_block_type(WCWP_PATH . 'blocks/chatbot', [
+        'render_callback' => 'wcwp_render_chatbot_block',
+    ]);
+
+    register_block_type(WCWP_PATH . 'blocks/whatsapp-button', [
+        'render_callback' => 'wcwp_render_whatsapp_button_block',
+    ]);
+}
+
+/**
+ * Chatbot block — defers to the existing shortcode renderer so the widget
+ * stays a single source of truth (FAQ matching, GPT fallback, agent
+ * routing all happen in chatbot-engine.php).
+ */
+function wcwp_render_chatbot_block($attributes = []) {
+    if (!function_exists('wcwp_chatbot_shortcode')) return '';
+    return (string) wcwp_chatbot_shortcode();
+}
+
+/**
+ * WhatsApp button block — emits a static anchor pointing at wa.me.
+ *
+ * Phone is normalized to digits-only (wa.me ignores punctuation). Empty
+ * phone is allowed and renders the legacy contact-picker URL — useful
+ * during page authoring before the admin has a number to plug in.
+ */
+function wcwp_render_whatsapp_button_block($attributes = []) {
+    $phone   = isset($attributes['phone']) ? wcwp_normalize_phone((string) $attributes['phone']) : '';
+    $text    = isset($attributes['text']) && $attributes['text'] !== ''
+        ? sanitize_text_field((string) $attributes['text'])
+        : __('Chat on WhatsApp', 'woochat-pro');
+    $message = isset($attributes['message']) ? sanitize_text_field((string) $attributes['message']) : '';
+
+    $url = 'https://wa.me/' . $phone;
+    if ($message !== '') {
+        // add_query_arg URL-encodes the value.
+        $url = add_query_arg('text', $message, $url);
+    }
+
+    $align = isset($attributes['align']) ? sanitize_html_class((string) $attributes['align']) : '';
+    $wrapper_class = 'wcwp-whatsapp-button-block';
+    if ($align !== '') {
+        $wrapper_class .= ' align' . $align;
+    }
+
+    wp_enqueue_style('wcwp-blocks-css');
+
+    return sprintf(
+        '<p class="%s"><a class="wcwp-whatsapp-button" href="%s" target="_blank" rel="noopener nofollow">%s</a></p>',
+        esc_attr($wrapper_class),
+        esc_url($url),
+        esc_html($text)
+    );
+}

--- a/includes/class-wcwp-plugin.php
+++ b/includes/class-wcwp-plugin.php
@@ -90,6 +90,7 @@ final class Plugin {
         require_once WCWP_PATH . 'includes/cart-recovery.php';
         require_once WCWP_PATH . 'includes/scheduler.php';
         require_once WCWP_PATH . 'includes/campaigns.php';
+        require_once WCWP_PATH . 'includes/blocks.php';
     }
 
     public function run_migrations() {

--- a/tests/Unit/BlocksTest.php
+++ b/tests/Unit/BlocksTest.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace WooChatPro\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class BlocksTest extends TestCase
+{
+    public function test_button_renders_normalized_phone_and_default_label(): void
+    {
+        $html = \wcwp_render_whatsapp_button_block([
+            'phone' => '+1 (415) 555-0100',
+        ]);
+
+        $this->assertStringContainsString('https://wa.me/14155550100', $html);
+        $this->assertStringContainsString('Chat on WhatsApp', $html);
+        $this->assertStringContainsString('target="_blank"', $html);
+        $this->assertStringContainsString('rel="noopener nofollow"', $html);
+    }
+
+    public function test_button_appends_preset_message_as_text_query(): void
+    {
+        $html = \wcwp_render_whatsapp_button_block([
+            'phone'   => '14155550100',
+            'message' => 'Hi! I have a question.',
+            'text'    => 'Talk to us',
+        ]);
+
+        $this->assertStringContainsString('Talk to us', $html);
+        $this->assertStringContainsString('https://wa.me/14155550100?text=Hi%21+I+have+a+question.', $html);
+    }
+
+    public function test_button_with_blank_phone_falls_back_to_picker_url(): void
+    {
+        // Empty phone should still produce a clickable wa.me link rather
+        // than rendering nothing — useful while authoring before the admin
+        // has plugged in a number.
+        $html = \wcwp_render_whatsapp_button_block(['phone' => '']);
+
+        $this->assertStringContainsString('href="https://wa.me/"', $html);
+    }
+
+    public function test_button_carries_alignment_class(): void
+    {
+        $html = \wcwp_render_whatsapp_button_block([
+            'phone' => '14155550100',
+            'align' => 'center',
+        ]);
+
+        $this->assertStringContainsString('class="wcwp-whatsapp-button-block aligncenter"', $html);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -53,7 +53,31 @@ if (!function_exists('wp_json_encode')) {
         return json_encode($data, $options, $depth);
     }
 }
+if (!function_exists('esc_url')) {
+    function esc_url($url) { return $url; }
+}
+if (!function_exists('esc_attr')) {
+    function esc_attr($value) { return $value; }
+}
+if (!function_exists('esc_html')) {
+    function esc_html($value) { return $value; }
+}
+if (!function_exists('sanitize_html_class')) {
+    function sanitize_html_class($class) { return preg_replace('/[^A-Za-z0-9_-]/', '', (string) $class); }
+}
+if (!function_exists('wp_enqueue_style')) {
+    function wp_enqueue_style(...$args) { /* no-op for unit tests */ }
+}
+if (!function_exists('add_query_arg')) {
+    // Minimal three-arg form (key, value, url) — enough for the block render
+    // tests. The real WP function handles arrays + various url shapes.
+    function add_query_arg($key, $value, $url) {
+        $sep = strpos($url, '?') === false ? '?' : '&';
+        return $url . $sep . $key . '=' . urlencode((string) $value);
+    }
+}
 
 require_once __DIR__ . '/../includes/helpers.php';
 require_once __DIR__ . '/../includes/cart-recovery.php';
 require_once __DIR__ . '/../includes/campaigns.php';
+require_once __DIR__ . '/../includes/blocks.php';


### PR DESCRIPTION
Two new blocks let admins drop chat/contact CTAs onto specific pages without relying solely on the global footer chatbot. Both ship without a build step (plain JS, no JSX) so the plugin still installs as a zip.

What changed
- blocks/chatbot/ — server-rendered block that calls the existing wcwp_chatbot_shortcode() so FAQ matching, GPT fallback, and agent routing all flow through one path. Editor preview is a static placeholder card; no live ServerSideRender (the chatbot is a fixed-position widget — previewing it inside the editor adds nothing).
- blocks/whatsapp-button/ — server-rendered button block with three attributes (phone, text, message). Phone is normalized via wcwp_normalize_phone(), message is appended via add_query_arg (URL-encoded). Empty phone falls back to wa.me/ so the block stays clickable while authoring. Inherits Gutenberg's left/center/right alignment via wcwp-whatsapp-button-block.align{left,center,right}.
- includes/blocks.php — single init-hooked registrar plus the two render callbacks. wp_enqueue_style on the button render so the brand-green CSS only loads on pages that actually use the block.
- assets/css/blocks.css — frontend button styles (#25d366 brand green) plus the editor placeholder card.
- includes/class-wcwp-plugin.php — boot_modules() now requires blocks.php after campaigns.php.
- tests/Unit/BlocksTest.php (4 tests) covers phone normalization, default label, preset-message URL encoding, alignment class passthrough, and the empty-phone fallback URL. Test bootstrap gained stubs for wp_enqueue_style / esc_url / esc_attr / esc_html / sanitize_html_class / add_query_arg.

What stays the same
- The footer-rendered chatbot path is untouched; the new chatbot block is an additional embed surface, not a replacement.
- No new options, no schema changes, no Pro gating on the button block (it's a static link generator that's useful at the free tier too).
- Plugin still ships hand-written JS — no npm/build step added.
- block.json files validate; both blocks register on init via the existing register_block_type API.

Test plan
- 24 PHPUnit tests pass (20 prior + 4 new), 48 assertions.
- php -l clean on all modified PHP files.
- Both block.json files parse as valid JSON.