### PR TITLE
Analytics dashboard upgrades — date-range presets, CSV export, per-template breakdown, conversion attribution

### DIFF
--- a/admin/views/tab-analytics.php
+++ b/admin/views/tab-analytics.php
@@ -3,7 +3,6 @@ if (!defined('ABSPATH')) exit;
 ?>
 <div id="wcwp-tab-content-analytics" class="wcwp-tab-content" style="display:none;">
     <?php $is_pro = wcwp_is_pro_active(); ?>
-    <?php $totals = wcwp_analytics_get_totals(); ?>
     <?php
     $filters = [
         'type' => isset($_GET['wcwp_type']) ? sanitize_text_field(wp_unslash($_GET['wcwp_type'])) : '',
@@ -12,12 +11,34 @@ if (!defined('ABSPATH')) exit;
         'date_from' => isset($_GET['wcwp_date_from']) ? sanitize_text_field(wp_unslash($_GET['wcwp_date_from'])) : '',
         'date_to' => isset($_GET['wcwp_date_to']) ? sanitize_text_field(wp_unslash($_GET['wcwp_date_to'])) : '',
     ];
+    $totals = wcwp_analytics_get_totals();
+    $breakdown = wcwp_analytics_get_per_type_breakdown($filters);
+    $conversions = wcwp_analytics_get_conversions($filters);
     $events = wcwp_analytics_get_events(25, $filters);
+    $export_url = wp_nonce_url(
+        add_query_arg(
+            array_merge(
+                ['action' => 'wcwp_analytics_export_csv'],
+                array_filter($filters, static function ($v) { return $v !== ''; })
+            ),
+            admin_url('admin-post.php')
+        ),
+        'wcwp_analytics_export',
+        'wcwp_analytics_export_nonce'
+    );
     ?>
     <?php if (!$is_pro) : ?>
         <div class="wcwp-pro-banner"><span class="dashicons dashicons-chart-bar"></span> <strong><?php esc_html_e('Analytics Dashboard', 'woochat-pro'); ?></strong> <?php esc_html_e('is a Pro feature.', 'woochat-pro'); ?> <button type="button" class="wcwp-open-upgrade-modal" style="margin-left:12px;"><?php esc_html_e('Upgrade', 'woochat-pro'); ?></button></div>
     <?php endif; ?>
-    <div class="wcwp-analytics-filters" style="margin:16px 0 8px;display:flex;gap:8px;flex-wrap:wrap;align-items:end;">
+    <div class="wcwp-analytics-presets" style="margin:16px 0 4px;display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
+        <span style="color:#666;font-size:0.95em;"><?php esc_html_e('Quick range:', 'woochat-pro'); ?></span>
+        <button type="button" class="button button-small wcwp-analytics-preset" data-range="today"><?php esc_html_e('Today', 'woochat-pro'); ?></button>
+        <button type="button" class="button button-small wcwp-analytics-preset" data-range="7d"><?php esc_html_e('Last 7 days', 'woochat-pro'); ?></button>
+        <button type="button" class="button button-small wcwp-analytics-preset" data-range="30d"><?php esc_html_e('Last 30 days', 'woochat-pro'); ?></button>
+        <button type="button" class="button button-small wcwp-analytics-preset" data-range="month"><?php esc_html_e('This month', 'woochat-pro'); ?></button>
+        <button type="button" class="button button-small wcwp-analytics-preset" data-range="all"><?php esc_html_e('All time', 'woochat-pro'); ?></button>
+    </div>
+    <div class="wcwp-analytics-filters" style="margin:8px 0;display:flex;gap:8px;flex-wrap:wrap;align-items:end;">
         <div>
             <label for="wcwp_type"><?php esc_html_e('Type', 'woochat-pro'); ?></label><br>
             <input type="text" id="wcwp_type" name="wcwp_type" value="<?php echo esc_attr($filters['type']); ?>" placeholder="order, cart_recovery" />
@@ -39,7 +60,10 @@ if (!defined('ABSPATH')) exit;
             <input type="date" id="wcwp_date_to" name="wcwp_date_to" value="<?php echo esc_attr($filters['date_to']); ?>" />
         </div>
         <div>
-            <button type="button" class="button" id="wcwp-analytics-filter-button"><?php esc_html_e('Filter', 'woochat-pro'); ?></button>
+            <button type="button" class="button button-primary" id="wcwp-analytics-filter-button"><?php esc_html_e('Filter', 'woochat-pro'); ?></button>
+        </div>
+        <div>
+            <a class="button" href="<?php echo esc_url($export_url); ?>" id="wcwp-analytics-export-csv"><span class="dashicons dashicons-download" style="vertical-align:middle;line-height:28px;"></span> <?php esc_html_e('Export CSV', 'woochat-pro'); ?></a>
         </div>
     </div>
     <div class="wcwp-analytics-cards" style="display:flex;gap:12px;flex-wrap:wrap;">
@@ -55,7 +79,59 @@ if (!defined('ABSPATH')) exit;
             <div class="wcwp-analytics-label"><?php esc_html_e('Clicked', 'woochat-pro'); ?></div>
             <div class="wcwp-analytics-value"><?php echo esc_html($totals['clicked']); ?></div>
         </div>
+        <div class="wcwp-analytics-card" style="background:#fff;border:1px solid #e5e5e5;border-radius:10px;padding:14px 16px;min-width:200px;">
+            <div class="wcwp-analytics-label">
+                <?php
+                /* translators: %d is the attribution window in days */
+                printf(
+                    esc_html__('Attributed orders (%d-day window)', 'woochat-pro'),
+                    (int) $conversions['window_days']
+                );
+                ?>
+            </div>
+            <div class="wcwp-analytics-value"><?php echo esc_html($conversions['conversions']); ?></div>
+            <?php if ($conversions['revenue'] > 0) : ?>
+                <div style="color:#666;font-size:0.92em;margin-top:4px;">
+                    <?php
+                    if (function_exists('wc_price')) {
+                        echo wp_kses_post(wc_price($conversions['revenue']));
+                    } else {
+                        echo esc_html(number_format_i18n($conversions['revenue'], 2));
+                    }
+                    ?>
+                </div>
+            <?php endif; ?>
+        </div>
     </div>
+    <h3 style="margin-top:20px;"><?php esc_html_e('Performance by template', 'woochat-pro'); ?></h3>
+    <table class="widefat striped" style="margin-top:10px;max-width:780px;">
+        <thead>
+            <tr>
+                <th><?php esc_html_e('Template / source', 'woochat-pro'); ?></th>
+                <th><?php esc_html_e('Sent', 'woochat-pro'); ?></th>
+                <th><?php esc_html_e('Delivered', 'woochat-pro'); ?></th>
+                <th><?php esc_html_e('Clicked', 'woochat-pro'); ?></th>
+                <th><?php esc_html_e('Failed', 'woochat-pro'); ?></th>
+                <th><?php esc_html_e('Total', 'woochat-pro'); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php if (!empty($breakdown)) : ?>
+                <?php foreach ($breakdown as $row) : ?>
+                    <tr>
+                        <td><code><?php echo esc_html($row['type']); ?></code></td>
+                        <td><?php echo esc_html((string) $row['sent']); ?></td>
+                        <td><?php echo esc_html((string) $row['delivered']); ?></td>
+                        <td><?php echo esc_html((string) $row['clicked']); ?></td>
+                        <td><?php echo esc_html((string) $row['failed']); ?></td>
+                        <td><strong><?php echo esc_html((string) $row['total']); ?></strong></td>
+                    </tr>
+                <?php endforeach; ?>
+            <?php else : ?>
+                <tr><td colspan="6"><?php esc_html_e('No events match the current filters.', 'woochat-pro'); ?></td></tr>
+            <?php endif; ?>
+        </tbody>
+    </table>
     <h3 style="margin-top:20px;"><?php esc_html_e('Recent Events', 'woochat-pro'); ?></h3>
     <table class="widefat striped" style="margin-top:10px;">
         <thead>

--- a/assets/js/admin-premium.js
+++ b/assets/js/admin-premium.js
@@ -344,6 +344,97 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 });
 
+// Date-range preset buttons (Today / Last 7 / Last 30 / This month / All time)
+document.addEventListener('DOMContentLoaded', function () {
+    const presets = document.querySelectorAll('.wcwp-analytics-preset');
+    if (!presets.length) return;
+
+    function fmt(d) {
+        // Format Date as YYYY-MM-DD in local time so it matches what the
+        // admin sees on screen (the date inputs are timezone-naive).
+        const y = d.getFullYear();
+        const m = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        return `${y}-${m}-${day}`;
+    }
+
+    function setRange(range) {
+        const fromInput = document.getElementById('wcwp_date_from');
+        const toInput   = document.getElementById('wcwp_date_to');
+        if (!fromInput || !toInput) return;
+
+        const today = new Date();
+        let from = '';
+        let to   = '';
+
+        if (range === 'today') {
+            from = to = fmt(today);
+        } else if (range === '7d') {
+            const start = new Date(today);
+            start.setDate(start.getDate() - 6);
+            from = fmt(start);
+            to   = fmt(today);
+        } else if (range === '30d') {
+            const start = new Date(today);
+            start.setDate(start.getDate() - 29);
+            from = fmt(start);
+            to   = fmt(today);
+        } else if (range === 'month') {
+            const start = new Date(today.getFullYear(), today.getMonth(), 1);
+            from = fmt(start);
+            to   = fmt(today);
+        } else if (range === 'all') {
+            from = '';
+            to   = '';
+        }
+
+        fromInput.value = from;
+        toInput.value   = to;
+
+        const filterBtn = document.getElementById('wcwp-analytics-filter-button');
+        if (filterBtn) filterBtn.click();
+    }
+
+    presets.forEach(btn => {
+        btn.addEventListener('click', function () {
+            setRange(btn.getAttribute('data-range'));
+        });
+    });
+});
+
+// Export CSV honors the date inputs at click time so the user doesn't
+// have to re-apply the filter just to export. The href was rendered with
+// whatever filters were already in the URL; this rebuild syncs it with
+// the live form values + presets.
+document.addEventListener('DOMContentLoaded', function () {
+    const exportLink = document.getElementById('wcwp-analytics-export-csv');
+    if (!exportLink) return;
+
+    exportLink.addEventListener('click', function (e) {
+        const href = exportLink.getAttribute('href');
+        if (!href) return;
+
+        const url = new URL(href, window.location.origin);
+        const fields = [
+            { id: 'wcwp_type', key: 'wcwp_type' },
+            { id: 'wcwp_status', key: 'wcwp_status' },
+            { id: 'wcwp_phone', key: 'wcwp_phone' },
+            { id: 'wcwp_date_from', key: 'wcwp_date_from' },
+            { id: 'wcwp_date_to', key: 'wcwp_date_to' }
+        ];
+        fields.forEach(field => {
+            const el = document.getElementById(field.id);
+            const value = el ? el.value.trim() : '';
+            if (value) {
+                url.searchParams.set(field.key, value);
+            } else {
+                url.searchParams.delete(field.key);
+            }
+        });
+        exportLink.setAttribute('href', url.pathname + url.search);
+    });
+});
+
 // Send test WhatsApp message
 document.addEventListener('DOMContentLoaded', function () {
     const sendBtn = document.getElementById('wcwp-send-test-message');

--- a/includes/analytics.php
+++ b/includes/analytics.php
@@ -11,6 +11,8 @@ if (!empty($_GET['wcwp_track'])) { // phpcs:ignore WordPress.Security.NonceVerif
 add_action('wp_ajax_wcwp_track_event', 'wcwp_track_event_ajax');
 add_action('wp_ajax_nopriv_wcwp_track_event', 'wcwp_track_event_ajax');
 
+add_action('admin_post_wcwp_analytics_export_csv', 'wcwp_analytics_export_csv');
+
 add_action('wcwp_cleanup_analytics', 'wcwp_cleanup_analytics');
 
 function wcwp_get_analytics_table_name() {
@@ -174,6 +176,279 @@ function wcwp_analytics_get_events($limit = 50, $filters = []) {
         }
     }
     return $rows;
+}
+
+/**
+ * Per-type (template) performance breakdown for the given filter window.
+ *
+ * Aggregates event rows grouped by the `type` column — which acts as a
+ * coarse template/source dimension (order, cart_recovery, followup, bulk,
+ * chatbot_gpt). Returned counts are raw per-status totals matching the
+ * "latest state" semantics of `wcwp_analytics_get_totals()`; `total` sums
+ * the four reportable terminal states (sent + delivered + clicked +
+ * failed) and excludes operational states like pending / test / opted_out.
+ *
+ * @param array $filters Same shape as wcwp_analytics_get_events filters.
+ * @return array<int, array{type:string,sent:int,delivered:int,clicked:int,failed:int,total:int}>
+ */
+function wcwp_analytics_get_per_type_breakdown($filters = []) {
+    global $wpdb;
+    $table = wcwp_get_analytics_table_name();
+
+    $where = [];
+    $params = [];
+
+    if (!empty($filters['type'])) {
+        $where[] = 'type = %s';
+        $params[] = $filters['type'];
+    }
+    if (!empty($filters['status'])) {
+        $where[] = 'status = %s';
+        $params[] = $filters['status'];
+    }
+    if (!empty($filters['phone'])) {
+        $where[] = 'phone LIKE %s';
+        $params[] = '%' . $wpdb->esc_like($filters['phone']) . '%';
+    }
+    if (!empty($filters['date_from'])) {
+        $where[] = 'created_at >= %s';
+        $params[] = $filters['date_from'] . ' 00:00:00';
+    }
+    if (!empty($filters['date_to'])) {
+        $where[] = 'created_at <= %s';
+        $params[] = $filters['date_to'] . ' 23:59:59';
+    }
+
+    $sql = "SELECT type, status, COUNT(*) AS total FROM {$table}";
+    if (!empty($where)) {
+        $sql .= ' WHERE ' . implode(' AND ', $where);
+    }
+    $sql .= ' GROUP BY type, status';
+
+    $rows = !empty($params)
+        ? $wpdb->get_results($wpdb->prepare($sql, $params), ARRAY_A)
+        : $wpdb->get_results($sql, ARRAY_A);
+
+    if (!$rows) return [];
+
+    $reportable = ['sent', 'delivered', 'clicked', 'failed'];
+    $out = [];
+    foreach ($rows as $row) {
+        $type = (string) $row['type'];
+        $status = (string) $row['status'];
+        if (!isset($out[$type])) {
+            $out[$type] = [
+                'type' => $type,
+                'sent' => 0,
+                'delivered' => 0,
+                'clicked' => 0,
+                'failed' => 0,
+                'total' => 0,
+            ];
+        }
+        if (in_array($status, $reportable, true)) {
+            $count = (int) $row['total'];
+            $out[$type][$status] = $count;
+            $out[$type]['total'] += $count;
+        }
+    }
+    ksort($out);
+    return array_values($out);
+}
+
+/**
+ * Pure conversion-attribution matcher.
+ *
+ * Given a set of analytics events and a set of WooCommerce orders, return
+ * how many events map to a subsequent order placed by the same normalized
+ * phone number, within `$window_seconds` of the event firing.
+ *
+ * Rules:
+ * - First-event-wins: events are processed in chronological order, each
+ *   matched event consumes one order so a single order is never double-
+ *   counted across two events to the same phone.
+ * - The matched order must be created at or after the event time.
+ * - Orders older than the event are ignored (no false positives from
+ *   pre-existing customer history).
+ *
+ * Extracted from `wcwp_analytics_get_conversions()` so it can be unit-
+ * tested without a database.
+ *
+ * @param array $events Each: ['event_id' => string, 'phone_norm' => string, 'time' => int unix].
+ * @param array $orders Each: ['order_id' => int, 'phone_norm' => string, 'time' => int unix, 'total' => float].
+ * @param int   $window_seconds Maximum elapsed time between event and order.
+ * @return array{conversions:int,revenue:float,matched:array<int,string>}
+ */
+function wcwp_analytics_match_conversions($events, $orders, $window_seconds) {
+    $empty = ['conversions' => 0, 'revenue' => 0.0, 'matched' => []];
+    if (!is_array($events) || !is_array($orders) || (int) $window_seconds <= 0) {
+        return $empty;
+    }
+
+    $orders_by_phone = [];
+    foreach ($orders as $o) {
+        if (empty($o['phone_norm'])) continue;
+        $orders_by_phone[$o['phone_norm']][] = $o;
+    }
+    foreach ($orders_by_phone as &$list) {
+        usort($list, static function ($a, $b) {
+            return (int) $a['time'] <=> (int) $b['time'];
+        });
+    }
+    unset($list);
+
+    usort($events, static function ($a, $b) {
+        return (int) $a['time'] <=> (int) $b['time'];
+    });
+
+    $consumed = [];
+    $conversions = 0;
+    $revenue = 0.0;
+    $matched = [];
+
+    foreach ($events as $e) {
+        $phone = $e['phone_norm'] ?? '';
+        if ($phone === '' || empty($orders_by_phone[$phone])) continue;
+        foreach ($orders_by_phone[$phone] as $o) {
+            if (!empty($consumed[$o['order_id']])) continue;
+            if ((int) $o['time'] < (int) $e['time']) continue;
+            if (((int) $o['time'] - (int) $e['time']) > (int) $window_seconds) break;
+            $consumed[$o['order_id']] = true;
+            $conversions++;
+            $revenue += (float) $o['total'];
+            $matched[(int) $o['order_id']] = (string) ($e['event_id'] ?? '');
+            break;
+        }
+    }
+
+    return [
+        'conversions' => $conversions,
+        'revenue' => $revenue,
+        'matched' => $matched,
+    ];
+}
+
+/**
+ * Conversion attribution summary for the given filter window.
+ *
+ * Pulls eligible events (status sent/delivered/clicked, phone present)
+ * within the filter window and joins them against WooCommerce orders by
+ * normalized phone within an attribution window (default 7 days,
+ * filterable). Best-effort — caps both event and order fetch at 5000.
+ *
+ * @param array $filters Same shape as wcwp_analytics_get_events filters.
+ * @return array{conversions:int,revenue:float,eligible_events:int,window_days:int}
+ */
+function wcwp_analytics_get_conversions($filters = []) {
+    $window_days = (int) apply_filters('wcwp_analytics_attribution_window_days', 7);
+    if ($window_days < 1) $window_days = 7;
+    $window_seconds = $window_days * DAY_IN_SECONDS;
+
+    $base = ['conversions' => 0, 'revenue' => 0.0, 'eligible_events' => 0, 'window_days' => $window_days];
+    if (!function_exists('wc_get_orders')) {
+        return $base;
+    }
+
+    // Drop status filter — we always look at sent/delivered/clicked.
+    $event_filters = $filters;
+    unset($event_filters['status']);
+    $events = wcwp_analytics_get_events(5000, $event_filters);
+
+    $eligible = [];
+    $earliest = PHP_INT_MAX;
+    $latest = 0;
+    foreach ($events as $e) {
+        if (empty($e['phone'])) continue;
+        if (!in_array($e['status'] ?? '', ['sent', 'delivered', 'clicked'], true)) continue;
+        $time = isset($e['time']) ? strtotime((string) $e['time']) : 0;
+        if (!$time) continue;
+        $eligible[] = [
+            'event_id' => (string) ($e['id'] ?? ''),
+            'phone_norm' => wcwp_normalize_phone($e['phone']),
+            'time' => $time,
+        ];
+        if ($time < $earliest) $earliest = $time;
+        if ($time > $latest) $latest = $time;
+    }
+
+    if (empty($eligible)) {
+        return $base;
+    }
+
+    $orders = wc_get_orders([
+        'limit' => 5000,
+        'date_created' => gmdate('Y-m-d\TH:i:s', $earliest) . '...' . gmdate('Y-m-d\TH:i:s', $latest + $window_seconds),
+        'status' => ['wc-processing', 'wc-on-hold', 'wc-completed'],
+        'orderby' => 'date',
+        'order' => 'ASC',
+    ]);
+
+    $order_records = [];
+    if (is_array($orders)) {
+        foreach ($orders as $order) {
+            if (!is_object($order) || !method_exists($order, 'get_billing_phone')) continue;
+            $phone_norm = wcwp_normalize_phone($order->get_billing_phone());
+            if ($phone_norm === '') continue;
+            $created = $order->get_date_created();
+            if (!$created) continue;
+            $order_records[] = [
+                'order_id' => (int) $order->get_id(),
+                'phone_norm' => $phone_norm,
+                'time' => (int) $created->getTimestamp(),
+                'total' => (float) $order->get_total(),
+            ];
+        }
+    }
+
+    $result = wcwp_analytics_match_conversions($eligible, $order_records, $window_seconds);
+    return [
+        'conversions' => $result['conversions'],
+        'revenue' => $result['revenue'],
+        'eligible_events' => count($eligible),
+        'window_days' => $window_days,
+    ];
+}
+
+function wcwp_analytics_export_csv() {
+    if (!current_user_can('manage_options')) {
+        wp_die(esc_html__('Unauthorized', 'woochat-pro'), '', ['response' => 403]);
+    }
+    check_admin_referer('wcwp_analytics_export', 'wcwp_analytics_export_nonce');
+
+    $filters = [
+        'type'      => isset($_GET['wcwp_type']) ? sanitize_text_field(wp_unslash($_GET['wcwp_type'])) : '',
+        'status'    => isset($_GET['wcwp_status']) ? sanitize_text_field(wp_unslash($_GET['wcwp_status'])) : '',
+        'phone'     => isset($_GET['wcwp_phone']) ? sanitize_text_field(wp_unslash($_GET['wcwp_phone'])) : '',
+        'date_from' => isset($_GET['wcwp_date_from']) ? sanitize_text_field(wp_unslash($_GET['wcwp_date_from'])) : '',
+        'date_to'   => isset($_GET['wcwp_date_to']) ? sanitize_text_field(wp_unslash($_GET['wcwp_date_to'])) : '',
+    ];
+
+    $limit = (int) apply_filters('wcwp_analytics_export_limit', 5000);
+    if ($limit < 1) $limit = 5000;
+
+    $events = wcwp_analytics_get_events($limit, $filters);
+
+    $filename = 'woochat-analytics-' . gmdate('Ymd-His') . '.csv';
+    nocache_headers();
+    header('Content-Type: text/csv; charset=utf-8');
+    header('Content-Disposition: attachment; filename="' . $filename . '"');
+
+    $out = fopen('php://output', 'w');
+    fputcsv($out, ['time', 'type', 'status', 'phone', 'order_id', 'provider', 'message_id', 'preview']);
+    foreach ($events as $evt) {
+        fputcsv($out, [
+            $evt['time'] ?? '',
+            $evt['type'] ?? '',
+            $evt['status'] ?? '',
+            $evt['phone'] ?? '',
+            $evt['order_id'] ?? '',
+            $evt['provider'] ?? '',
+            $evt['message_id'] ?? '',
+            $evt['message_preview'] ?? '',
+        ]);
+    }
+    fclose($out);
+    exit;
 }
 
 function wcwp_analytics_insert_event($event) {

--- a/tests/Unit/AnalyticsTest.php
+++ b/tests/Unit/AnalyticsTest.php
@@ -1,0 +1,128 @@
+<?php
+declare(strict_types=1);
+
+namespace WooChatPro\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class AnalyticsTest extends TestCase
+{
+    private function event(string $id, string $phone, int $time): array
+    {
+        return ['event_id' => $id, 'phone_norm' => $phone, 'time' => $time];
+    }
+
+    private function order(int $id, string $phone, int $time, float $total): array
+    {
+        return ['order_id' => $id, 'phone_norm' => $phone, 'time' => $time, 'total' => $total];
+    }
+
+    public function test_match_conversions_attributes_order_within_window(): void
+    {
+        $t = 1_700_000_000;
+        $events = [$this->event('e1', '15551234567', $t)];
+        $orders = [$this->order(101, '15551234567', $t + (2 * DAY_IN_SECONDS), 49.99)];
+
+        $result = \wcwp_analytics_match_conversions($events, $orders, 7 * DAY_IN_SECONDS);
+
+        $this->assertSame(1, $result['conversions']);
+        $this->assertEqualsWithDelta(49.99, $result['revenue'], 0.0001);
+        $this->assertSame(['e1'], array_values($result['matched']));
+    }
+
+    public function test_match_conversions_ignores_orders_outside_window(): void
+    {
+        $t = 1_700_000_000;
+        $events = [$this->event('e1', '15551234567', $t)];
+        $orders = [$this->order(101, '15551234567', $t + (8 * DAY_IN_SECONDS), 49.99)];
+
+        $result = \wcwp_analytics_match_conversions($events, $orders, 7 * DAY_IN_SECONDS);
+
+        $this->assertSame(0, $result['conversions']);
+        $this->assertSame(0.0, $result['revenue']);
+    }
+
+    public function test_match_conversions_ignores_orders_before_event(): void
+    {
+        $t = 1_700_000_000;
+        $events = [$this->event('e1', '15551234567', $t)];
+        // Pre-existing customer history — must not be attributed.
+        $orders = [$this->order(101, '15551234567', $t - 3600, 49.99)];
+
+        $result = \wcwp_analytics_match_conversions($events, $orders, 7 * DAY_IN_SECONDS);
+
+        $this->assertSame(0, $result['conversions']);
+    }
+
+    public function test_match_conversions_first_event_wins_for_shared_phone(): void
+    {
+        $t = 1_700_000_000;
+        // Two events to same phone. Only one matching order — earlier event claims it.
+        $events = [
+            $this->event('late',  '15551234567', $t + 3600),
+            $this->event('early', '15551234567', $t),
+        ];
+        $orders = [$this->order(101, '15551234567', $t + 7200, 25.0)];
+
+        $result = \wcwp_analytics_match_conversions($events, $orders, 7 * DAY_IN_SECONDS);
+
+        $this->assertSame(1, $result['conversions']);
+        $this->assertSame(['early'], array_values($result['matched']));
+    }
+
+    public function test_match_conversions_does_not_double_count_single_order(): void
+    {
+        $t = 1_700_000_000;
+        $events = [
+            $this->event('e1', '15551234567', $t),
+            $this->event('e2', '15551234567', $t + 60),
+        ];
+        $orders = [$this->order(101, '15551234567', $t + 3600, 30.0)];
+
+        $result = \wcwp_analytics_match_conversions($events, $orders, 7 * DAY_IN_SECONDS);
+
+        $this->assertSame(1, $result['conversions']);
+        $this->assertEqualsWithDelta(30.0, $result['revenue'], 0.0001);
+    }
+
+    public function test_match_conversions_two_phones_two_orders_two_conversions(): void
+    {
+        $t = 1_700_000_000;
+        $events = [
+            $this->event('e1', '15551111111', $t),
+            $this->event('e2', '15552222222', $t + 100),
+        ];
+        $orders = [
+            $this->order(101, '15551111111', $t + 3600, 10.0),
+            $this->order(102, '15552222222', $t + 7200, 20.0),
+        ];
+
+        $result = \wcwp_analytics_match_conversions($events, $orders, 7 * DAY_IN_SECONDS);
+
+        $this->assertSame(2, $result['conversions']);
+        $this->assertEqualsWithDelta(30.0, $result['revenue'], 0.0001);
+    }
+
+    public function test_match_conversions_zero_window_returns_empty(): void
+    {
+        $t = 1_700_000_000;
+        $events = [$this->event('e1', '15551234567', $t)];
+        $orders = [$this->order(101, '15551234567', $t + 60, 5.0)];
+
+        $result = \wcwp_analytics_match_conversions($events, $orders, 0);
+
+        $this->assertSame(0, $result['conversions']);
+        $this->assertSame(0.0, $result['revenue']);
+    }
+
+    public function test_match_conversions_skips_events_with_empty_phone(): void
+    {
+        $t = 1_700_000_000;
+        $events = [$this->event('e1', '', $t)];
+        $orders = [$this->order(101, '15551234567', $t + 60, 5.0)];
+
+        $result = \wcwp_analytics_match_conversions($events, $orders, DAY_IN_SECONDS);
+
+        $this->assertSame(0, $result['conversions']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -77,7 +77,12 @@ if (!function_exists('add_query_arg')) {
     }
 }
 
+if (!defined('DAY_IN_SECONDS')) {
+    define('DAY_IN_SECONDS', 86400);
+}
+
 require_once __DIR__ . '/../includes/helpers.php';
 require_once __DIR__ . '/../includes/cart-recovery.php';
 require_once __DIR__ . '/../includes/campaigns.php';
 require_once __DIR__ . '/../includes/blocks.php';
+require_once __DIR__ . '/../includes/analytics.php';


### PR DESCRIPTION
## Summary

Tier 3 #8 of the premium roadmap — four user-visible improvements to the analytics tab, all backed by the existing `wp_wcwp_analytics_events` table.

## What changed

**Date-range presets** — Quick-pick buttons (Today, Last 7 days, Last 30 days, This month, All time) above the filter row. Clicking a preset fills the from/to date inputs in local browser time and triggers the existing Filter button flow.

**CSV export** — New `admin_post_wcwp_analytics_export_csv` handler streams the current filter window as CSV (capped at 5000 rows, filterable via `wcwp_analytics_export_limit`). Capability + nonce gated. The Export CSV link's href is rebuilt on click so the filter inputs the admin sees on screen are what gets exported, even before they hit Filter.

**Per-template performance breakdown** — New `wcwp_analytics_get_per_type_breakdown()` aggregates events grouped by `type` (order / cart_recovery / followup / bulk / chatbot_gpt) and status. Rendered as a "Performance by template" table between the totals cards and the recent-events list. Counts respect the active filter window. Total column sums sent + delivered + clicked + failed (terminal states only — operational states like pending / test / opted_out excluded).

**Conversion attribution** — New `wcwp_analytics_get_conversions()` pulls eligible events (sent/delivered/clicked, phone present) in the filter window and joins them against WooCommerce orders by normalized phone within an attribution window (default 7 days, filterable via `wcwp_analytics_attribution_window_days`). Matching extracted into a pure helper, `wcwp_analytics_match_conversions()`, so it's testable without a database. Rules: first-event-wins for shared phones, no double-counting a single order, pre-event order history ignored. Wraps `wc_get_orders` so it's HPOS-compatible. Capped at 5000 events / 5000 orders — best-effort for very high-volume stores. Surfaced as a fourth totals card with order count and (when `wc_price` exists) attributed revenue.

## What stays the same

- Existing `wcwp_analytics_get_totals()` / `wcwp_analytics_get_events()` shape and behavior — both are still used by the totals cards and Recent Events list.
- Existing filter inputs and the Filter button JS flow.
- No schema migration: no new columns or tables. Per-template breakdown uses the existing `type` field; conversion attribution joins to WooCommerce orders at query time.
- No new credentials or external API calls.

## Test plan

- [ ] PHPUnit: 32 tests / 63 assertions green (`composer test`).
- [ ] PHPCS: clean against project ruleset (`composer lint`).
- [ ] Open Analytics tab — totals cards still render; new "Attributed orders" card shows current window.
- [ ] Click each preset (Today / 7d / 30d / This month / All time) — date inputs fill correctly and the page reloads with filtered data.
- [ ] Apply a phone or type filter, click Export CSV — file downloads with current filters honored, header row + matching events.
- [ ] "Performance by template" table populates with rows per type seen in the data.
- [ ] With WC orders present matching event phones within 7 days, the conversion card shows a non-zero count + revenue.
- [ ] Without WooCommerce active, conversion card shows 0 (defensive `function_exists('wc_get_orders')` guard).

## Risk / rollback

Low risk. Pure additions: 1 new admin_post handler, 4 new functions in `includes/analytics.php`, presentation-only rewrite of the analytics tab view, additive JS for presets + export-link sync. No changes to existing function signatures or DB schema. Rollback = revert the merge commit.