### PR TITLE
Template A/B testing — 50/50 split + per-variant conversion attribution

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -57,6 +57,12 @@ function wcwp_register_settings() {
     register_setting('wcwp_settings_group', 'wcwp_optout_webhook_token', ['sanitize_callback' => 'wcwp_sanitize_text']);
     register_setting('wcwp_settings_group', 'wcwp_test_phone', ['sanitize_callback' => 'wcwp_sanitize_text']);
     register_setting('wcwp_settings_group', 'wcwp_test_message', ['sanitize_callback' => 'wcwp_sanitize_textarea']);
+    register_setting('wcwp_settings_group', 'wcwp_order_message_template_b', ['sanitize_callback' => 'wcwp_sanitize_textarea']);
+    register_setting('wcwp_settings_group', 'wcwp_cart_recovery_message_b', ['sanitize_callback' => 'wcwp_sanitize_textarea']);
+    register_setting('wcwp_settings_group', 'wcwp_followup_template_b', ['sanitize_callback' => 'wcwp_sanitize_textarea']);
+    register_setting('wcwp_settings_group', 'wcwp_order_message_ab_enabled', ['sanitize_callback' => 'wcwp_sanitize_yes_no']);
+    register_setting('wcwp_settings_group', 'wcwp_cart_recovery_ab_enabled', ['sanitize_callback' => 'wcwp_sanitize_yes_no']);
+    register_setting('wcwp_settings_group', 'wcwp_followup_ab_enabled', ['sanitize_callback' => 'wcwp_sanitize_yes_no']);
 }
 
 add_action('wp_ajax_wcwp_dismiss_onboarding', 'wcwp_ajax_dismiss_onboarding');

--- a/admin/views/tab-analytics.php
+++ b/admin/views/tab-analytics.php
@@ -132,6 +132,87 @@ if (!defined('ABSPATH')) exit;
             <?php endif; ?>
         </tbody>
     </table>
+    <h3 style="margin-top:24px;"><?php esc_html_e('A/B test results', 'woochat-pro'); ?></h3>
+    <?php
+    $ab_kinds_cfg = wcwp_ab_kinds();
+    $ab_any_enabled = false;
+    foreach ($ab_kinds_cfg as $ab_kind => $ab_cfg) {
+        if (get_option($ab_cfg['option_enabled'], 'no') === 'yes') {
+            $ab_any_enabled = true;
+            break;
+        }
+    }
+    ?>
+    <?php if (!$ab_any_enabled) : ?>
+        <p class="description" style="margin-top:8px;"><?php esc_html_e('No A/B tests are running. Turn on "A/B test this message" on the Messaging, Cart Recovery, or Scheduler tabs to start measuring.', 'woochat-pro'); ?></p>
+    <?php else : ?>
+        <table class="widefat striped" style="margin-top:10px;">
+            <thead>
+                <tr>
+                    <th><?php esc_html_e('Test', 'woochat-pro'); ?></th>
+                    <th><?php esc_html_e('Variant', 'woochat-pro'); ?></th>
+                    <th><?php esc_html_e('Sent', 'woochat-pro'); ?></th>
+                    <th><?php esc_html_e('Conversions', 'woochat-pro'); ?></th>
+                    <th><?php esc_html_e('Conv. rate', 'woochat-pro'); ?></th>
+                    <th><?php esc_html_e('Revenue', 'woochat-pro'); ?></th>
+                    <th><?php esc_html_e('Outcome', 'woochat-pro'); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($ab_kinds_cfg as $ab_kind => $ab_cfg) :
+                    if (get_option($ab_cfg['option_enabled'], 'no') !== 'yes') continue;
+                    $ab_results = wcwp_ab_get_results($ab_kind, $filters);
+                    foreach (['a', 'b'] as $variant) :
+                        $row = $ab_results[$variant];
+                        $is_winner = $ab_results['winner'] === $variant;
+                ?>
+                    <tr>
+                        <?php if ($variant === 'a') : ?>
+                            <td rowspan="2"><strong><?php echo esc_html($ab_cfg['label']); ?></strong></td>
+                        <?php endif; ?>
+                        <td><?php echo esc_html(strtoupper($variant)); ?><?php if ($is_winner) : ?> <span style="color:#1c7c54;font-weight:600;">★</span><?php endif; ?></td>
+                        <td><?php echo esc_html((string) $row['sent']); ?></td>
+                        <td><?php echo esc_html((string) $row['conversions']); ?></td>
+                        <td><?php echo esc_html(number_format_i18n($row['cvr'] * 100, 1) . '%'); ?></td>
+                        <td><?php
+                            if ($row['revenue'] > 0 && function_exists('wc_price')) {
+                                echo wp_kses_post(wc_price($row['revenue']));
+                            } else {
+                                echo esc_html(number_format_i18n($row['revenue'], 2));
+                            }
+                        ?></td>
+                        <?php if ($variant === 'a') :
+                            if ($ab_results['winner'] === null) {
+                                $outcome = sprintf(
+                                    /* translators: %d is the minimum sample size per variant before declaring a winner */
+                                    esc_html__('Insufficient data (need %d sends per variant)', 'woochat-pro'),
+                                    (int) apply_filters('wcwp_ab_min_sample_size', 30)
+                                );
+                            } else {
+                                $outcome = sprintf(
+                                    /* translators: %s is the winning variant letter (A or B) */
+                                    esc_html__('Variant %s leads', 'woochat-pro'),
+                                    strtoupper($ab_results['winner'])
+                                );
+                            }
+                        ?>
+                            <td rowspan="2"><?php echo $outcome; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped via esc_html__ inside sprintf above. ?></td>
+                        <?php endif; ?>
+                    </tr>
+                <?php endforeach; endforeach; ?>
+            </tbody>
+        </table>
+        <p class="description" style="margin-top:6px;">
+            <?php
+            /* translators: %d is the attribution window in days */
+            printf(
+                esc_html__('Conversions count orders placed within %d days of the message by the same phone number — the same attribution window the totals card uses.', 'woochat-pro'),
+                (int) apply_filters('wcwp_analytics_attribution_window_days', 7)
+            );
+            ?>
+        </p>
+    <?php endif; ?>
+
     <h3 style="margin-top:20px;"><?php esc_html_e('Recent Events', 'woochat-pro'); ?></h3>
     <table class="widefat striped" style="margin-top:10px;">
         <thead>

--- a/admin/views/tab-cart-recovery.php
+++ b/admin/views/tab-cart-recovery.php
@@ -44,6 +44,36 @@ if (!defined('ABSPATH')) exit;
                 </p>
             </td>
         </tr>
+        <?php
+        $cart_ab_enabled = get_option('wcwp_cart_recovery_ab_enabled', 'no');
+        $cart_message_b  = get_option('wcwp_cart_recovery_message_b', '');
+        ?>
+        <tr class="wcwp-ab-row" data-ab-kind="cart_recovery">
+            <th scope="row"><label for="wcwp_cart_recovery_ab_enabled"><?php esc_html_e('A/B test this message', 'woochat-pro'); ?></label><span class="wcwp-help-icon">?<span class="wcwp-tooltip"><?php esc_html_e('Send a 50/50 split between this template and Variant B. Each abandoned cart is assigned a variant deterministically by phone. View results on the Analytics tab.', 'woochat-pro'); ?></span></span></th>
+            <td>
+                <select name="wcwp_cart_recovery_ab_enabled" id="wcwp_cart_recovery_ab_enabled" class="wcwp-ab-toggle" data-ab-target="wcwp-ab-variant-b-cart-recovery">
+                    <option value="no" <?php selected($cart_ab_enabled, 'no'); ?>><?php esc_html_e('No', 'woochat-pro'); ?></option>
+                    <option value="yes" <?php selected($cart_ab_enabled, 'yes'); ?>><?php esc_html_e('Yes', 'woochat-pro'); ?></option>
+                </select>
+                <p class="description"><?php esc_html_e('Resends from the Recent Attempts table always use Variant A regardless of this setting.', 'woochat-pro'); ?></p>
+            </td>
+        </tr>
+        <tr class="wcwp-ab-variant-b" id="wcwp-ab-variant-b-cart-recovery" style="<?php echo $cart_ab_enabled === 'yes' ? '' : 'display:none;'; ?>">
+            <th scope="row"><label for="wcwp_cart_recovery_message_b"><?php esc_html_e('Variant B', 'woochat-pro'); ?></label></th>
+            <td>
+                <textarea id="wcwp_cart_recovery_message_b" name="wcwp_cart_recovery_message_b" rows="5" class="large-text"><?php echo esc_textarea($cart_message_b); ?></textarea>
+                <p class="description"><?php
+                    /* translators: do not translate placeholders inside curly braces */
+                    esc_html_e('Use placeholders: {items}, {total}, {currency_symbol}, {cart_url}', 'woochat-pro');
+                ?></p>
+                <p style="margin-top:6px;">
+                    <button type="button" class="button wcwp-browse-templates" data-target="wcwp_cart_recovery_message_b" data-kind="cart_recovery">
+                        <span class="dashicons dashicons-book" style="vertical-align:middle;line-height:28px;"></span>
+                        <?php esc_html_e('Browse template library', 'woochat-pro'); ?>
+                    </button>
+                </p>
+            </td>
+        </tr>
     </table>
     <?php
     // After the cart recovery settings table, show the last 10 recovery attempts

--- a/admin/views/tab-messaging.php
+++ b/admin/views/tab-messaging.php
@@ -33,5 +33,35 @@ if (!defined('ABSPATH')) exit;
                 </p>
             </td>
         </tr>
+        <?php
+        $order_ab_enabled = get_option('wcwp_order_message_ab_enabled', 'no');
+        $order_template_b = get_option('wcwp_order_message_template_b', '');
+        ?>
+        <tr class="wcwp-ab-row" data-ab-kind="order">
+            <th scope="row"><label for="wcwp_order_message_ab_enabled"><?php esc_html_e('A/B test this message', 'woochat-pro'); ?></label><span class="wcwp-help-icon">?<span class="wcwp-tooltip"><?php esc_html_e('Send a 50/50 split between this template and Variant B. Each customer is assigned the same variant deterministically. View results on the Analytics tab.', 'woochat-pro'); ?></span></span></th>
+            <td>
+                <select name="wcwp_order_message_ab_enabled" id="wcwp_order_message_ab_enabled" class="wcwp-ab-toggle" data-ab-target="wcwp-ab-variant-b-order">
+                    <option value="no" <?php selected($order_ab_enabled, 'no'); ?>><?php esc_html_e('No', 'woochat-pro'); ?></option>
+                    <option value="yes" <?php selected($order_ab_enabled, 'yes'); ?>><?php esc_html_e('Yes', 'woochat-pro'); ?></option>
+                </select>
+                <p class="description"><?php esc_html_e('When enabled and Variant B is non-empty, automatic order confirmations split 50/50 between A and B.', 'woochat-pro'); ?></p>
+            </td>
+        </tr>
+        <tr class="wcwp-ab-variant-b" id="wcwp-ab-variant-b-order" style="<?php echo $order_ab_enabled === 'yes' ? '' : 'display:none;'; ?>">
+            <th scope="row"><label for="wcwp_order_message_template_b"><?php esc_html_e('Variant B', 'woochat-pro'); ?></label></th>
+            <td>
+                <textarea id="wcwp_order_message_template_b" name="wcwp_order_message_template_b" rows="5" class="large-text"><?php echo esc_textarea($order_template_b); ?></textarea>
+                <p class="description"><?php
+                    /* translators: do not translate placeholders inside curly braces */
+                    esc_html_e('Use placeholders: {name}, {order_id}, {total}, {currency_symbol}', 'woochat-pro');
+                ?></p>
+                <p style="margin-top:6px;">
+                    <button type="button" class="button wcwp-browse-templates" data-target="wcwp_order_message_template_b" data-kind="order">
+                        <span class="dashicons dashicons-book" style="vertical-align:middle;line-height:28px;"></span>
+                        <?php esc_html_e('Browse template library', 'woochat-pro'); ?>
+                    </button>
+                </p>
+            </td>
+        </tr>
     </table>
 </div>

--- a/admin/views/tab-scheduler.php
+++ b/admin/views/tab-scheduler.php
@@ -37,6 +37,33 @@ if (!defined('ABSPATH')) exit;
                 </p>
             </td>
         </tr>
+        <?php
+        $followup_ab_enabled = get_option('wcwp_followup_ab_enabled', 'no');
+        $followup_template_b = get_option('wcwp_followup_template_b', '');
+        ?>
+        <tr class="wcwp-ab-row" data-ab-kind="followup">
+            <th scope="row"><label for="wcwp_followup_ab_enabled"><?php esc_html_e('A/B test this message', 'woochat-pro'); ?></label><span class="wcwp-help-icon">?<span class="wcwp-tooltip"><?php esc_html_e('Send a 50/50 split between this template and Variant B. Each order is assigned a variant deterministically. View results on the Analytics tab.', 'woochat-pro'); ?></span></span></th>
+            <td>
+                <select name="wcwp_followup_ab_enabled" id="wcwp_followup_ab_enabled" class="wcwp-ab-toggle" data-ab-target="wcwp-ab-variant-b-followup" <?php disabled(!$is_pro); ?>>
+                    <option value="no" <?php selected($followup_ab_enabled, 'no'); ?>><?php esc_html_e('No', 'woochat-pro'); ?></option>
+                    <option value="yes" <?php selected($followup_ab_enabled, 'yes'); ?>><?php esc_html_e('Yes', 'woochat-pro'); ?></option>
+                </select>
+                <p class="description"><?php esc_html_e('When GPT generation is enabled, the variant is still tagged on the event but the message body comes from GPT.', 'woochat-pro'); ?></p>
+            </td>
+        </tr>
+        <tr class="wcwp-ab-variant-b" id="wcwp-ab-variant-b-followup" style="<?php echo $followup_ab_enabled === 'yes' ? '' : 'display:none;'; ?>">
+            <th scope="row"><label for="wcwp_followup_template_b"><?php esc_html_e('Variant B', 'woochat-pro'); ?></label></th>
+            <td>
+                <textarea id="wcwp_followup_template_b" name="wcwp_followup_template_b" rows="5" class="large-text" <?php disabled(!$is_pro); ?>><?php echo esc_textarea($followup_template_b); ?></textarea>
+                <p class="description"><?php esc_html_e('Sent in place of the main template for half of orders when A/B is on.', 'woochat-pro'); ?></p>
+                <p style="margin-top:6px;">
+                    <button type="button" class="button wcwp-browse-templates" data-target="wcwp_followup_template_b" data-kind="followup" <?php disabled(!$is_pro); ?>>
+                        <span class="dashicons dashicons-book" style="vertical-align:middle;line-height:28px;"></span>
+                        <?php esc_html_e('Browse template library', 'woochat-pro'); ?>
+                    </button>
+                </p>
+            </td>
+        </tr>
         <tr>
             <th scope="row"><label for="wcwp_followup_use_gpt"><?php esc_html_e('Use GPT (optional)', 'woochat-pro'); ?></label><span class="wcwp-help-icon">?<span class="wcwp-tooltip"><?php esc_html_e('Generate the follow-up copy with your GPT endpoint; falls back to the template if the call fails.', 'woochat-pro'); ?></span></span></th>
             <td>

--- a/assets/js/admin-premium.js
+++ b/assets/js/admin-premium.js
@@ -344,6 +344,24 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 });
 
+// A/B test toggles — show/hide the Variant B textarea row when the
+// admin flips the per-kind toggle. Persisting still requires WP's
+// Save Changes; this is just live UI state.
+document.addEventListener('DOMContentLoaded', function () {
+    const toggles = document.querySelectorAll('.wcwp-ab-toggle');
+    if (!toggles.length) return;
+    toggles.forEach(function (sel) {
+        const targetId = sel.getAttribute('data-ab-target');
+        if (!targetId) return;
+        const target = document.getElementById(targetId);
+        if (!target) return;
+        function sync() {
+            target.style.display = sel.value === 'yes' ? '' : 'none';
+        }
+        sel.addEventListener('change', sync);
+    });
+});
+
 // Date-range preset buttons (Today / Last 7 / Last 30 / This month / All time)
 document.addEventListener('DOMContentLoaded', function () {
     const presets = document.querySelectorAll('.wcwp-analytics-preset');

--- a/includes/ab-testing.php
+++ b/includes/ab-testing.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * Template A/B testing.
+ *
+ * Lets admins run a 50/50 split between two variants of each automated
+ * message (Order confirmation / Cart recovery / Follow-up) and compare
+ * which one converts better. Reuses the analytics events table — the
+ * variant id is written into the event's `meta.ab_variant` field at
+ * send time, then the results helper joins those events to subsequent
+ * WC orders via the existing wcwp_analytics_match_conversions() pure
+ * matcher (PR #49).
+ *
+ * Variant assignment is deterministic per recipient: the same phone (or
+ * order id) always lands on the same variant, so a customer who
+ * abandons a cart twice won't be measured under inconsistent variants
+ * and a re-fired retry won't suddenly switch them. The splitter uses
+ * `crc32(kind:key) & 1`, which gives a stable, uniform 50/50 split on
+ * both 32-bit and 64-bit PHP.
+ *
+ * Storage:
+ *   - wcwp_{kind}_template       — variant A (existing option, untouched).
+ *   - wcwp_{kind}_template_b     — variant B (new option, autoload off).
+ *   - wcwp_{kind}_ab_enabled     — yes/no master toggle (new, default 'no').
+ *
+ * When the toggle is OFF, or B is empty, every send falls through to
+ * variant A — behavior is byte-identical to a pre-PR install.
+ */
+
+if (!defined('ABSPATH')) exit;
+
+/**
+ * Map of A/B-eligible message kinds to their option keys + defaults.
+ *
+ * Filterable so a third party could in theory add a new kind, but the
+ * plugin only wires the three automated paths today.
+ *
+ * @return array<string, array{label:string, option_a:string, option_b:string, option_enabled:string, default_a:string}>
+ */
+function wcwp_ab_kinds() {
+    $kinds = [
+        'order' => [
+            'label'          => __('Order confirmation', 'woochat-pro'),
+            'option_a'       => 'wcwp_order_message_template',
+            'option_b'       => 'wcwp_order_message_template_b',
+            'option_enabled' => 'wcwp_order_message_ab_enabled',
+            'default_a'      => 'Hi {name}, thanks for your order #{order_id}! Total: {total} {currency_symbol}.',
+        ],
+        'cart_recovery' => [
+            'label'          => __('Cart recovery', 'woochat-pro'),
+            'option_a'       => 'wcwp_cart_recovery_message',
+            'option_b'       => 'wcwp_cart_recovery_message_b',
+            'option_enabled' => 'wcwp_cart_recovery_ab_enabled',
+            'default_a'      => "👋 Hey! You left items in your cart:\n\n{items}\n\nTotal: {total} {currency_symbol}\nClick here to complete your order: {cart_url}",
+        ],
+        'followup' => [
+            'label'          => __('Follow-up', 'woochat-pro'),
+            'option_a'       => 'wcwp_followup_template',
+            'option_b'       => 'wcwp_followup_template_b',
+            'option_enabled' => 'wcwp_followup_ab_enabled',
+            'default_a'      => 'Hi {name}, thanks again for your order #{order_id}! Reply if you have any questions.',
+        ],
+    ];
+
+    /**
+     * Filter the A/B-eligible message kinds.
+     *
+     * @param array $kinds Kind-keyed config map.
+     */
+    return (array) apply_filters('wcwp_ab_kinds', $kinds);
+}
+
+/**
+ * Pick a variant deterministically for a given (kind, key) pair.
+ *
+ * Same input → same variant on every call, on any host. Distribution
+ * across many keys is roughly 50/50 (CRC32 LSB is uniform). Works on
+ * both 32-bit and 64-bit PHP because we mask with 1 instead of using
+ * modulo on a possibly-signed int.
+ *
+ * @param string     $kind One of the kinds returned by wcwp_ab_kinds().
+ * @param string|int $key  Stable per-recipient key (phone or order id).
+ * @return string 'a' or 'b'.
+ */
+function wcwp_ab_pick_variant($kind, $key) {
+    $kind = (string) $kind;
+    $key  = (string) $key;
+    if ($kind === '' || $key === '') return 'a';
+    return ((crc32($kind . ':' . $key) & 1) === 0) ? 'a' : 'b';
+}
+
+/**
+ * Resolve the template that should be sent for one specific recipient.
+ *
+ * Returns ['variant' => 'a'|'b', 'template' => string]. Always falls
+ * back to variant A (the existing option) if A/B is disabled, B is
+ * empty, or the kind is unknown — so callers can pass the result
+ * straight through without an extra null check.
+ *
+ * @param string     $kind       Kind id from wcwp_ab_kinds().
+ * @param string|int $stable_key Per-recipient key — phone for cart
+ *                               recovery, order id for orders/followups.
+ * @return array{variant:string, template:string}
+ */
+function wcwp_ab_get_template($kind, $stable_key) {
+    $kinds = wcwp_ab_kinds();
+    if (!isset($kinds[$kind])) {
+        return ['variant' => 'a', 'template' => ''];
+    }
+    $cfg = $kinds[$kind];
+
+    $a_template = (string) get_option($cfg['option_a'], $cfg['default_a']);
+    $enabled    = get_option($cfg['option_enabled'], 'no') === 'yes';
+    $b_template = $enabled ? (string) get_option($cfg['option_b'], '') : '';
+
+    if (!$enabled || trim($b_template) === '') {
+        return ['variant' => 'a', 'template' => $a_template];
+    }
+
+    $variant  = wcwp_ab_pick_variant($kind, $stable_key);
+    $template = $variant === 'b' ? $b_template : $a_template;
+    return ['variant' => $variant, 'template' => $template];
+}
+
+/**
+ * Partition analytics events by their stored variant.
+ *
+ * Pure helper extracted so the partitioning logic is unit-testable
+ * without DB or option fixtures. Events without a recognised variant
+ * are dropped (they predate A/B or were sent with the toggle off).
+ *
+ * @param array $events Analytics event rows from wcwp_analytics_get_events().
+ * @return array{a: array<int, array>, b: array<int, array>}
+ */
+function wcwp_ab_partition_events_by_variant($events) {
+    $out = ['a' => [], 'b' => []];
+    if (!is_array($events)) return $out;
+
+    foreach ($events as $e) {
+        $meta = $e['meta'] ?? [];
+        $variant = is_array($meta) && isset($meta['ab_variant']) ? (string) $meta['ab_variant'] : '';
+        if ($variant === 'a' || $variant === 'b') {
+            $out[$variant][] = $e;
+        }
+    }
+    return $out;
+}
+
+/**
+ * Aggregate per-variant performance for one kind, including conversions.
+ *
+ * Returns:
+ *   [
+ *     'a' => [ 'sent', 'conversions', 'revenue', 'cvr' ],
+ *     'b' => [ 'sent', 'conversions', 'revenue', 'cvr' ],
+ *     'winner'      => 'a' | 'b' | null,
+ *     'window_days' => int,
+ *     'total_sent'  => int,
+ *   ]
+ *
+ * `sent` counts events whose status reached a deliverable terminal
+ * state (sent / delivered / clicked) — the same definition used for
+ * conversion eligibility in PR #49. `cvr` is conversions / sent (0 when
+ * sent is 0). `winner` is null until both variants reach the minimum
+ * sample size (default 30 each, filterable) so admins don't crown a
+ * winner off three sends.
+ *
+ * @param string $kind    Kind id from wcwp_ab_kinds().
+ * @param array  $filters Same shape as wcwp_analytics_get_events() filters
+ *                        (date_from, date_to). The type filter is forced
+ *                        to $kind here.
+ * @return array
+ */
+function wcwp_ab_get_results($kind, $filters = []) {
+    $window_days = (int) apply_filters('wcwp_analytics_attribution_window_days', 7);
+    if ($window_days < 1) $window_days = 7;
+    $window_seconds = $window_days * DAY_IN_SECONDS;
+
+    $min_sample = (int) apply_filters('wcwp_ab_min_sample_size', 30);
+    if ($min_sample < 1) $min_sample = 30;
+
+    $blank = [
+        'sent'        => 0,
+        'conversions' => 0,
+        'revenue'     => 0.0,
+        'cvr'         => 0.0,
+    ];
+    $base = [
+        'a'           => $blank,
+        'b'           => $blank,
+        'winner'      => null,
+        'window_days' => $window_days,
+        'total_sent'  => 0,
+    ];
+
+    $kinds = wcwp_ab_kinds();
+    if (!isset($kinds[$kind])) {
+        return $base;
+    }
+
+    $event_filters = is_array($filters) ? $filters : [];
+    $event_filters['type'] = $kind;
+    unset($event_filters['status']);
+    $events = wcwp_analytics_get_events(5000, $event_filters);
+
+    $partitioned = wcwp_ab_partition_events_by_variant($events);
+
+    // Build the eligible-event lists (sent/delivered/clicked + phone) per
+    // variant, plus the combined time window for one shared order fetch.
+    $eligible_by_variant = ['a' => [], 'b' => []];
+    $earliest = PHP_INT_MAX;
+    $latest   = 0;
+    $sent_counts = ['a' => 0, 'b' => 0];
+
+    foreach (['a', 'b'] as $variant) {
+        foreach ($partitioned[$variant] as $e) {
+            $status = $e['status'] ?? '';
+            if (!in_array($status, ['sent', 'delivered', 'clicked'], true)) continue;
+            $sent_counts[$variant]++;
+            if (empty($e['phone'])) continue;
+            $time = isset($e['time']) ? strtotime((string) $e['time']) : 0;
+            if (!$time) continue;
+            $eligible_by_variant[$variant][] = [
+                'event_id'   => (string) ($e['id'] ?? ''),
+                'phone_norm' => wcwp_normalize_phone($e['phone']),
+                'time'       => $time,
+            ];
+            if ($time < $earliest) $earliest = $time;
+            if ($time > $latest)   $latest   = $time;
+        }
+    }
+
+    $total_eligible = count($eligible_by_variant['a']) + count($eligible_by_variant['b']);
+
+    // Fetch orders once for the combined window — both variants attribute
+    // against the same order universe (a customer who got variant B can't
+    // somehow buy via variant A's window).
+    $order_records = [];
+    if ($total_eligible > 0 && function_exists('wc_get_orders')) {
+        $orders = wc_get_orders([
+            'limit'        => 5000,
+            'date_created' => gmdate('Y-m-d\TH:i:s', $earliest) . '...' . gmdate('Y-m-d\TH:i:s', $latest + $window_seconds),
+            'status'       => ['wc-processing', 'wc-on-hold', 'wc-completed'],
+            'orderby'      => 'date',
+            'order'        => 'ASC',
+        ]);
+        if (is_array($orders)) {
+            foreach ($orders as $order) {
+                if (!is_object($order) || !method_exists($order, 'get_billing_phone')) continue;
+                $phone_norm = wcwp_normalize_phone($order->get_billing_phone());
+                if ($phone_norm === '') continue;
+                $created = $order->get_date_created();
+                if (!$created) continue;
+                $order_records[] = [
+                    'order_id'   => (int) $order->get_id(),
+                    'phone_norm' => $phone_norm,
+                    'time'       => (int) $created->getTimestamp(),
+                    'total'      => (float) $order->get_total(),
+                ];
+            }
+        }
+    }
+
+    $results = $base;
+    foreach (['a', 'b'] as $variant) {
+        $sent = $sent_counts[$variant];
+        if (!empty($eligible_by_variant[$variant]) && !empty($order_records)) {
+            $match = wcwp_analytics_match_conversions($eligible_by_variant[$variant], $order_records, $window_seconds);
+            $conversions = (int) $match['conversions'];
+            $revenue     = (float) $match['revenue'];
+        } else {
+            $conversions = 0;
+            $revenue     = 0.0;
+        }
+        $results[$variant] = [
+            'sent'        => $sent,
+            'conversions' => $conversions,
+            'revenue'     => $revenue,
+            'cvr'         => $sent > 0 ? ($conversions / $sent) : 0.0,
+        ];
+    }
+
+    $results['total_sent'] = $results['a']['sent'] + $results['b']['sent'];
+
+    if ($results['a']['sent'] >= $min_sample && $results['b']['sent'] >= $min_sample) {
+        if ($results['a']['cvr'] > $results['b']['cvr']) {
+            $results['winner'] = 'a';
+        } elseif ($results['b']['cvr'] > $results['a']['cvr']) {
+            $results['winner'] = 'b';
+        }
+    }
+
+    return $results;
+}

--- a/includes/cart-recovery.php
+++ b/includes/cart-recovery.php
@@ -235,7 +235,11 @@ function wcwp_send_cart_recovery_whatsapp($phone, $cart_items, $consent = 'no', 
         ]);
     }
     $tracked_cart_url = $event_id ? wcwp_analytics_tracking_url($event_id, $cart_url) : $cart_url;
-    $message = wcwp_render_cart_recovery_message($items, $total, $tracked_cart_url);
+    // Variant selection happens here, not at the render call site, so the
+    // resend admin button + Recent Attempts view stay on variant A. Only
+    // the automated cart-recovery worker participates in the A/B test.
+    $picked  = wcwp_ab_get_template('cart_recovery', $phone);
+    $message = wcwp_render_cart_recovery_message($items, $total, $tracked_cart_url, $picked['template']);
     $preview = wcwp_redact_message($message);
 
     $log_file = wcwp_get_log_file();
@@ -260,7 +264,11 @@ function wcwp_send_cart_recovery_whatsapp($phone, $cart_items, $consent = 'no', 
         return 'opted_out';
     }
 
-    $result = wcwp_send_whatsapp_message($phone, $message, false, ['type' => 'cart_recovery', 'event_id' => $event_id]);
+    $result = wcwp_send_whatsapp_message($phone, $message, false, [
+        'type'       => 'cart_recovery',
+        'event_id'   => $event_id,
+        'ab_variant' => $picked['variant'],
+    ]);
     if ($event_id) {
         wcwp_analytics_update_event($event_id, ['status' => $result === true ? 'sent' : 'failed', 'message_preview' => $preview]);
     }
@@ -406,8 +414,10 @@ function wcwp_sum_cart_items_total($cart_items) {
  * tracking-wrapped cart URL) and by the admin "recent attempts" view (with
  * the bare cart URL).
  */
-function wcwp_render_cart_recovery_message($items, $total, $cart_url) {
-    $template = get_option('wcwp_cart_recovery_message', "👋 Hey! You left items in your cart:\n\n{items}\n\nTotal: {total} {currency_symbol}\nClick here to complete your order: {cart_url}");
+function wcwp_render_cart_recovery_message($items, $total, $cart_url, $template = null) {
+    if ($template === null || $template === '') {
+        $template = get_option('wcwp_cart_recovery_message', "👋 Hey! You left items in your cart:\n\n{items}\n\nTotal: {total} {currency_symbol}\nClick here to complete your order: {cart_url}");
+    }
     return str_replace(
         ['{items}', '{total}', '{cart_url}', '{currency_symbol}'],
         [implode("\n", $items), $total, $cart_url, wcwp_currency_symbol_text()],

--- a/includes/class-wcwp-plugin.php
+++ b/includes/class-wcwp-plugin.php
@@ -81,6 +81,7 @@ final class Plugin {
 
         require_once WCWP_PATH . 'includes/analytics.php';
         require_once WCWP_PATH . 'includes/template-library.php';
+        require_once WCWP_PATH . 'includes/ab-testing.php';
         require_once WCWP_PATH . 'admin/settings-page.php';
         require_once WCWP_PATH . 'includes/chatbot-engine.php';
         require_once WCWP_PATH . 'includes/license-manager.php';

--- a/includes/messaging.php
+++ b/includes/messaging.php
@@ -92,16 +92,20 @@ function wcwp_send_whatsapp_message( $to, $message, $manual = false, $context = 
     $event_type = isset( $context['type'] ) && $context['type'] ? $context['type'] : 'order';
 
     if ( ! $event_id ) {
+        $meta = [
+            'source' => $context['type'] ?? 'order',
+            'manual' => $manual ? 'yes' : 'no',
+        ];
+        if ( isset( $context['ab_variant'] ) && in_array( $context['ab_variant'], [ 'a', 'b' ], true ) ) {
+            $meta['ab_variant'] = $context['ab_variant'];
+        }
         $event_id = wcwp_analytics_log_event( $event_type, [
             'status'          => 'pending',
             'phone'           => $to,
             'order_id'        => isset( $context['order_id'] ) ? intval( $context['order_id'] ) : 0,
             'message_preview' => $safe_msg,
             'provider'        => $provider_id,
-            'meta'            => [
-                'source' => $context['type'] ?? 'order',
-                'manual' => $manual ? 'yes' : 'no',
-            ],
+            'meta'            => $meta,
         ] );
     } else {
         wcwp_analytics_update_event( $event_id, [

--- a/includes/order-hooks.php
+++ b/includes/order-hooks.php
@@ -24,14 +24,19 @@ function wcwp_send_whatsapp_on_order_complete($order_id) {
     $name = $order->get_billing_first_name();
     $total = $order->get_total();
 
-    $template = get_option('wcwp_order_message_template', 'Hi {name}, thanks for your order #{order_id}! Total: {total} {currency_symbol}.');
+    $picked    = wcwp_ab_get_template('order', $order_id);
+    $template  = $picked['template'];
     $message = str_replace(
         ['{name}', '{order_id}', '{total}', '{currency_symbol}'],
         [$name, $order_id, $total, wcwp_currency_symbol_text()],
         $template
     );
 
-    $result = wcwp_send_whatsapp_message($to, $message, false, ['type' => 'order', 'order_id' => $order_id]);
+    $result = wcwp_send_whatsapp_message($to, $message, false, [
+        'type'       => 'order',
+        'order_id'   => $order_id,
+        'ab_variant' => $picked['variant'],
+    ]);
     if ($result === true) {
         $order->update_meta_data('_wcwp_order_msg_sent', current_time('mysql'));
         $order->save();

--- a/includes/scheduler.php
+++ b/includes/scheduler.php
@@ -44,11 +44,14 @@ function wcwp_send_followup_message_handler($order_id) {
     // burns attempts on the same `false` return.
     if (wcwp_is_opted_out($to)) return;
 
-    $message = wcwp_build_followup_message($order);
+    $picked  = wcwp_ab_get_template('followup', $order_id);
+    $message = wcwp_build_followup_message($order, $picked['template']);
 
     // Optional GPT-generated content. Falls back to the templated $message
     // when the helper returns '' (missing creds, network error, non-200,
-    // or empty response).
+    // or empty response). Note: GPT output is variant-agnostic — the
+    // ab_variant tag still rides along on the event so you can compare A
+    // vs B once you turn GPT off.
     if (get_option('wcwp_followup_use_gpt', 'no') === 'yes') {
         $maybe_ai = wcwp_generate_gpt_followup($order);
         if (!empty($maybe_ai)) {
@@ -56,7 +59,11 @@ function wcwp_send_followup_message_handler($order_id) {
         }
     }
 
-    $result = wcwp_send_whatsapp_message($to, $message, false, ['type' => 'followup', 'order_id' => $order_id]);
+    $result = wcwp_send_whatsapp_message($to, $message, false, [
+        'type'       => 'followup',
+        'order_id'   => $order_id,
+        'ab_variant' => $picked['variant'],
+    ]);
     if ($result === true) {
         $order->update_meta_data('_wcwp_followup_sent', current_time('mysql'));
         $order->save();
@@ -85,8 +92,10 @@ function wcwp_send_followup_message_handler($order_id) {
     wp_schedule_single_event($next_at, 'wcwp_send_followup_message', [$order_id]);
 }
 
-function wcwp_build_followup_message($order) {
-    $template = get_option('wcwp_followup_template', "Hi {name}, thanks again for your order #{order_id}! Reply if you have any questions.");
+function wcwp_build_followup_message($order, $template = null) {
+    if ($template === null || $template === '') {
+        $template = get_option('wcwp_followup_template', "Hi {name}, thanks again for your order #{order_id}! Reply if you have any questions.");
+    }
     return str_replace(
         ['{name}', '{order_id}', '{total}', '{status}', '{date}', '{currency_symbol}'],
         [

--- a/tests/Unit/AbTestingTest.php
+++ b/tests/Unit/AbTestingTest.php
@@ -1,0 +1,162 @@
+<?php
+declare(strict_types=1);
+
+namespace WooChatPro\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class AbTestingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['wcwp_test_options'] = [];
+    }
+
+    public function test_pick_variant_is_deterministic(): void
+    {
+        $first  = \wcwp_ab_pick_variant('order', '12345');
+        $second = \wcwp_ab_pick_variant('order', '12345');
+        $third  = \wcwp_ab_pick_variant('order', '12345');
+
+        $this->assertSame($first, $second);
+        $this->assertSame($first, $third);
+        $this->assertContains($first, ['a', 'b']);
+    }
+
+    public function test_pick_variant_returns_a_or_b(): void
+    {
+        for ($i = 0; $i < 50; $i++) {
+            $v = \wcwp_ab_pick_variant('cart_recovery', 'phone-' . $i);
+            $this->assertContains($v, ['a', 'b'], "Iteration $i returned unexpected '$v'.");
+        }
+    }
+
+    public function test_pick_variant_distributes_roughly_evenly(): void
+    {
+        $a = 0;
+        $b = 0;
+        // CRC32 is uniform across crafted inputs, so 1000 random keys
+        // should land within 40-60% of either bucket. Wide window so the
+        // test isn't flaky on edge distributions.
+        for ($i = 0; $i < 1000; $i++) {
+            $v = \wcwp_ab_pick_variant('order', 'order-' . $i);
+            if ($v === 'a') { $a++; } else { $b++; }
+        }
+        $this->assertGreaterThan(400, $a, 'Variant A should be allocated at least 40% of 1000 keys.');
+        $this->assertGreaterThan(400, $b, 'Variant B should be allocated at least 40% of 1000 keys.');
+    }
+
+    public function test_pick_variant_is_kind_scoped(): void
+    {
+        // The same key under two different kinds should be allowed to
+        // diverge — kinds are independent splits.
+        $a_orders = 0;
+        $b_orders = 0;
+        $a_carts  = 0;
+        $b_carts  = 0;
+        for ($i = 0; $i < 100; $i++) {
+            $key = 'k' . $i;
+            \wcwp_ab_pick_variant('order', $key) === 'a' ? $a_orders++ : $b_orders++;
+            \wcwp_ab_pick_variant('cart_recovery', $key) === 'a' ? $a_carts++ : $b_carts++;
+        }
+        $this->assertSame(100, $a_orders + $b_orders);
+        $this->assertSame(100, $a_carts + $b_carts);
+    }
+
+    public function test_pick_variant_falls_back_to_a_for_empty_input(): void
+    {
+        $this->assertSame('a', \wcwp_ab_pick_variant('', 'key'));
+        $this->assertSame('a', \wcwp_ab_pick_variant('order', ''));
+    }
+
+    public function test_get_template_returns_a_when_disabled(): void
+    {
+        $GLOBALS['wcwp_test_options']['wcwp_order_message_template'] = 'Variant A body';
+        $GLOBALS['wcwp_test_options']['wcwp_order_message_template_b'] = 'Variant B body';
+        $GLOBALS['wcwp_test_options']['wcwp_order_message_ab_enabled'] = 'no';
+
+        $picked = \wcwp_ab_get_template('order', '42');
+
+        $this->assertSame('a', $picked['variant']);
+        $this->assertSame('Variant A body', $picked['template']);
+    }
+
+    public function test_get_template_returns_a_when_b_is_empty(): void
+    {
+        $GLOBALS['wcwp_test_options']['wcwp_order_message_template'] = 'Variant A body';
+        $GLOBALS['wcwp_test_options']['wcwp_order_message_template_b'] = '   '; // whitespace only
+        $GLOBALS['wcwp_test_options']['wcwp_order_message_ab_enabled'] = 'yes';
+
+        $picked = \wcwp_ab_get_template('order', '42');
+
+        $this->assertSame('a', $picked['variant']);
+        $this->assertSame('Variant A body', $picked['template']);
+    }
+
+    public function test_get_template_picks_b_when_enabled_and_key_hashes_to_b(): void
+    {
+        $GLOBALS['wcwp_test_options']['wcwp_order_message_template'] = 'A body';
+        $GLOBALS['wcwp_test_options']['wcwp_order_message_template_b'] = 'B body';
+        $GLOBALS['wcwp_test_options']['wcwp_order_message_ab_enabled'] = 'yes';
+
+        // Find a key that lands on B so we can assert the lookup wired up.
+        $b_key = null;
+        for ($i = 0; $i < 50; $i++) {
+            if (\wcwp_ab_pick_variant('order', 'k' . $i) === 'b') {
+                $b_key = 'k' . $i;
+                break;
+            }
+        }
+        $this->assertNotNull($b_key, 'Could not find a B-mapping key in 50 attempts.');
+
+        $picked = \wcwp_ab_get_template('order', $b_key);
+        $this->assertSame('b', $picked['variant']);
+        $this->assertSame('B body', $picked['template']);
+    }
+
+    public function test_get_template_unknown_kind_returns_a_with_empty_template(): void
+    {
+        $picked = \wcwp_ab_get_template('not-a-kind', 'k1');
+        $this->assertSame('a', $picked['variant']);
+        $this->assertSame('', $picked['template']);
+    }
+
+    public function test_partition_events_groups_by_variant(): void
+    {
+        $events = [
+            ['id' => 'e1', 'meta' => ['ab_variant' => 'a']],
+            ['id' => 'e2', 'meta' => ['ab_variant' => 'b']],
+            ['id' => 'e3', 'meta' => ['ab_variant' => 'a']],
+            ['id' => 'e4', 'meta' => []],                         // dropped — no variant
+            ['id' => 'e5', 'meta' => ['ab_variant' => 'c']],     // dropped — invalid variant
+            ['id' => 'e6'],                                        // dropped — no meta
+        ];
+        $partitioned = \wcwp_ab_partition_events_by_variant($events);
+
+        $this->assertCount(2, $partitioned['a']);
+        $this->assertCount(1, $partitioned['b']);
+        $this->assertSame('e1', $partitioned['a'][0]['id']);
+        $this->assertSame('e3', $partitioned['a'][1]['id']);
+        $this->assertSame('e2', $partitioned['b'][0]['id']);
+    }
+
+    public function test_partition_events_handles_non_array_input(): void
+    {
+        $this->assertSame(['a' => [], 'b' => []], \wcwp_ab_partition_events_by_variant([]));
+        $this->assertSame(['a' => [], 'b' => []], \wcwp_ab_partition_events_by_variant(null));
+    }
+
+    public function test_kinds_includes_all_three_known_kinds(): void
+    {
+        $kinds = \wcwp_ab_kinds();
+        $this->assertArrayHasKey('order', $kinds);
+        $this->assertArrayHasKey('cart_recovery', $kinds);
+        $this->assertArrayHasKey('followup', $kinds);
+        foreach ($kinds as $id => $cfg) {
+            $this->assertArrayHasKey('label', $cfg, "Kind $id missing label.");
+            $this->assertArrayHasKey('option_a', $cfg);
+            $this->assertArrayHasKey('option_b', $cfg);
+            $this->assertArrayHasKey('option_enabled', $cfg);
+        }
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -87,3 +87,4 @@ require_once __DIR__ . '/../includes/campaigns.php';
 require_once __DIR__ . '/../includes/blocks.php';
 require_once __DIR__ . '/../includes/analytics.php';
 require_once __DIR__ . '/../includes/template-library.php';
+require_once __DIR__ . '/../includes/ab-testing.php';

--- a/uninstall.php
+++ b/uninstall.php
@@ -63,6 +63,12 @@ $option_keys = [
     'wcwp_optout_webhook_token',
     'wcwp_db_version',
     'wcwp_onboarding_completed',
+    'wcwp_order_message_template_b',
+    'wcwp_cart_recovery_message_b',
+    'wcwp_followup_template_b',
+    'wcwp_order_message_ab_enabled',
+    'wcwp_cart_recovery_ab_enabled',
+    'wcwp_followup_ab_enabled',
 ];
 
 foreach ($option_keys as $key) {


### PR DESCRIPTION
## Summary

Tier 3 #10 of the premium roadmap. 50/50 split-test infrastructure for the three automated message kinds (Order confirmation / Cart recovery / Follow-up), with per-variant conversion attribution surfaced on the Analytics tab. Builds on the template library (PR #50) and the conversion-attribution helper (PR #49).

## What changed

**Variant allocation** — Deterministic per recipient: `wcwp_ab_pick_variant($kind, $key)` returns `'a'` or `'b'` from `crc32("$kind:$key") & 1`. Same input → same variant on every call, on any host, on both 32-bit and 64-bit PHP. Stable keys: phone for cart recovery, order id for orders + follow-ups. A customer who restarts a checkout or whose retry fires later cannot hop variants mid-test.

**Storage (6 new options)**
- `wcwp_{kind}_template_b` — Variant B body.
- `wcwp_{kind}_ab_enabled` — yes/no master toggle, default `no`.

When the toggle is off or B is empty, behavior is byte-identical to pre-PR — Variant A is always sent. All six keys are registered in `settings-page.php` and added to `uninstall.php`'s delete list.

**Dispatcher integration**
- `order-hooks.php` (auto path only; manual + admin test stay on A) and `scheduler.php` pick the variant up front via `wcwp_ab_get_template()`, plumb it through `wcwp_build_followup_message()` (signature gained an optional `$template` arg with backwards-compatible default), and pass `'ab_variant' => 'a'|'b'` in the messaging context.
- `cart-recovery.php` picks the variant in `wcwp_send_cart_recovery_whatsapp()` (the only auto path) and passes the picked template to `wcwp_render_cart_recovery_message()` — which now takes an optional 4th arg. The Resend admin button + Recent Attempts preview always render with Variant A, so admin actions don't pollute the test sample.
- `messaging.php`'s analytics-event creator writes `meta.ab_variant` when the context carries one. Pre-PR events have no `ab_variant` key and are silently dropped from results aggregation — no migration needed.

**Results surface** — `wcwp_ab_get_results($kind, $filters)` returns per-variant `sent / conversions / revenue / cvr` plus a `winner` (`'a'`, `'b'`, or `null` when either side is below the min sample size — default 30 per variant, filterable via `wcwp_ab_min_sample_size`). Pulls events filtered by type, partitions by `meta.ab_variant` via the pure helper `wcwp_ab_partition_events_by_variant()`, then runs `match_conversions` against a single combined `wc_get_orders` fetch covering the union window. Surfaced as a new "A/B test results" panel on the Analytics tab between the per-template breakdown and the recent-events list, with a star next to the winning variant.

**Tab UI** — Each of the three tabs got a two-row A/B section under its main template textarea: a yes/no toggle and a Variant B textarea (hidden when the toggle is off, revealed live via a `.wcwp-ab-toggle` change listener in `admin-premium.js`). Variant B has its own "Browse template library" button that targets the B textarea. Scheduler's A/B toggle inherits the existing `$is_pro` disabled gate.

## What stays the same

- All existing template options (`wcwp_order_message_template`, `wcwp_cart_recovery_message`, `wcwp_followup_template`) keep their meaning — Variant A is just the existing template.
- Manual order-edit "Send WhatsApp" button + admin Test Message do not pick a variant. Test sample stays clean.
- Cart-recovery Resend button + Recent Attempts table render Variant A unconditionally.
- Conversion-attribution rules from PR #49 (first-event-wins, no double-counting, pre-event orders ignored, HPOS-compatible). Both variants attribute against the same order universe in one shared `wc_get_orders` call.

## Test plan

- [x] PHPUnit: 53 tests / 395 assertions green (`composer test`).
- [x] PHPCS: clean against project ruleset (`composer lint`).
- [x] On Messaging / Cart Recovery / Scheduler tabs, flip "A/B test this message" to Yes — Variant B textarea appears live, "Browse template library" populates it.
- [x] Save with Variant B set, place a test order — analytics event for that order has `meta.ab_variant` set to the variant the order id hashes to. Re-trigger the same order id (e.g. via the retry path) — variant stays the same.
- [x] Toggle A/B off and on without changing Variant B — the same recipient still gets the same variant.
- [x] Open Analytics tab — "A/B test results" table appears with one block per running test. With <30 sends per variant, outcome reads "Insufficient data (need 30 sends per variant)".
- [x] Without WC orders matching the event phones, conversions = 0 / cvr = 0% but `sent` populates correctly.
- [x] Without any A/B toggle on, the Analytics panel shows the empty-state hint instead of the table.

## Risk / rollback

Low risk. No schema changes. Existing message-sending paths preserve byte-identical behavior whenever `ab_enabled` is `no` or Variant B is empty. The only function-signature changes are additive optional arguments (`wcwp_render_cart_recovery_message`, `wcwp_build_followup_message`) — every existing caller works unchanged. Pre-existing analytics events without `meta.ab_variant` are silently ignored by the partition helper. Rollback = revert the merge commit; the 6 new option keys remain in the DB but are harmless (untouched by every other code path) and will be cleaned up on uninstall.