### PR TITLE
Template library — pre-written starters per industry & message kind

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -187,6 +187,10 @@ function wcwp_render_settings_page() {
     // Enqueue premium admin JS
     wp_enqueue_script('wcwp-admin-premium-js', WCWP_URL . 'assets/js/admin-premium.js', [], WCWP_VERSION, true);
     wp_enqueue_script('wcwp-campaigns-js', WCWP_URL . 'assets/js/campaigns.js', [], WCWP_VERSION, true);
+    wp_enqueue_script('wcwp-template-library-js', WCWP_URL . 'assets/js/template-library.js', [], WCWP_VERSION, true);
+    wp_localize_script('wcwp-template-library-js', 'wcwpTemplateLibraryI18n', [
+        'empty' => __('No templates available for this section yet.', 'woochat-pro'),
+    ]);
     wp_localize_script('wcwp-campaigns-js', 'wcwpCampaigns', [
         'ajaxUrl' => admin_url('admin-ajax.php'),
         'nonce'   => wp_create_nonce('wcwp_campaigns'),
@@ -388,6 +392,7 @@ function wcwp_render_settings_page() {
             <?php require $views . '/tab-license.php'; ?>
             <?php submit_button(); ?>
         </form>
+        <?php require $views . '/template-library-modal.php'; ?>
     </div>
     <div id="wcwp-upgrade-modal">
         <div class="wcwp-upgrade-modal-content">

--- a/admin/views/tab-cart-recovery.php
+++ b/admin/views/tab-cart-recovery.php
@@ -36,6 +36,12 @@ if (!defined('ABSPATH')) exit;
                     /* translators: do not translate placeholders inside curly braces */
                     esc_html_e('Use placeholders: {items}, {total}, {currency_symbol}, {cart_url}', 'woochat-pro');
                 ?></p>
+                <p style="margin-top:6px;">
+                    <button type="button" class="button wcwp-browse-templates" data-target="wcwp_cart_recovery_message" data-kind="cart_recovery">
+                        <span class="dashicons dashicons-book" style="vertical-align:middle;line-height:28px;"></span>
+                        <?php esc_html_e('Browse template library', 'woochat-pro'); ?>
+                    </button>
+                </p>
             </td>
         </tr>
     </table>

--- a/admin/views/tab-messaging.php
+++ b/admin/views/tab-messaging.php
@@ -20,11 +20,17 @@ if (!defined('ABSPATH')) exit;
         <tr>
             <th scope="row"><label for="wcwp_order_message_template"><?php esc_html_e('Order Message Template', 'woochat-pro'); ?></label><span class="wcwp-help-icon">?<span class="wcwp-tooltip"><?php esc_html_e('Customize the WhatsApp message sent for new orders. Use placeholders: {name}, {order_id}, {total}, {currency_symbol}', 'woochat-pro'); ?></span></span></th>
             <td>
-                <textarea name="wcwp_order_message_template" rows="5" class="large-text"><?php echo esc_textarea(get_option('wcwp_order_message_template', 'Hi {name}, thanks for your order #{order_id}! Total: {total} {currency_symbol}.')); ?></textarea>
+                <textarea id="wcwp_order_message_template" name="wcwp_order_message_template" rows="5" class="large-text"><?php echo esc_textarea(get_option('wcwp_order_message_template', 'Hi {name}, thanks for your order #{order_id}! Total: {total} {currency_symbol}.')); ?></textarea>
                 <p class="description"><?php
                     /* translators: do not translate placeholders inside curly braces */
                     esc_html_e('Use placeholders: {name}, {order_id}, {total}, {currency_symbol}', 'woochat-pro');
                 ?></p>
+                <p style="margin-top:6px;">
+                    <button type="button" class="button wcwp-browse-templates" data-target="wcwp_order_message_template" data-kind="order">
+                        <span class="dashicons dashicons-book" style="vertical-align:middle;line-height:28px;"></span>
+                        <?php esc_html_e('Browse template library', 'woochat-pro'); ?>
+                    </button>
+                </p>
             </td>
         </tr>
     </table>

--- a/admin/views/tab-scheduler.php
+++ b/admin/views/tab-scheduler.php
@@ -29,6 +29,12 @@ if (!defined('ABSPATH')) exit;
             <td>
                 <textarea name="wcwp_followup_template" id="wcwp_followup_template" rows="5" class="large-text" <?php disabled(!$is_pro); ?>><?php echo esc_textarea(get_option('wcwp_followup_template', "Hi {name}, thanks again for your order #{order_id}! Reply if you have any questions.")); ?></textarea>
                 <p class="description"><?php esc_html_e('Sent once per order after the delay.', 'woochat-pro'); ?></p>
+                <p style="margin-top:6px;">
+                    <button type="button" class="button wcwp-browse-templates" data-target="wcwp_followup_template" data-kind="followup" <?php disabled(!$is_pro); ?>>
+                        <span class="dashicons dashicons-book" style="vertical-align:middle;line-height:28px;"></span>
+                        <?php esc_html_e('Browse template library', 'woochat-pro'); ?>
+                    </button>
+                </p>
             </td>
         </tr>
         <tr>

--- a/admin/views/template-library-modal.php
+++ b/admin/views/template-library-modal.php
@@ -1,0 +1,39 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+$wcwp_template_library = wcwp_get_template_library();
+?>
+<div id="wcwp-template-library-modal" class="wcwp-template-library-modal" style="display:none;" aria-hidden="true">
+    <div class="wcwp-template-library-overlay"></div>
+    <div class="wcwp-template-library-dialog" role="dialog" aria-modal="true" aria-labelledby="wcwp-template-library-title">
+        <header class="wcwp-template-library-header">
+            <h2 id="wcwp-template-library-title"><?php esc_html_e('Template library', 'woochat-pro'); ?></h2>
+            <p class="wcwp-template-library-subtitle"><?php esc_html_e('Pick a starter and tweak it to taste. Placeholders inside curly braces are filled in automatically when the message is sent.', 'woochat-pro'); ?></p>
+            <button type="button" class="wcwp-template-library-close" aria-label="<?php esc_attr_e('Close', 'woochat-pro'); ?>">&times;</button>
+        </header>
+        <div class="wcwp-template-library-body">
+            <?php
+            foreach ($wcwp_template_library as $industry_id => $industry) :
+                $industry_label = isset($industry['label']) ? (string) $industry['label'] : (string) $industry_id;
+                $templates = isset($industry['templates']) && is_array($industry['templates']) ? $industry['templates'] : [];
+                foreach ($templates as $t) :
+                    $kind = isset($t['kind']) ? (string) $t['kind'] : '';
+                    $name = isset($t['name']) ? (string) $t['name'] : '';
+                    $body = isset($t['body']) ? (string) $t['body'] : '';
+                    if ($kind === '' || $body === '') continue;
+            ?>
+                <article class="wcwp-template-card" data-kind="<?php echo esc_attr($kind); ?>" data-industry="<?php echo esc_attr($industry_id); ?>">
+                    <div class="wcwp-template-card-meta">
+                        <span class="wcwp-template-industry"><?php echo esc_html($industry_label); ?></span>
+                        <h3 class="wcwp-template-name"><?php echo esc_html($name); ?></h3>
+                    </div>
+                    <pre class="wcwp-template-body"><?php echo esc_html($body); ?></pre>
+                    <button type="button" class="button button-primary wcwp-template-use" data-body="<?php echo esc_attr($body); ?>"><?php esc_html_e('Use this template', 'woochat-pro'); ?></button>
+                </article>
+            <?php
+                endforeach;
+            endforeach;
+            ?>
+        </div>
+    </div>
+</div>

--- a/assets/css/admin-premium.css
+++ b/assets/css/admin-premium.css
@@ -639,4 +639,135 @@
 .wcwp-dark-mode .wcwp-dark-toggle .wcwp-dark-icon {
   transform: rotate(180deg) scale(1.2);
   color: #23272b;
-} 
+}
+
+/* Template Library Modal */
+.wcwp-template-library-modal {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  z-index: 99998;
+}
+.wcwp-template-library-overlay {
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(44,62,80,0.45);
+}
+.wcwp-template-library-dialog {
+  position: relative;
+  background: #fff;
+  border-radius: 14px;
+  box-shadow: 0 12px 40px rgba(44,62,80,0.25);
+  width: min(900px, 92vw);
+  max-height: 86vh;
+  margin: 5vh auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.wcwp-template-library-header {
+  padding: 20px 28px 14px;
+  border-bottom: 1px solid #ececec;
+}
+.wcwp-template-library-header h2 {
+  color: #1c7c54;
+  margin: 0 0 4px 0;
+  font-size: 1.4rem;
+}
+.wcwp-template-library-subtitle {
+  color: #666;
+  margin: 0;
+  font-size: 0.95rem;
+}
+.wcwp-template-library-close {
+  position: absolute;
+  top: 14px; right: 18px;
+  font-size: 1.6rem;
+  color: #888;
+  background: none;
+  border: none;
+  cursor: pointer;
+  line-height: 1;
+}
+.wcwp-template-library-body {
+  padding: 18px 28px 24px;
+  overflow-y: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 14px;
+}
+.wcwp-template-card {
+  background: #f9fbfa;
+  border: 1px solid #e5ece8;
+  border-radius: 10px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.wcwp-template-card-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.wcwp-template-industry {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #2ec4b6;
+  font-weight: 600;
+}
+.wcwp-template-name {
+  margin: 0;
+  font-size: 1.02rem;
+  color: #1c7c54;
+}
+.wcwp-template-body {
+  background: #fff;
+  border: 1px solid #ececec;
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 0.92em;
+  line-height: 1.45;
+  white-space: pre-line;
+  word-break: break-word;
+  margin: 0;
+  max-height: 180px;
+  overflow-y: auto;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+.wcwp-template-use {
+  align-self: flex-start;
+}
+.wcwp-template-library-empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  color: #888;
+  font-style: italic;
+  padding: 20px 0;
+}
+body.wcwp-template-library-open {
+  overflow: hidden;
+}
+.wcwp-dark-mode .wcwp-template-library-dialog {
+  background: #181c1f;
+  color: #e5e5e5;
+}
+.wcwp-dark-mode .wcwp-template-library-header {
+  border-bottom-color: #23272b;
+}
+.wcwp-dark-mode .wcwp-template-library-header h2,
+.wcwp-dark-mode .wcwp-template-name {
+  color: #2ec4b6;
+}
+.wcwp-dark-mode .wcwp-template-library-subtitle {
+  color: #b2f7ef;
+}
+.wcwp-dark-mode .wcwp-template-card {
+  background: #23272b;
+  border-color: #2ec4b6;
+}
+.wcwp-dark-mode .wcwp-template-body {
+  background: #181c1f;
+  border-color: #2ec4b6;
+  color: #e5e5e5;
+}

--- a/assets/js/template-library.js
+++ b/assets/js/template-library.js
@@ -1,0 +1,95 @@
+// WooChat Pro – Template Library modal
+//
+// Wires the "Browse template library" button next to each message
+// textarea (Order, Cart Recovery, Follow-up) to a single shared modal
+// that filters its template cards to the kind requested by the
+// triggering button. Clicking "Use this template" populates the
+// originating textarea — admin still has to hit WP's Save Changes to
+// persist.
+
+(function () {
+    function open(modal) {
+        modal.style.display = 'block';
+        modal.setAttribute('aria-hidden', 'false');
+        document.body.classList.add('wcwp-template-library-open');
+    }
+
+    function close(modal) {
+        modal.style.display = 'none';
+        modal.setAttribute('aria-hidden', 'true');
+        document.body.classList.remove('wcwp-template-library-open');
+        modal.removeAttribute('data-target-id');
+    }
+
+    function applyFilter(modal, kind) {
+        const cards = modal.querySelectorAll('.wcwp-template-card');
+        let visible = 0;
+        cards.forEach(function (card) {
+            const match = !kind || card.getAttribute('data-kind') === kind;
+            card.style.display = match ? '' : 'none';
+            if (match) visible++;
+        });
+
+        let empty = modal.querySelector('.wcwp-template-library-empty');
+        if (!empty) {
+            empty = document.createElement('p');
+            empty.className = 'wcwp-template-library-empty';
+            empty.textContent = '';
+            const body = modal.querySelector('.wcwp-template-library-body');
+            if (body) body.appendChild(empty);
+        }
+        empty.style.display = visible === 0 ? '' : 'none';
+        if (visible === 0) {
+            empty.textContent =
+                (window.wcwpTemplateLibraryI18n && wcwpTemplateLibraryI18n.empty) ||
+                'No templates available for this section yet.';
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        const modal = document.getElementById('wcwp-template-library-modal');
+        if (!modal) return;
+
+        const closeBtn = modal.querySelector('.wcwp-template-library-close');
+        const overlay = modal.querySelector('.wcwp-template-library-overlay');
+
+        document.querySelectorAll('.wcwp-browse-templates').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                const targetId = btn.getAttribute('data-target') || '';
+                const kind = btn.getAttribute('data-kind') || '';
+                modal.setAttribute('data-target-id', targetId);
+                applyFilter(modal, kind);
+                open(modal);
+            });
+        });
+
+        modal.querySelectorAll('.wcwp-template-use').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                const targetId = modal.getAttribute('data-target-id');
+                const body = btn.getAttribute('data-body') || '';
+                if (!targetId) {
+                    close(modal);
+                    return;
+                }
+                const target = document.getElementById(targetId);
+                if (target) {
+                    target.value = body;
+                    target.dispatchEvent(new Event('change', { bubbles: true }));
+                    target.focus();
+                    if (target.scrollIntoView) {
+                        target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                    }
+                }
+                close(modal);
+            });
+        });
+
+        if (closeBtn) closeBtn.addEventListener('click', function () { close(modal); });
+        if (overlay) overlay.addEventListener('click', function () { close(modal); });
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape' && modal.style.display === 'block') {
+                close(modal);
+            }
+        });
+    });
+})();

--- a/includes/class-wcwp-plugin.php
+++ b/includes/class-wcwp-plugin.php
@@ -80,6 +80,7 @@ final class Plugin {
         require_once WCWP_PATH . 'includes/messaging.php';
 
         require_once WCWP_PATH . 'includes/analytics.php';
+        require_once WCWP_PATH . 'includes/template-library.php';
         require_once WCWP_PATH . 'admin/settings-page.php';
         require_once WCWP_PATH . 'includes/chatbot-engine.php';
         require_once WCWP_PATH . 'includes/license-manager.php';

--- a/includes/template-library.php
+++ b/includes/template-library.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * Pre-written template library.
+ *
+ * Static catalog of WhatsApp message starters organised by industry ×
+ * message kind (order / cart_recovery / followup). Surfaced on the admin
+ * tabs as a "Browse template library" modal next to each textarea so a
+ * fresh install has a sensible starting point instead of staring at a
+ * blank box.
+ *
+ * Adding a new industry, kind, or template is a one-stop edit here; the
+ * modal UI iterates whatever wcwp_get_template_library() returns.
+ *
+ * Each template entry:
+ *   - kind: 'order' | 'cart_recovery' | 'followup'
+ *   - name: short label shown on the card (translated)
+ *   - body: message body with WooChat placeholders (translated)
+ *
+ * Placeholders by kind (matching what the existing dispatchers
+ * substitute — see tab-messaging.php / tab-cart-recovery.php /
+ * tab-scheduler.php):
+ *   - order:         {name}, {order_id}, {total}, {currency_symbol}
+ *   - cart_recovery: {items}, {total}, {currency_symbol}, {cart_url}
+ *   - followup:      {name}, {order_id}, {total}, {currency_symbol},
+ *                    {status}, {date}
+ */
+
+if (!defined('ABSPATH')) exit;
+
+/**
+ * Return the full template library, grouped by industry.
+ *
+ * @return array<string, array{label:string, templates: array<int, array{kind:string,name:string,body:string}>}>
+ */
+function wcwp_get_template_library() {
+    $library = [
+        'fashion' => [
+            'label'     => __('Fashion & Apparel', 'woochat-pro'),
+            'templates' => [
+                [
+                    'kind' => 'order',
+                    'name' => __('Stylish confirmation', 'woochat-pro'),
+                    'body' => __("Hi {name}! 👗 Your order #{order_id} is confirmed — total {total} {currency_symbol}. We'll text you the moment it ships ✨", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'order',
+                    'name' => __('VIP packing', 'woochat-pro'),
+                    'body' => __("Thanks {name}! Order #{order_id} ({total} {currency_symbol}) is being styled and packed with care. 💌", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'order',
+                    'name' => __('Drop-in confirmation', 'woochat-pro'),
+                    'body' => __("Yay {name}! 🛍️ Order #{order_id} for {total} {currency_symbol} is in. New favourites incoming!", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'cart_recovery',
+                    'name' => __('FOMO nudge', 'woochat-pro'),
+                    'body' => __("Hey, these gems are still waiting in your bag 👀\n\n{items}\n\nTotal: {total} {currency_symbol}\nGrab them before they sell out → {cart_url}", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'cart_recovery',
+                    'name' => __('Wishlist saved', 'woochat-pro'),
+                    'body' => __("Don't miss out — your wishlist items are saved:\n\n{items}\n\nTotal: {total} {currency_symbol}\nCheckout in seconds: {cart_url}", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'cart_recovery',
+                    'name' => __('Friendly reminder', 'woochat-pro'),
+                    'body' => __("👋 Quick reminder — your cart is saved.\n\n{items}\nTotal: {total} {currency_symbol}\n{cart_url}", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'followup',
+                    'name' => __('Loving the look?', 'woochat-pro'),
+                    'body' => __("Hey {name}! 👋 How are you loving order #{order_id}? Reply with a 💖 if you want first dibs on next drops!", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'followup',
+                    'name' => __('Quick review ask', 'woochat-pro'),
+                    'body' => __("Hi {name}! It's been a few days since order #{order_id} — we'd love to hear what you think. Got a sec for a quick review?", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'followup',
+                    'name' => __('VIP invite', 'woochat-pro'),
+                    'body' => __("{name}! Hope you're rocking your new pieces 🌟 Order #{order_id} treating you well? Reply YES to join our VIP list.", 'woochat-pro'),
+                ],
+            ],
+        ],
+        'food' => [
+            'label'     => __('Food & Restaurants', 'woochat-pro'),
+            'templates' => [
+                [
+                    'kind' => 'order',
+                    'name' => __('Order received', 'woochat-pro'),
+                    'body' => __("Hi {name}! 🍽️ Order #{order_id} is in — total {total} {currency_symbol}. We'll let you know when it's on the way.", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'order',
+                    'name' => __('Cooking now', 'woochat-pro'),
+                    'body' => __("Thanks {name}! Order #{order_id} ({total} {currency_symbol}) is being prepared fresh. ETA in your confirmation email.", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'order',
+                    'name' => __('Made with love', 'woochat-pro'),
+                    'body' => __("{name}, order received! 👨‍🍳 #{order_id} for {total} {currency_symbol}. Cooking with love.", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'cart_recovery',
+                    'name' => __('Hungry yet?', 'woochat-pro'),
+                    'body' => __("Hi! Hungry yet? 🍽️\n\nYour cart:\n{items}\n\nTotal: {total} {currency_symbol}\nFinish your order: {cart_url}", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'cart_recovery',
+                    'name' => __('Selection saved', 'woochat-pro'),
+                    'body' => __("Still thinking about it? Your selection is saved:\n\n{items}\n\nTotal: {total} {currency_symbol}\n{cart_url}", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'cart_recovery',
+                    'name' => __('Quick checkout', 'woochat-pro'),
+                    'body' => __("Quick reminder! 🛒\n\n{items}\nTotal: {total} {currency_symbol}\n\nCheckout in 30 seconds: {cart_url}", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'followup',
+                    'name' => __('How was the meal?', 'woochat-pro'),
+                    'body' => __("Hi {name}! Hope you enjoyed order #{order_id}. We'd love a quick review — reply with anything from 1-5 ⭐", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'followup',
+                    'name' => __('Favourites for next time', 'woochat-pro'),
+                    'body' => __("Hey {name}! 🍴 How was your meal from order #{order_id}? Got any favourites you'd like next time?", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'followup',
+                    'name' => __('Specials opt-in', 'woochat-pro'),
+                    'body' => __("{name}, thanks again for ordering with us! Order #{order_id} treating you well? Reply YES if you'd like to hear about specials.", 'woochat-pro'),
+                ],
+            ],
+        ],
+        'services' => [
+            'label'     => __('Services & Consulting', 'woochat-pro'),
+            'templates' => [
+                [
+                    'kind' => 'order',
+                    'name' => __('Booking confirmed', 'woochat-pro'),
+                    'body' => __("Hi {name}, thank you for your booking. Reference #{order_id}, total {total} {currency_symbol}. Confirmation details have been emailed to you.", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'order',
+                    'name' => __('Next steps incoming', 'woochat-pro'),
+                    'body' => __("Hello {name}, your order #{order_id} for {total} {currency_symbol} has been received. We will be in touch shortly to confirm next steps.", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'order',
+                    'name' => __('Open line', 'woochat-pro'),
+                    'body' => __("Thank you {name}. Order #{order_id} ({total} {currency_symbol}) is confirmed. Please reply if you have any questions.", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'cart_recovery',
+                    'name' => __('Unfinished booking', 'woochat-pro'),
+                    'body' => __("Hi, you have an unfinished booking with us:\n\n{items}\n\nTotal: {total} {currency_symbol}\n\nResume here: {cart_url}", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'cart_recovery',
+                    'name' => __('Selection saved', 'woochat-pro'),
+                    'body' => __("Hello, just a friendly reminder that your selection is still saved:\n\n{items}\n\nTotal: {total} {currency_symbol}\nComplete your booking: {cart_url}", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'cart_recovery',
+                    'name' => __('Time-limited hold', 'woochat-pro'),
+                    'body' => __("Reminder: your cart is held for a limited time.\n\n{items}\nTotal: {total} {currency_symbol}\n{cart_url}", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'followup',
+                    'name' => __('Open for questions', 'woochat-pro'),
+                    'body' => __("Hi {name}, thank you again for choosing us. If you have any questions about order #{order_id}, simply reply to this message.", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'followup',
+                    'name' => __('Feedback request', 'woochat-pro'),
+                    'body' => __("Hello {name}, we hope everything went smoothly with order #{order_id}. We would appreciate any feedback you can share.", 'woochat-pro'),
+                ],
+                [
+                    'kind' => 'followup',
+                    'name' => __("What's next?", 'woochat-pro'),
+                    'body' => __("{name}, thanks for trusting us with your project. Order #{order_id} is now complete on our end. Let us know how we can help next.", 'woochat-pro'),
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * Filter the template library before it is consumed.
+     *
+     * Lets a third party register a new industry or replace the default
+     * copy without touching core. Each industry must have a `label`
+     * (string) and `templates` (array of templates with kind/name/body).
+     *
+     * @param array $library Industry-keyed library.
+     */
+    return (array) apply_filters('wcwp_template_library', $library);
+}
+
+/**
+ * Return all templates of a given kind, flattened across industries.
+ *
+ * Each returned entry adds `industry_id` and `industry_label` so the
+ * caller can group / label without re-walking the library.
+ *
+ * @param string $kind One of: order, cart_recovery, followup.
+ * @return array<int, array{kind:string,name:string,body:string,industry_id:string,industry_label:string}>
+ */
+function wcwp_get_templates_by_kind($kind) {
+    $kind = is_string($kind) ? trim($kind) : '';
+    if ($kind === '') return [];
+
+    $library = wcwp_get_template_library();
+    $out = [];
+    foreach ($library as $industry_id => $industry) {
+        $label = isset($industry['label']) ? (string) $industry['label'] : (string) $industry_id;
+        $templates = isset($industry['templates']) && is_array($industry['templates']) ? $industry['templates'] : [];
+        foreach ($templates as $t) {
+            if (($t['kind'] ?? '') !== $kind) continue;
+            $out[] = [
+                'kind'           => (string) $t['kind'],
+                'name'           => (string) ($t['name'] ?? ''),
+                'body'           => (string) ($t['body'] ?? ''),
+                'industry_id'    => (string) $industry_id,
+                'industry_label' => $label,
+            ];
+        }
+    }
+    return $out;
+}

--- a/tests/Unit/TemplateLibraryTest.php
+++ b/tests/Unit/TemplateLibraryTest.php
@@ -1,0 +1,102 @@
+<?php
+declare(strict_types=1);
+
+namespace WooChatPro\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class TemplateLibraryTest extends TestCase
+{
+    public function test_library_has_at_least_three_industries(): void
+    {
+        $library = \wcwp_get_template_library();
+        $this->assertIsArray($library);
+        $this->assertGreaterThanOrEqual(3, count($library), 'Library should ship with at least three industries.');
+    }
+
+    public function test_each_industry_has_label_and_templates(): void
+    {
+        $library = \wcwp_get_template_library();
+        foreach ($library as $industry_id => $industry) {
+            $this->assertArrayHasKey('label', $industry, "Industry $industry_id missing label.");
+            $this->assertNotSame('', $industry['label']);
+            $this->assertArrayHasKey('templates', $industry, "Industry $industry_id missing templates.");
+            $this->assertIsArray($industry['templates']);
+            $this->assertNotEmpty($industry['templates'], "Industry $industry_id has no templates.");
+        }
+    }
+
+    public function test_each_template_has_required_fields_and_known_kind(): void
+    {
+        $library = \wcwp_get_template_library();
+        $valid_kinds = ['order', 'cart_recovery', 'followup'];
+        foreach ($library as $industry_id => $industry) {
+            foreach ($industry['templates'] as $i => $t) {
+                $where = "$industry_id template #$i";
+                $this->assertArrayHasKey('kind', $t, "$where missing kind.");
+                $this->assertContains($t['kind'], $valid_kinds, "$where has unknown kind '{$t['kind']}'.");
+                $this->assertArrayHasKey('name', $t, "$where missing name.");
+                $this->assertNotSame('', $t['name'], "$where has empty name.");
+                $this->assertArrayHasKey('body', $t, "$where missing body.");
+                $this->assertNotSame('', $t['body'], "$where has empty body.");
+            }
+        }
+    }
+
+    public function test_each_industry_covers_all_three_kinds(): void
+    {
+        $library = \wcwp_get_template_library();
+        foreach ($library as $industry_id => $industry) {
+            $kinds = array_unique(array_column($industry['templates'], 'kind'));
+            sort($kinds);
+            $this->assertSame(
+                ['cart_recovery', 'followup', 'order'],
+                $kinds,
+                "Industry $industry_id should have at least one template of each kind."
+            );
+        }
+    }
+
+    public function test_get_templates_by_kind_returns_only_matching_kind(): void
+    {
+        $orders = \wcwp_get_templates_by_kind('order');
+        $this->assertNotEmpty($orders);
+        foreach ($orders as $t) {
+            $this->assertSame('order', $t['kind']);
+            $this->assertArrayHasKey('industry_id', $t);
+            $this->assertArrayHasKey('industry_label', $t);
+            $this->assertNotSame('', $t['industry_label']);
+        }
+    }
+
+    public function test_get_templates_by_kind_returns_empty_for_unknown_kind(): void
+    {
+        $this->assertSame([], \wcwp_get_templates_by_kind('does-not-exist'));
+    }
+
+    public function test_get_templates_by_kind_returns_empty_for_blank_input(): void
+    {
+        $this->assertSame([], \wcwp_get_templates_by_kind(''));
+    }
+
+    public function test_cart_recovery_templates_reference_cart_url_placeholder(): void
+    {
+        // Sanity check: cart_recovery messages without {cart_url} would
+        // ship without a clickable link to the cart, defeating the
+        // purpose of the message.
+        $cart = \wcwp_get_templates_by_kind('cart_recovery');
+        $this->assertNotEmpty($cart);
+        foreach ($cart as $t) {
+            $this->assertStringContainsString('{cart_url}', $t['body'], "Cart recovery template '{$t['name']}' missing {cart_url} placeholder.");
+        }
+    }
+
+    public function test_followup_templates_reference_order_id_placeholder(): void
+    {
+        $followup = \wcwp_get_templates_by_kind('followup');
+        $this->assertNotEmpty($followup);
+        foreach ($followup as $t) {
+            $this->assertStringContainsString('{order_id}', $t['body'], "Follow-up template '{$t['name']}' missing {order_id} placeholder.");
+        }
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -86,3 +86,4 @@ require_once __DIR__ . '/../includes/cart-recovery.php';
 require_once __DIR__ . '/../includes/campaigns.php';
 require_once __DIR__ . '/../includes/blocks.php';
 require_once __DIR__ . '/../includes/analytics.php';
+require_once __DIR__ . '/../includes/template-library.php';


### PR DESCRIPTION
## Summary

Tier 3 #9 of the premium roadmap. Pre-written WhatsApp message starters organised by industry × message kind, surfaced as a "Browse template library" button next to each editable textarea (Order / Cart Recovery / Follow-up). Reduces time-to-value for fresh installs by giving admins a sensible starting point instead of a blank box.

## What changed

**Library content** — Three industries × 3 message kinds × 3 templates = 27 starters. Industries: Fashion & Apparel (playful, emoji-heavy), Food & Restaurants (warm, casual), Services & Consulting (professional, direct). Per-kind copy uses the exact placeholders the dispatchers already substitute.

**Catalog API** — New `includes/template-library.php` exports two pure functions:
- `wcwp_get_template_library()` returns the industry-keyed catalog, filterable via `wcwp_template_library` so a third party can register a new industry without touching core.
- `wcwp_get_templates_by_kind($kind)` flattens to one kind across industries with `industry_id` / `industry_label` tagged on each row.

No DB writes — purely in-memory data.

**Modal UI** — Single shared partial at `admin/views/template-library-modal.php` rendered once at the bottom of the settings page. Each Browse button carries `data-target` (textarea id) + `data-kind`; JS filters cards on open. "Use this template" populates the originating textarea (admin still hits Save Changes to persist), fires a `change` event for any external listeners, and scrolls the textarea into view. Closes on overlay click, × button, or Escape key. Brand-green styling matches the existing upgrade modal; dark-mode rules added.

**Wiring**
- Order textarea in `tab-messaging.php` gained an `id` attribute (was `name`-only) so JS can target it.
- Browse buttons added to `tab-messaging.php` / `tab-cart-recovery.php` / `tab-scheduler.php`. Scheduler button inherits the existing `$is_pro` disabled gate.
- `Plugin::boot_modules()` loads `template-library.php`; settings page enqueues `template-library.js` with a localized i18n payload for the empty-state string.

## What stays the same

- All existing default template strings (no migration of saved options — this only changes what fresh installs see when clicking "Browse").
- Placeholder substitution logic in `cart-recovery.php` / `order-hooks.php` / `scheduler.php`.
- The campaigns-tab textarea is intentionally untouched — campaigns use a different placeholder set (`{site}` not order placeholders) and a separate template library is out of scope.

## Test plan

- [x] PHPUnit: 41 tests / 305 assertions green (`composer test`).
- [x] PHPCS: clean against project ruleset (`composer lint`).
- [x] On the Messaging tab, click "Browse template library" — modal opens showing 9 cards (3 industries × 3 order templates).
- [x] Click "Use this template" on any card — modal closes, the Order textarea is populated, page scrolls to it.
- [x] Repeat on Cart Recovery and Scheduler tabs — only matching-kind cards appear in each.
- [x] Press Escape / click overlay / click × — modal closes.
- [x] On a free (non-Pro) install, the Scheduler Browse button is disabled (matches the textarea's existing `disabled` state).
- [x] In dark mode (toggle in admin), modal styling adapts.

## Risk / rollback

Low risk. Pure additions: new include with two functions, new modal partial, new JS file, three additive button blocks in existing tab views, additive CSS section. No DB schema changes, no changes to existing function signatures, no changes to runtime message-sending paths. The Order textarea gained an `id` attribute — this is additive, no consumer of the existing `name` attribute is affected. Rollback = revert the merge commit.