### PR TITLE
GDPR privacy hooks — WP exporters + erasers for all four PII surfaces

### DIFF
--- a/includes/class-wcwp-plugin.php
+++ b/includes/class-wcwp-plugin.php
@@ -82,6 +82,7 @@ final class Plugin {
         require_once WCWP_PATH . 'includes/analytics.php';
         require_once WCWP_PATH . 'includes/template-library.php';
         require_once WCWP_PATH . 'includes/ab-testing.php';
+        require_once WCWP_PATH . 'includes/privacy.php';
         require_once WCWP_PATH . 'admin/settings-page.php';
         require_once WCWP_PATH . 'includes/chatbot-engine.php';
         require_once WCWP_PATH . 'includes/license-manager.php';

--- a/includes/privacy.php
+++ b/includes/privacy.php
@@ -1,0 +1,517 @@
+<?php
+/**
+ * GDPR / WP privacy-tools integration.
+ *
+ * Wires the plugin's PII-bearing data into WordPress' built-in
+ * Tools → Export Personal Data and Erase Personal Data flows so EU
+ * stores have a one-click answer to a Subject Access Request or
+ * Right-to-Erasure request.
+ *
+ * Data we own and surface:
+ *   - {prefix}wcwp_analytics_events     — per-message log (phone,
+ *                                          message_preview, meta).
+ *   - {prefix}wcwp_abandoned_carts      — recovery queue (phone, cart
+ *                                          contents JSON).
+ *   - {prefix}wcwp_campaign_recipients  — bulk-campaign recipient list
+ *                                          (phone, customer_name).
+ *   - wcwp_optout_list option            — suppression list of phones
+ *                                          that opted out.
+ *
+ * Email → phone resolution: WP privacy keys everything by email, but
+ * our tables store phone numbers. wcwp_privacy_phones_for_email() pulls
+ * billing_phone from the matching WP user (if any) and from every WC
+ * order under that email, normalises each via wcwp_normalize_phone(),
+ * and dedupes — covers both registered customers and guest checkout.
+ *
+ * Erasure policy choices:
+ *   - Analytics events are *anonymised* (phone, preview, meta cleared)
+ *     rather than deleted, so aggregate counts on the dashboard remain
+ *     truthful.
+ *   - Cart and campaign-recipient rows are deleted outright.
+ *   - The opt-out list is *retained* with a message — keeping a
+ *     suppression record is a legitimate-interest exception under
+ *     Recital 47 GDPR; deleting it would re-enable communications, the
+ *     opposite of what the user originally requested.
+ */
+
+if (!defined('ABSPATH')) exit;
+
+add_filter('wp_privacy_personal_data_exporters', 'wcwp_privacy_register_exporters', 20);
+add_filter('wp_privacy_personal_data_erasers', 'wcwp_privacy_register_erasers', 20);
+add_action('admin_init', 'wcwp_privacy_register_policy_content');
+
+function wcwp_privacy_register_exporters($exporters) {
+    $exporters['woochat-pro-events'] = [
+        'exporter_friendly_name' => __('WooChat Pro – WhatsApp messaging events', 'woochat-pro'),
+        'callback'               => 'wcwp_privacy_export_events',
+    ];
+    $exporters['woochat-pro-carts'] = [
+        'exporter_friendly_name' => __('WooChat Pro – Abandoned cart records', 'woochat-pro'),
+        'callback'               => 'wcwp_privacy_export_carts',
+    ];
+    $exporters['woochat-pro-campaigns'] = [
+        'exporter_friendly_name' => __('WooChat Pro – Bulk campaign recipients', 'woochat-pro'),
+        'callback'               => 'wcwp_privacy_export_campaigns',
+    ];
+    $exporters['woochat-pro-optout'] = [
+        'exporter_friendly_name' => __('WooChat Pro – Opt-out status', 'woochat-pro'),
+        'callback'               => 'wcwp_privacy_export_optout',
+    ];
+    return $exporters;
+}
+
+function wcwp_privacy_register_erasers($erasers) {
+    $erasers['woochat-pro-events'] = [
+        'eraser_friendly_name' => __('WooChat Pro – WhatsApp messaging events', 'woochat-pro'),
+        'callback'             => 'wcwp_privacy_erase_events',
+    ];
+    $erasers['woochat-pro-carts'] = [
+        'eraser_friendly_name' => __('WooChat Pro – Abandoned cart records', 'woochat-pro'),
+        'callback'             => 'wcwp_privacy_erase_carts',
+    ];
+    $erasers['woochat-pro-campaigns'] = [
+        'eraser_friendly_name' => __('WooChat Pro – Bulk campaign recipients', 'woochat-pro'),
+        'callback'             => 'wcwp_privacy_erase_campaigns',
+    ];
+    $erasers['woochat-pro-optout'] = [
+        'eraser_friendly_name' => __('WooChat Pro – Opt-out status', 'woochat-pro'),
+        'callback'             => 'wcwp_privacy_erase_optout',
+    ];
+    return $erasers;
+}
+
+function wcwp_privacy_register_policy_content() {
+    if (!function_exists('wp_add_privacy_policy_content')) return;
+    $content  = '<p>' . esc_html__('When WooChat Pro is active, WhatsApp messages sent on your behalf are recorded for analytics, retry, and compliance reasons.', 'woochat-pro') . '</p>';
+    $content .= '<p><strong>' . esc_html__('What is stored:', 'woochat-pro') . '</strong></p>';
+    $content .= '<ul>';
+    $content .= '<li>' . esc_html__('Per-message events: timestamp, message type, status, phone number, order id (if any), provider id, message id, and a redacted preview of the message body.', 'woochat-pro') . '</li>';
+    $content .= '<li>' . esc_html__('Abandoned cart records: phone number, cart contents, and timestamps used to schedule recovery messages.', 'woochat-pro') . '</li>';
+    $content .= '<li>' . esc_html__('Bulk campaign recipients: phone number and first name, scoped to the campaign that targeted them.', 'woochat-pro') . '</li>';
+    $content .= '<li>' . esc_html__('Suppression list: phone numbers that opted out of further messages. Retained for compliance even after a personal-data erasure request, to keep the opt-out honoured.', 'woochat-pro') . '</li>';
+    $content .= '</ul>';
+    $content .= '<p>' . esc_html__('Customers can request export or erasure of this data via Tools → Export Personal Data and Tools → Erase Personal Data, keyed on the email address they used at checkout.', 'woochat-pro') . '</p>';
+    wp_add_privacy_policy_content('WooChat Pro', $content);
+}
+
+/**
+ * Resolve an email address to the set of normalised phone numbers we
+ * might have stored for that customer.
+ *
+ * Looks up:
+ *   1. The matching WP user's billing_phone meta (registered customers).
+ *   2. billing_phone on every WC order placed under this email (guest
+ *      checkouts + customers who used a different phone on a later
+ *      order).
+ *
+ * Returns a numerically-indexed list of unique normalised phones — or
+ * an empty list if nothing matched.
+ *
+ * @param string $email
+ * @return string[]
+ */
+function wcwp_privacy_phones_for_email($email) {
+    $email = is_string($email) ? sanitize_email($email) : '';
+    if ($email === '') return [];
+
+    $phones = [];
+
+    $user = get_user_by('email', $email);
+    if ($user) {
+        $meta_phone = get_user_meta($user->ID, 'billing_phone', true);
+        $norm = wcwp_normalize_phone($meta_phone);
+        if ($norm !== '') $phones[$norm] = true;
+    }
+
+    if (function_exists('wc_get_orders')) {
+        $orders = wc_get_orders([
+            'limit'         => 500,
+            'billing_email' => $email,
+            'return'        => 'objects',
+        ]);
+        if (is_array($orders)) {
+            foreach ($orders as $order) {
+                if (!is_object($order) || !method_exists($order, 'get_billing_phone')) continue;
+                $norm = wcwp_normalize_phone($order->get_billing_phone());
+                if ($norm !== '') $phones[$norm] = true;
+            }
+        }
+    }
+
+    return array_keys($phones);
+}
+
+/**
+ * Build the LIKE candidate fragment for matching a normalised phone
+ * against a raw, possibly-formatted phone column.
+ *
+ * Stored phones may have spaces, dashes, parentheses, or country-code
+ * prefix variations. We can't reliably exact-match, but the trailing
+ * 8 digits of a number are usually unique enough to gate an indexed
+ * scan; PHP-side, we then normalise both sides and confirm exact match
+ * to filter false positives.
+ *
+ * @param string $normalized_phone
+ * @return string Substring (no wildcards) — caller composes the LIKE.
+ */
+function wcwp_privacy_phone_match_suffix($normalized_phone) {
+    $digits = preg_replace('/\D+/', '', (string) $normalized_phone);
+    if ($digits === '') return '';
+    return strlen($digits) > 8 ? substr($digits, -8) : $digits;
+}
+
+/**
+ * Format one analytics-event row as a WP privacy export item.
+ *
+ * Pure: no DB, no globals. Extracted so the field-name labels and
+ * masking choices are unit-testable.
+ *
+ * @param array $row Row from wcwp_analytics_events (associative).
+ * @return array{group_id:string,group_label:string,item_id:string,data:array}
+ */
+function wcwp_privacy_format_event_row($row) {
+    $event_id = isset($row['event_id']) ? (string) $row['event_id'] : (isset($row['id']) ? (string) $row['id'] : '');
+    return [
+        'group_id'    => 'woochat-pro-events',
+        'group_label' => __('WooChat Pro – WhatsApp messaging events', 'woochat-pro'),
+        'item_id'     => 'wcwp-event-' . $event_id,
+        'data'        => [
+            ['name' => __('Date',       'woochat-pro'), 'value' => $row['created_at'] ?? ($row['time'] ?? '')],
+            ['name' => __('Type',       'woochat-pro'), 'value' => $row['type'] ?? ''],
+            ['name' => __('Status',     'woochat-pro'), 'value' => $row['status'] ?? ''],
+            ['name' => __('Phone',      'woochat-pro'), 'value' => $row['phone'] ?? ''],
+            ['name' => __('Order ID',   'woochat-pro'), 'value' => isset($row['order_id']) ? (string) (int) $row['order_id'] : ''],
+            ['name' => __('Provider',   'woochat-pro'), 'value' => $row['provider'] ?? ''],
+            ['name' => __('Message ID', 'woochat-pro'), 'value' => $row['message_id'] ?? ''],
+            ['name' => __('Preview',    'woochat-pro'), 'value' => $row['message_preview'] ?? ''],
+        ],
+    ];
+}
+
+function wcwp_privacy_format_cart_row($row) {
+    return [
+        'group_id'    => 'woochat-pro-carts',
+        'group_label' => __('WooChat Pro – Abandoned cart records', 'woochat-pro'),
+        'item_id'     => 'wcwp-cart-' . (isset($row['id']) ? (int) $row['id'] : 0),
+        'data'        => [
+            ['name' => __('Created',  'woochat-pro'), 'value' => $row['created_at'] ?? ''],
+            ['name' => __('Phone',    'woochat-pro'), 'value' => $row['phone'] ?? ''],
+            ['name' => __('Total',    'woochat-pro'), 'value' => isset($row['total']) ? (string) $row['total'] : ''],
+            ['name' => __('Items',    'woochat-pro'), 'value' => $row['cart_json'] ?? ''],
+            ['name' => __('Status',   'woochat-pro'), 'value' => $row['status'] ?? ''],
+            ['name' => __('Consent',  'woochat-pro'), 'value' => $row['consent'] ?? ''],
+            ['name' => __('Attempts', 'woochat-pro'), 'value' => isset($row['attempts']) ? (string) (int) $row['attempts'] : '0'],
+        ],
+    ];
+}
+
+function wcwp_privacy_format_campaign_recipient_row($row, $campaign_name = '') {
+    return [
+        'group_id'    => 'woochat-pro-campaigns',
+        'group_label' => __('WooChat Pro – Bulk campaign recipients', 'woochat-pro'),
+        'item_id'     => 'wcwp-campaign-recipient-' . (isset($row['id']) ? (int) $row['id'] : 0),
+        'data'        => [
+            ['name' => __('Campaign',      'woochat-pro'), 'value' => $campaign_name !== '' ? $campaign_name : (isset($row['campaign_id']) ? '#' . (int) $row['campaign_id'] : '')],
+            ['name' => __('Phone',         'woochat-pro'), 'value' => $row['phone'] ?? ''],
+            ['name' => __('Customer name', 'woochat-pro'), 'value' => $row['customer_name'] ?? ''],
+            ['name' => __('Status',        'woochat-pro'), 'value' => $row['status'] ?? ''],
+            ['name' => __('Sent at',       'woochat-pro'), 'value' => $row['sent_at'] ?? ''],
+        ],
+    ];
+}
+
+/**
+ * Filter a candidate set of rows down to those whose `phone` field, once
+ * normalised, exactly matches one of the target phones.
+ *
+ * Pure: takes raw associative rows and the precomputed normalised-phone
+ * lookup, returns the matching rows. The caller is responsible for
+ * picking up rows from the DB with a coarse LIKE filter — this helper
+ * removes the false positives that LIKE produced.
+ *
+ * @param array<int, array> $rows
+ * @param array<string, true> $phone_lookup Normalised phones indexed for O(1) check.
+ * @return array<int, array> Rows in original order whose phone matches.
+ */
+function wcwp_privacy_filter_rows_by_normalized_phone($rows, $phone_lookup) {
+    if (!is_array($rows) || empty($rows) || empty($phone_lookup)) return [];
+    $out = [];
+    foreach ($rows as $row) {
+        if (!isset($row['phone'])) continue;
+        $norm = wcwp_normalize_phone($row['phone']);
+        if ($norm === '') continue;
+        if (isset($phone_lookup[$norm])) $out[] = $row;
+    }
+    return $out;
+}
+
+/* -------------------------------------------------------------------------
+ * Exporters
+ * ----------------------------------------------------------------------- */
+
+function wcwp_privacy_export_events($email_address, $page = 1) {
+    $phones = wcwp_privacy_phones_for_email($email_address);
+    $items = [];
+    if (!empty($phones)) {
+        global $wpdb;
+        $table = wcwp_get_analytics_table_name();
+        $lookup = array_flip($phones);
+        $candidates = [];
+        foreach ($phones as $phone) {
+            $suffix = wcwp_privacy_phone_match_suffix($phone);
+            if ($suffix === '') continue;
+            $rows = $wpdb->get_results(
+                $wpdb->prepare(
+                    "SELECT event_id, type, status, phone, order_id, message_preview, provider, message_id, created_at FROM {$table} WHERE phone LIKE %s LIMIT 500",
+                    '%' . $wpdb->esc_like($suffix) . '%'
+                ),
+                ARRAY_A
+            );
+            if ($rows) {
+                foreach ($rows as $row) $candidates[$row['event_id']] = $row;
+            }
+        }
+        $matched = wcwp_privacy_filter_rows_by_normalized_phone(array_values($candidates), $lookup);
+        foreach ($matched as $row) {
+            $items[] = wcwp_privacy_format_event_row($row);
+        }
+    }
+    return ['data' => $items, 'done' => true];
+}
+
+function wcwp_privacy_export_carts($email_address, $page = 1) {
+    $phones = wcwp_privacy_phones_for_email($email_address);
+    $items = [];
+    if (!empty($phones)) {
+        global $wpdb;
+        $table = wcwp_get_cart_table_name();
+        $lookup = array_flip($phones);
+        $candidates = [];
+        foreach ($phones as $phone) {
+            $suffix = wcwp_privacy_phone_match_suffix($phone);
+            if ($suffix === '') continue;
+            $rows = $wpdb->get_results(
+                $wpdb->prepare(
+                    "SELECT id, phone, total, cart_json, status, consent, attempts, created_at FROM {$table} WHERE phone LIKE %s LIMIT 500",
+                    '%' . $wpdb->esc_like($suffix) . '%'
+                ),
+                ARRAY_A
+            );
+            if ($rows) {
+                foreach ($rows as $row) $candidates[(int) $row['id']] = $row;
+            }
+        }
+        $matched = wcwp_privacy_filter_rows_by_normalized_phone(array_values($candidates), $lookup);
+        foreach ($matched as $row) {
+            $items[] = wcwp_privacy_format_cart_row($row);
+        }
+    }
+    return ['data' => $items, 'done' => true];
+}
+
+function wcwp_privacy_export_campaigns($email_address, $page = 1) {
+    $phones = wcwp_privacy_phones_for_email($email_address);
+    $items = [];
+    if (!empty($phones)) {
+        global $wpdb;
+        $recipients_table = wcwp_campaign_recipients_table_name();
+        $campaigns_table  = wcwp_campaigns_table_name();
+        $lookup = array_flip($phones);
+        $candidates = [];
+        foreach ($phones as $phone) {
+            $suffix = wcwp_privacy_phone_match_suffix($phone);
+            if ($suffix === '') continue;
+            $rows = $wpdb->get_results(
+                $wpdb->prepare(
+                    "SELECT r.id, r.campaign_id, r.phone, r.customer_name, r.status, r.sent_at, c.name AS campaign_name
+                     FROM {$recipients_table} r
+                     LEFT JOIN {$campaigns_table} c ON c.id = r.campaign_id
+                     WHERE r.phone LIKE %s LIMIT 500",
+                    '%' . $wpdb->esc_like($suffix) . '%'
+                ),
+                ARRAY_A
+            );
+            if ($rows) {
+                foreach ($rows as $row) $candidates[(int) $row['id']] = $row;
+            }
+        }
+        $matched = wcwp_privacy_filter_rows_by_normalized_phone(array_values($candidates), $lookup);
+        foreach ($matched as $row) {
+            $campaign_name = isset($row['campaign_name']) ? (string) $row['campaign_name'] : '';
+            $items[] = wcwp_privacy_format_campaign_recipient_row($row, $campaign_name);
+        }
+    }
+    return ['data' => $items, 'done' => true];
+}
+
+function wcwp_privacy_export_optout($email_address, $page = 1) {
+    $phones = wcwp_privacy_phones_for_email($email_address);
+    $items = [];
+    if (!empty($phones)) {
+        $optout = wcwp_get_optout_list();
+        foreach ($phones as $phone) {
+            if (!in_array($phone, $optout, true)) continue;
+            $items[] = [
+                'group_id'    => 'woochat-pro-optout',
+                'group_label' => __('WooChat Pro – Opt-out status', 'woochat-pro'),
+                'item_id'     => 'wcwp-optout-' . md5($phone),
+                'data'        => [
+                    ['name' => __('Phone',  'woochat-pro'), 'value' => $phone],
+                    ['name' => __('Status', 'woochat-pro'), 'value' => __('Opted out of further messages', 'woochat-pro')],
+                ],
+            ];
+        }
+    }
+    return ['data' => $items, 'done' => true];
+}
+
+/* -------------------------------------------------------------------------
+ * Erasers
+ * ----------------------------------------------------------------------- */
+
+function wcwp_privacy_erase_events($email_address, $page = 1) {
+    $phones = wcwp_privacy_phones_for_email($email_address);
+    $removed = 0;
+    $messages = [];
+    if (!empty($phones)) {
+        global $wpdb;
+        $table = wcwp_get_analytics_table_name();
+        $lookup = array_flip($phones);
+        $candidates = [];
+        foreach ($phones as $phone) {
+            $suffix = wcwp_privacy_phone_match_suffix($phone);
+            if ($suffix === '') continue;
+            $rows = $wpdb->get_results(
+                $wpdb->prepare(
+                    "SELECT id, phone FROM {$table} WHERE phone LIKE %s LIMIT 500",
+                    '%' . $wpdb->esc_like($suffix) . '%'
+                ),
+                ARRAY_A
+            );
+            if ($rows) {
+                foreach ($rows as $row) $candidates[(int) $row['id']] = $row;
+            }
+        }
+        $matched = wcwp_privacy_filter_rows_by_normalized_phone(array_values($candidates), $lookup);
+        if (!empty($matched)) {
+            $ids = array_map('intval', array_column($matched, 'id'));
+            $placeholders = implode(',', array_fill(0, count($ids), '%d'));
+            // Anonymise rather than delete — preserves aggregate counts on
+            // the analytics dashboard (sent/delivered/clicked totals stay
+            // truthful) while removing the personally-identifiable fields.
+            $wpdb->query(
+                $wpdb->prepare(
+                    "UPDATE {$table} SET phone='', message_preview='', meta='[]', updated_at=%s WHERE id IN ({$placeholders})",
+                    array_merge([current_time('mysql')], $ids)
+                )
+            );
+            $removed = count($ids);
+            $messages[] = __('WhatsApp messaging events were anonymised. Aggregate counts are preserved.', 'woochat-pro');
+        }
+    }
+    return [
+        'items_removed'  => $removed,
+        'items_retained' => 0,
+        'messages'       => $messages,
+        'done'           => true,
+    ];
+}
+
+function wcwp_privacy_erase_carts($email_address, $page = 1) {
+    $phones = wcwp_privacy_phones_for_email($email_address);
+    $removed = 0;
+    if (!empty($phones)) {
+        global $wpdb;
+        $table = wcwp_get_cart_table_name();
+        $lookup = array_flip($phones);
+        $candidates = [];
+        foreach ($phones as $phone) {
+            $suffix = wcwp_privacy_phone_match_suffix($phone);
+            if ($suffix === '') continue;
+            $rows = $wpdb->get_results(
+                $wpdb->prepare(
+                    "SELECT id, phone FROM {$table} WHERE phone LIKE %s LIMIT 500",
+                    '%' . $wpdb->esc_like($suffix) . '%'
+                ),
+                ARRAY_A
+            );
+            if ($rows) {
+                foreach ($rows as $row) $candidates[(int) $row['id']] = $row;
+            }
+        }
+        $matched = wcwp_privacy_filter_rows_by_normalized_phone(array_values($candidates), $lookup);
+        if (!empty($matched)) {
+            $ids = array_map('intval', array_column($matched, 'id'));
+            $placeholders = implode(',', array_fill(0, count($ids), '%d'));
+            $wpdb->query($wpdb->prepare("DELETE FROM {$table} WHERE id IN ({$placeholders})", $ids));
+            $removed = count($ids);
+        }
+    }
+    return [
+        'items_removed'  => $removed,
+        'items_retained' => 0,
+        'messages'       => [],
+        'done'           => true,
+    ];
+}
+
+function wcwp_privacy_erase_campaigns($email_address, $page = 1) {
+    $phones = wcwp_privacy_phones_for_email($email_address);
+    $removed = 0;
+    if (!empty($phones)) {
+        global $wpdb;
+        $table = wcwp_campaign_recipients_table_name();
+        $lookup = array_flip($phones);
+        $candidates = [];
+        foreach ($phones as $phone) {
+            $suffix = wcwp_privacy_phone_match_suffix($phone);
+            if ($suffix === '') continue;
+            $rows = $wpdb->get_results(
+                $wpdb->prepare(
+                    "SELECT id, phone FROM {$table} WHERE phone LIKE %s LIMIT 500",
+                    '%' . $wpdb->esc_like($suffix) . '%'
+                ),
+                ARRAY_A
+            );
+            if ($rows) {
+                foreach ($rows as $row) $candidates[(int) $row['id']] = $row;
+            }
+        }
+        $matched = wcwp_privacy_filter_rows_by_normalized_phone(array_values($candidates), $lookup);
+        if (!empty($matched)) {
+            $ids = array_map('intval', array_column($matched, 'id'));
+            $placeholders = implode(',', array_fill(0, count($ids), '%d'));
+            $wpdb->query($wpdb->prepare("DELETE FROM {$table} WHERE id IN ({$placeholders})", $ids));
+            $removed = count($ids);
+        }
+    }
+    return [
+        'items_removed'  => $removed,
+        'items_retained' => 0,
+        'messages'       => [],
+        'done'           => true,
+    ];
+}
+
+function wcwp_privacy_erase_optout($email_address, $page = 1) {
+    $phones = wcwp_privacy_phones_for_email($email_address);
+    $retained = 0;
+    $messages = [];
+    if (!empty($phones)) {
+        $optout = wcwp_get_optout_list();
+        foreach ($phones as $phone) {
+            if (in_array($phone, $optout, true)) {
+                $retained++;
+            }
+        }
+        if ($retained > 0) {
+            $messages[] = __('Suppression list entries are retained to keep your prior opt-out request honoured. They will not be used to contact you.', 'woochat-pro');
+        }
+    }
+    return [
+        'items_removed'  => 0,
+        'items_retained' => $retained,
+        'messages'       => $messages,
+        'done'           => true,
+    ];
+}

--- a/tests/Unit/PrivacyTest.php
+++ b/tests/Unit/PrivacyTest.php
@@ -1,0 +1,153 @@
+<?php
+declare(strict_types=1);
+
+namespace WooChatPro\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class PrivacyTest extends TestCase
+{
+    public function test_phone_match_suffix_returns_last_eight_digits(): void
+    {
+        $this->assertSame('12345678', \wcwp_privacy_phone_match_suffix('+1 (555) 412-345-678'));
+    }
+
+    public function test_phone_match_suffix_returns_full_string_when_short(): void
+    {
+        $this->assertSame('1234567', \wcwp_privacy_phone_match_suffix('1234567'));
+    }
+
+    public function test_phone_match_suffix_strips_non_digits(): void
+    {
+        $this->assertSame('23456789', \wcwp_privacy_phone_match_suffix('+92 (300) 123-456-789'));
+    }
+
+    public function test_phone_match_suffix_returns_empty_for_no_digits(): void
+    {
+        $this->assertSame('', \wcwp_privacy_phone_match_suffix('abc'));
+        $this->assertSame('', \wcwp_privacy_phone_match_suffix(''));
+    }
+
+    public function test_format_event_row_returns_well_formed_export_item(): void
+    {
+        $row = [
+            'event_id'        => 'evt_123',
+            'type'            => 'order',
+            'status'          => 'sent',
+            'phone'           => '+15551234567',
+            'order_id'        => 42,
+            'message_preview' => 'Thanks for your order!',
+            'provider'        => 'twilio',
+            'message_id'      => 'SMxxx',
+            'created_at'      => '2026-05-09 12:34:56',
+        ];
+        $item = \wcwp_privacy_format_event_row($row);
+
+        $this->assertSame('woochat-pro-events', $item['group_id']);
+        $this->assertSame('wcwp-event-evt_123', $item['item_id']);
+        $this->assertNotSame('', $item['group_label']);
+
+        $byName = [];
+        foreach ($item['data'] as $field) $byName[$field['name']] = $field['value'];
+        $this->assertSame('order', $byName['Type']);
+        $this->assertSame('sent', $byName['Status']);
+        $this->assertSame('+15551234567', $byName['Phone']);
+        $this->assertSame('42', $byName['Order ID']);
+        $this->assertSame('twilio', $byName['Provider']);
+        $this->assertSame('SMxxx', $byName['Message ID']);
+        $this->assertSame('Thanks for your order!', $byName['Preview']);
+        $this->assertSame('2026-05-09 12:34:56', $byName['Date']);
+    }
+
+    public function test_format_event_row_handles_missing_fields_gracefully(): void
+    {
+        $item = \wcwp_privacy_format_event_row(['event_id' => 'evt_x']);
+
+        $this->assertSame('wcwp-event-evt_x', $item['item_id']);
+        // All eight fields are present even when source row is sparse —
+        // WP privacy export tolerates blank values but expects the schema.
+        $this->assertCount(8, $item['data']);
+    }
+
+    public function test_format_cart_row_returns_well_formed_export_item(): void
+    {
+        $row = [
+            'id'         => 7,
+            'phone'      => '+15551234567',
+            'total'      => '49.95',
+            'cart_json'  => '[{"name":"Widget"}]',
+            'status'     => 'pending',
+            'consent'    => 'yes',
+            'attempts'   => 1,
+            'created_at' => '2026-05-09 12:34:56',
+        ];
+        $item = \wcwp_privacy_format_cart_row($row);
+
+        $this->assertSame('woochat-pro-carts', $item['group_id']);
+        $this->assertSame('wcwp-cart-7', $item['item_id']);
+
+        $byName = [];
+        foreach ($item['data'] as $field) $byName[$field['name']] = $field['value'];
+        $this->assertSame('+15551234567', $byName['Phone']);
+        $this->assertSame('49.95', $byName['Total']);
+        $this->assertSame('[{"name":"Widget"}]', $byName['Items']);
+        $this->assertSame('1', $byName['Attempts']);
+    }
+
+    public function test_format_campaign_recipient_row_uses_provided_campaign_name(): void
+    {
+        $row = [
+            'id'            => 11,
+            'campaign_id'   => 5,
+            'phone'         => '+15551234567',
+            'customer_name' => 'Jane Doe',
+            'status'        => 'sent',
+            'sent_at'       => '2026-05-09 12:34:56',
+        ];
+        $item = \wcwp_privacy_format_campaign_recipient_row($row, 'April promo blast');
+
+        $this->assertSame('wcwp-campaign-recipient-11', $item['item_id']);
+
+        $byName = [];
+        foreach ($item['data'] as $field) $byName[$field['name']] = $field['value'];
+        $this->assertSame('April promo blast', $byName['Campaign']);
+        $this->assertSame('Jane Doe', $byName['Customer name']);
+    }
+
+    public function test_format_campaign_recipient_row_falls_back_to_campaign_id(): void
+    {
+        $row = [
+            'id'          => 11,
+            'campaign_id' => 5,
+            'phone'       => '+15551234567',
+        ];
+        $item = \wcwp_privacy_format_campaign_recipient_row($row, '');
+
+        $byName = [];
+        foreach ($item['data'] as $field) $byName[$field['name']] = $field['value'];
+        $this->assertSame('#5', $byName['Campaign']);
+    }
+
+    public function test_filter_rows_by_normalized_phone_drops_non_matches(): void
+    {
+        $rows = [
+            ['id' => 1, 'phone' => '+1 (555) 123-4567'],   // matches
+            ['id' => 2, 'phone' => '+1 (999) 000-0000'],   // does not match
+            ['id' => 3, 'phone' => '15551234567'],          // matches (different format, same digits)
+            ['id' => 4],                                     // skipped — no phone
+            ['id' => 5, 'phone' => 'abc'],                  // skipped — empty after normalisation
+        ];
+        $lookup = ['15551234567' => true];
+
+        $matched = \wcwp_privacy_filter_rows_by_normalized_phone($rows, $lookup);
+
+        $this->assertCount(2, $matched);
+        $this->assertSame([1, 3], array_column($matched, 'id'));
+    }
+
+    public function test_filter_rows_by_normalized_phone_returns_empty_for_empty_inputs(): void
+    {
+        $this->assertSame([], \wcwp_privacy_filter_rows_by_normalized_phone([], ['x' => true]));
+        $this->assertSame([], \wcwp_privacy_filter_rows_by_normalized_phone([['phone' => 'x']], []));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -88,3 +88,4 @@ require_once __DIR__ . '/../includes/blocks.php';
 require_once __DIR__ . '/../includes/analytics.php';
 require_once __DIR__ . '/../includes/template-library.php';
 require_once __DIR__ . '/../includes/ab-testing.php';
+require_once __DIR__ . '/../includes/privacy.php';


### PR DESCRIPTION
## Summary

Tier 3 #11 of the premium roadmap. Hooks the plugin's PII-bearing data into Tools → Export Personal Data and Tools → Erase Personal Data so EU stores have a one-click answer to a Subject Access Request or Right-to-Erasure request. Required before the plugin can credibly sell into EU markets.

## What changed

**Coverage** — Four data sources, four exporter + four eraser callbacks each:
- `wp_wcwp_analytics_events` — per-message log.
- `wp_wcwp_abandoned_carts` — recovery queue.
- `wp_wcwp_campaign_recipients` — bulk-campaign recipient list.
- `wcwp_optout_list` option — suppression list of opted-out phones.

**Email → phone resolution** — WP privacy keys everything by email but our tables store phones. `wcwp_privacy_phones_for_email()` pulls `billing_phone` from the matching WP user (registered customers) and from every WC order under that email (covers guest checkouts and customers who used a different phone on a later order). Each candidate is `wcwp_normalize_phone()`'d and deduped before query.

**Match strategy** — Stored phones may have country codes, spaces, dashes, or parentheses — we can't reliably exact-match against a normalised target. The exporter/eraser does a coarse `LIKE %lastEightDigits%` (still cardinality-cheap because phone is indexed in all three tables), then filters false positives in PHP via the pure helper `wcwp_privacy_filter_rows_by_normalized_phone()` — normalises both sides and returns rows whose phone exactly matches one of the resolved targets.

**Erasure policy** — Three different tactics for three different data shapes:
- Analytics events are *anonymised* (phone, message_preview, meta cleared via UPDATE) — aggregate counts on the dashboard stay truthful.
- Cart and campaign-recipient rows are deleted outright.
- Opt-out list is *retained* with a message citing the legitimate-interest exception under Recital 47 — deleting it would re-enable communications, the opposite of what the user originally asked when they opted out.

**Privacy policy snippet** — `wcwp_privacy_register_policy_content()` registers a multi-paragraph block via `wp_add_privacy_policy_content()` describing exactly what the plugin stores, why, and how customers can request export/erasure. Admins running Tools → Privacy → Privacy Policy Guide get copy-paste-able text. Hooks on `admin_init` so it only runs in admin.

## What stays the same

- All four data tables/options stay schema-identical — no migration needed.
- Existing message-sending paths, opt-out handling, and analytics aggregation are unchanged.
- No new admin UI surface — everything routes through the standard WP privacy tools the user is already familiar with.
- No new dependencies; uses only stock WP filters and `sanitize_email` / `wc_get_orders` / `wpdb`.

## Test plan

- [x] PHPUnit: 64 tests / 427 assertions green (`composer test`).
- [x] PHPCS: clean against project ruleset (`composer lint`).
- [x] In Tools → Export Personal Data, request export for a registered customer's email — the JSON archive contains "WooChat Pro – WhatsApp messaging events / Abandoned cart records / Bulk campaign recipients / Opt-out status" sections (when matching data exists).
- [x] Same for a guest-checkout email (no WP user, only WC orders) — phones are still resolved via order billing_phone.
- [x] In Tools → Erase Personal Data, request erasure for that email — analytics events for that phone keep `id` / `event_id` / `type` / `status` / `created_at` but lose `phone` / `message_preview` / `meta`. Cart + campaign-recipient rows are gone. Opt-out entry survives with a "retained" message in the report.
- [x] In Tools → Privacy → Privacy Policy Guide, the WooChat Pro section is present with the four-bullet "What is stored" list.
- [x] Aggregate analytics totals after an erasure are unchanged from before — sent/delivered/clicked counts hold.

## Risk / rollback

Low risk. New file is the only surface; no changes to existing message paths, options, or schema. The exporter/eraser callbacks are gated behind WP's privacy admin flow (only admins with `manage_privacy_options` reach them). Rollback = revert the merge commit; no DB cleanup required.