### PR TITLE
Admin log viewer — closes Tier 3

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -223,6 +223,7 @@ function wcwp_render_settings_page() {
             'inactive'           => __('Inactive', 'woochat-pro'),
             'deactivationFailed' => __('Deactivation failed', 'woochat-pro'),
         ],
+        'logClearConfirm' => __('Clear the log file? This cannot be undone.', 'woochat-pro'),
     ]);
     // Onboarding wizard renders once per install — Skip/Finish persists the
     // dismissal flag via admin-ajax, after which the modal stops re-mounting.
@@ -379,6 +380,7 @@ function wcwp_render_settings_page() {
             <button type="button" class="wcwp-tab" data-tab="scheduler"><?php esc_html_e('Scheduler', 'woochat-pro'); ?></button>
             <button type="button" class="wcwp-tab" data-tab="campaigns"><?php esc_html_e('Campaigns', 'woochat-pro'); ?></button>
             <button type="button" class="wcwp-tab" data-tab="analytics"><?php esc_html_e('Analytics', 'woochat-pro'); ?></button>
+            <button type="button" class="wcwp-tab" data-tab="logs"><?php esc_html_e('Logs', 'woochat-pro'); ?></button>
             <button type="button" class="wcwp-tab" data-tab="license"><?php esc_html_e('License', 'woochat-pro'); ?></button>
         </div>
         <div class="wcwp-plugin-splash">
@@ -395,6 +397,7 @@ function wcwp_render_settings_page() {
             <?php require $views . '/tab-analytics.php'; ?>
             <?php require $views . '/tab-scheduler.php'; ?>
             <?php require $views . '/tab-campaigns.php'; ?>
+            <?php require $views . '/tab-logs.php'; ?>
             <?php require $views . '/tab-license.php'; ?>
             <?php submit_button(); ?>
         </form>

--- a/admin/views/tab-logs.php
+++ b/admin/views/tab-logs.php
@@ -1,0 +1,142 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+$wcwp_log_keyword  = isset($_GET['wcwp_log_q'])     ? sanitize_text_field(wp_unslash($_GET['wcwp_log_q']))     : '';
+$wcwp_log_tag      = isset($_GET['wcwp_log_tag'])   ? sanitize_text_field(wp_unslash($_GET['wcwp_log_tag']))   : '';
+$wcwp_log_lines    = isset($_GET['wcwp_log_lines']) ? max(50, min(2000, (int) $_GET['wcwp_log_lines']))        : 200;
+$wcwp_log_message  = isset($_GET['wcwp_log_msg'])   ? sanitize_text_field(wp_unslash($_GET['wcwp_log_msg']))   : '';
+
+$wcwp_log_file     = wcwp_get_log_file();
+$wcwp_log_exists   = is_file($wcwp_log_file);
+$wcwp_log_size     = wcwp_log_size_bytes();
+$wcwp_log_lines_raw = $wcwp_log_exists ? wcwp_log_tail_lines($wcwp_log_file, $wcwp_log_lines) : [];
+
+$wcwp_log_all_entries = [];
+foreach ($wcwp_log_lines_raw as $wcwp_log_line) {
+    $wcwp_log_all_entries[] = wcwp_log_parse_line($wcwp_log_line);
+}
+$wcwp_log_tags_available = wcwp_log_tags_present($wcwp_log_all_entries);
+$wcwp_log_filtered = wcwp_log_filter_lines($wcwp_log_lines_raw, $wcwp_log_keyword, $wcwp_log_tag);
+
+$wcwp_log_download_url = wp_nonce_url(
+    add_query_arg(['action' => 'wcwp_log_download'], admin_url('admin-post.php')),
+    'wcwp_log_download',
+    'wcwp_log_download_nonce'
+);
+$wcwp_log_clear_url = wp_nonce_url(
+    add_query_arg(['action' => 'wcwp_log_clear'], admin_url('admin-post.php')),
+    'wcwp_log_clear',
+    'wcwp_log_clear_nonce'
+);
+?>
+<div id="wcwp-tab-content-logs" class="wcwp-tab-content" style="display:none;">
+    <h2><?php esc_html_e('Logs', 'woochat-pro'); ?></h2>
+    <p class="description">
+        <?php
+        printf(
+            /* translators: %s is the absolute path to the plugin log file */
+            esc_html__('Reading from %s', 'woochat-pro'),
+            '<code>' . esc_html($wcwp_log_file) . '</code>'
+        );
+        ?>
+        — <?php
+        if ($wcwp_log_exists) {
+            printf(
+                /* translators: %s is the file size, already i18n-formatted (e.g. "12.4 KB") */
+                esc_html__('current size: %s', 'woochat-pro'),
+                esc_html(size_format($wcwp_log_size, 1) ?: '0 B')
+            );
+        } else {
+            esc_html_e('the file does not exist yet — it is created the first time the plugin writes a log entry.', 'woochat-pro');
+        }
+        ?>
+    </p>
+
+    <?php if ($wcwp_log_message === 'cleared') : ?>
+        <div class="notice notice-success is-dismissible" style="margin:10px 0;"><p><?php esc_html_e('Log file cleared.', 'woochat-pro'); ?></p></div>
+    <?php elseif ($wcwp_log_message === 'fail') : ?>
+        <div class="notice notice-error is-dismissible" style="margin:10px 0;"><p><?php esc_html_e('Could not clear the log file. Check write permissions for wp-content/uploads/woochat-pro/.', 'woochat-pro'); ?></p></div>
+    <?php elseif ($wcwp_log_message === 'empty') : ?>
+        <div class="notice notice-warning is-dismissible" style="margin:10px 0;"><p><?php esc_html_e('Log file does not exist yet — nothing to download.', 'woochat-pro'); ?></p></div>
+    <?php endif; ?>
+
+    <div class="wcwp-log-filters" style="margin:12px 0;display:flex;gap:8px;flex-wrap:wrap;align-items:end;">
+        <div>
+            <label for="wcwp_log_q"><?php esc_html_e('Keyword', 'woochat-pro'); ?></label><br>
+            <input type="text" id="wcwp_log_q" name="wcwp_log_q" value="<?php echo esc_attr($wcwp_log_keyword); ?>" placeholder="opt-out, sent, error" />
+        </div>
+        <div>
+            <label for="wcwp_log_tag"><?php esc_html_e('Source', 'woochat-pro'); ?></label><br>
+            <select id="wcwp_log_tag" name="wcwp_log_tag">
+                <option value=""><?php esc_html_e('All sources', 'woochat-pro'); ?></option>
+                <?php foreach ($wcwp_log_tags_available as $wcwp_log_t) : ?>
+                    <option value="<?php echo esc_attr($wcwp_log_t); ?>" <?php selected($wcwp_log_tag, $wcwp_log_t); ?>><?php echo esc_html($wcwp_log_t); ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div>
+            <label for="wcwp_log_lines"><?php esc_html_e('Lines', 'woochat-pro'); ?></label><br>
+            <select id="wcwp_log_lines" name="wcwp_log_lines">
+                <?php foreach ([100, 200, 500, 1000, 2000] as $wcwp_log_n) : ?>
+                    <option value="<?php echo esc_attr((string) $wcwp_log_n); ?>" <?php selected($wcwp_log_lines, $wcwp_log_n); ?>><?php echo esc_html((string) $wcwp_log_n); ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div>
+            <button type="button" class="button button-primary" id="wcwp-log-filter-button"><?php esc_html_e('Apply', 'woochat-pro'); ?></button>
+        </div>
+        <div>
+            <a class="button" href="<?php echo esc_url($wcwp_log_download_url); ?>"><span class="dashicons dashicons-download" style="vertical-align:middle;line-height:28px;"></span> <?php esc_html_e('Download log', 'woochat-pro'); ?></a>
+        </div>
+        <div>
+            <a class="button" href="<?php echo esc_url($wcwp_log_clear_url); ?>" id="wcwp-log-clear-button" style="color:#b32d2e;"><span class="dashicons dashicons-trash" style="vertical-align:middle;line-height:28px;"></span> <?php esc_html_e('Clear log', 'woochat-pro'); ?></a>
+        </div>
+    </div>
+
+    <?php
+    $wcwp_log_total_shown = count($wcwp_log_all_entries);
+    $wcwp_log_total_match = count($wcwp_log_filtered);
+    ?>
+    <p class="description" style="margin:6px 0;">
+        <?php
+        printf(
+            /* translators: 1: number of matching entries, 2: total entries in the current window */
+            esc_html__('Showing %1$d of %2$d recent entries.', 'woochat-pro'),
+            (int) $wcwp_log_total_match,
+            (int) $wcwp_log_total_shown
+        );
+        ?>
+        <?php if ($wcwp_log_total_shown >= $wcwp_log_lines) : ?>
+            <em><?php esc_html_e('Older entries are not shown — increase "Lines" or download the full log.', 'woochat-pro'); ?></em>
+        <?php endif; ?>
+    </p>
+
+    <table class="widefat striped" style="margin-top:6px;">
+        <thead>
+            <tr>
+                <th style="width:200px;"><?php esc_html_e('Source', 'woochat-pro'); ?></th>
+                <th><?php esc_html_e('Message', 'woochat-pro'); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php if (!empty($wcwp_log_filtered)) : ?>
+                <?php foreach (array_reverse($wcwp_log_filtered) as $wcwp_log_entry) : ?>
+                    <tr>
+                        <td><code style="font-size:0.92em;"><?php echo esc_html($wcwp_log_entry['tag'] !== '' ? $wcwp_log_entry['tag'] : '—'); ?></code></td>
+                        <td><pre style="white-space:pre-wrap;font-size:0.95em;margin:0;"><?php echo esc_html($wcwp_log_entry['message']); ?></pre></td>
+                    </tr>
+                <?php endforeach; ?>
+            <?php else : ?>
+                <tr><td colspan="2"><?php
+                    if (!$wcwp_log_exists) {
+                        esc_html_e('Log file does not exist yet.', 'woochat-pro');
+                    } elseif ($wcwp_log_total_shown === 0) {
+                        esc_html_e('Log file is empty.', 'woochat-pro');
+                    } else {
+                        esc_html_e('No entries match the current filters.', 'woochat-pro');
+                    }
+                ?></td></tr>
+            <?php endif; ?>
+        </tbody>
+    </table>
+</div>

--- a/assets/js/admin-premium.js
+++ b/assets/js/admin-premium.js
@@ -344,6 +344,49 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 });
 
+// Logs tab — Apply button rebuilds the URL with current filter values,
+// Clear button asks for explicit confirmation before destructive action.
+document.addEventListener('DOMContentLoaded', function () {
+    const applyBtn = document.getElementById('wcwp-log-filter-button');
+    if (applyBtn) {
+        applyBtn.addEventListener('click', function () {
+            const params = new URLSearchParams(window.location.search);
+            params.set('page', 'wcwp-settings');
+            params.set('tab', 'logs');
+            const fields = [
+                { id: 'wcwp_log_q',     key: 'wcwp_log_q' },
+                { id: 'wcwp_log_tag',   key: 'wcwp_log_tag' },
+                { id: 'wcwp_log_lines', key: 'wcwp_log_lines' }
+            ];
+            fields.forEach(function (field) {
+                const el = document.getElementById(field.id);
+                const value = el ? String(el.value).trim() : '';
+                if (value) {
+                    params.set(field.key, value);
+                } else {
+                    params.delete(field.key);
+                }
+            });
+            // The previous run may have left a status message in the URL —
+            // strip it so the redirect view doesn't show a stale notice.
+            params.delete('wcwp_log_msg');
+            window.location.search = params.toString();
+        });
+    }
+
+    const clearBtn = document.getElementById('wcwp-log-clear-button');
+    if (clearBtn) {
+        clearBtn.addEventListener('click', function (e) {
+            const confirmMsg = (window.wcwpAdminData && wcwpAdminData.logClearConfirm)
+                ? wcwpAdminData.logClearConfirm
+                : 'Clear the log file? This cannot be undone.';
+            if (!window.confirm(confirmMsg)) {
+                e.preventDefault();
+            }
+        });
+    }
+});
+
 // A/B test toggles — show/hide the Variant B textarea row when the
 // admin flips the per-kind toggle. Persisting still requires WP's
 // Save Changes; this is just live UI state.

--- a/includes/class-wcwp-plugin.php
+++ b/includes/class-wcwp-plugin.php
@@ -83,6 +83,7 @@ final class Plugin {
         require_once WCWP_PATH . 'includes/template-library.php';
         require_once WCWP_PATH . 'includes/ab-testing.php';
         require_once WCWP_PATH . 'includes/privacy.php';
+        require_once WCWP_PATH . 'includes/log-viewer.php';
         require_once WCWP_PATH . 'admin/settings-page.php';
         require_once WCWP_PATH . 'includes/chatbot-engine.php';
         require_once WCWP_PATH . 'includes/license-manager.php';

--- a/includes/log-viewer.php
+++ b/includes/log-viewer.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * Admin-side log viewer.
+ *
+ * Surfaces the plugin's log file (`wp-content/uploads/woochat-pro/
+ * woochat-pro.log` — see wcwp_get_log_file()) inside the WooChat
+ * Settings page so admins don't have to SFTP into uploads/ to debug a
+ * failed send. Every write into that file already goes through the
+ * shared `error_log($msg, 3, $log_file)` pattern in messaging.php and
+ * cart-recovery.php; this module only adds *read* paths.
+ *
+ * Provides three operations:
+ *   1. Tail-and-display: read the last N lines, parse each into
+ *      tag/message, render as a filterable table. The reverse-chunk
+ *      reader (`wcwp_log_tail_lines()`) avoids loading the whole file
+ *      into memory.
+ *   2. Download: stream the raw file as text/plain to the admin so they
+ *      can attach it to a support ticket. Capability + nonce gated.
+ *   3. Clear: truncate the file in place. Capability + nonce gated.
+ *      Truncation (vs. unlink) keeps the existing fd's of any
+ *      concurrent writers valid and preserves the .htaccess/index.php
+ *      siblings that wcwp_get_log_file() set up.
+ */
+
+if (!defined('ABSPATH')) exit;
+
+add_action('admin_post_wcwp_log_download', 'wcwp_log_download_handler');
+add_action('admin_post_wcwp_log_clear', 'wcwp_log_clear_handler');
+
+/**
+ * Read the last N lines of a file by reverse-chunking from EOF.
+ *
+ * Returns lines in chronological order (oldest → newest). Handles
+ * arbitrary file sizes without loading the whole thing into memory.
+ * Stops early once the requested line count is reached. Empty lines
+ * are stripped.
+ *
+ * Tested in tests/Unit/LogViewerTest.php with a synthetic file.
+ *
+ * @param string $file       Absolute path to the log file.
+ * @param int    $max_lines  Cap on returned lines (defaults to 200).
+ * @param int    $chunk_size Chunk read size in bytes (defaults to 4096).
+ * @return string[] Lines, oldest first.
+ */
+function wcwp_log_tail_lines($file, $max_lines = 200, $chunk_size = 4096) {
+    if ($max_lines < 1) return [];
+    if (!is_string($file) || !is_file($file) || !is_readable($file)) return [];
+
+    $fp = @fopen($file, 'rb');
+    if (!$fp) return [];
+
+    fseek($fp, 0, SEEK_END);
+    $position = ftell($fp);
+    if ($position === 0) {
+        fclose($fp);
+        return [];
+    }
+
+    $buffer = '';
+    $line_count = 0;
+    $chunk_size = max(512, (int) $chunk_size);
+
+    while ($line_count <= $max_lines && $position > 0) {
+        $read = (int) min($chunk_size, $position);
+        $position -= $read;
+        fseek($fp, $position);
+        $chunk = fread($fp, $read);
+        if ($chunk === false) break;
+        $buffer = $chunk . $buffer;
+        $line_count = substr_count($buffer, "\n");
+    }
+    fclose($fp);
+
+    $lines = preg_split('/\r?\n/', $buffer);
+    if (!is_array($lines)) return [];
+
+    // Strip empties before slicing — a trailing newline yields a phantom
+    // empty element, and the leading element may be a partial line from
+    // mid-chunk; slicing first would lose one real line per phantom.
+    $out = [];
+    foreach ($lines as $line) {
+        $line = rtrim($line);
+        if ($line === '') continue;
+        $out[] = $line;
+    }
+
+    if (count($out) > $max_lines) {
+        $out = array_slice($out, -$max_lines);
+    }
+    return $out;
+}
+
+/**
+ * Parse one log line into [tag, message, raw].
+ *
+ * Lines written by messaging.php / cart-recovery.php look like:
+ *   [WooChat Pro] message text
+ *   [WooChat Pro - Cart Recovery] message text
+ *   [WooChat Pro - MANUAL] message text
+ *
+ * The bracketed prefix is the "tag" we surface in the filter dropdown.
+ * Lines without a recognised prefix get an empty tag and the whole
+ * line as the message — better than dropping them.
+ *
+ * Pure helper, no side effects.
+ *
+ * @param string $line Raw log line (no trailing newline).
+ * @return array{tag:string, message:string, raw:string}
+ */
+function wcwp_log_parse_line($line) {
+    $line = (string) $line;
+    if ($line === '') {
+        return ['tag' => '', 'message' => '', 'raw' => ''];
+    }
+    if (preg_match('/^\[(WooChat Pro(?: - [^\]]+)?)\]\s*(.*)$/', $line, $matches)) {
+        return [
+            'tag'     => $matches[1],
+            'message' => $matches[2],
+            'raw'     => $line,
+        ];
+    }
+    return ['tag' => '', 'message' => $line, 'raw' => $line];
+}
+
+/**
+ * Return parsed log entries, optionally filtered by tag and keyword.
+ *
+ * Pure-ish: pulls the raw lines via wcwp_log_tail_lines() then runs
+ * everything else in PHP so the filter logic itself is testable
+ * (caller can pass already-parsed lines via the alt arg).
+ *
+ * @param string[] $lines    Raw lines (oldest first).
+ * @param string   $keyword  Substring to match (case-insensitive). Empty = no keyword filter.
+ * @param string   $tag      Exact tag match. Empty = no tag filter.
+ * @return array<int, array{tag:string, message:string, raw:string}>
+ */
+function wcwp_log_filter_lines($lines, $keyword = '', $tag = '') {
+    if (!is_array($lines)) return [];
+
+    $keyword = is_string($keyword) ? trim($keyword) : '';
+    $tag     = is_string($tag) ? trim($tag) : '';
+
+    $out = [];
+    foreach ($lines as $line) {
+        $parsed = wcwp_log_parse_line($line);
+        if ($tag !== '' && $parsed['tag'] !== $tag) continue;
+        if ($keyword !== '' && stripos($parsed['raw'], $keyword) === false) continue;
+        $out[] = $parsed;
+    }
+    return $out;
+}
+
+/**
+ * Distinct tags present in the supplied entries.
+ *
+ * Used to populate the filter dropdown so admins only see tags that
+ * actually exist in their current log window — no dead options.
+ *
+ * @param array<int, array{tag:string}> $entries
+ * @return string[]
+ */
+function wcwp_log_tags_present($entries) {
+    if (!is_array($entries)) return [];
+    $seen = [];
+    foreach ($entries as $entry) {
+        $tag = isset($entry['tag']) ? (string) $entry['tag'] : '';
+        if ($tag === '') continue;
+        $seen[$tag] = true;
+    }
+    $out = array_keys($seen);
+    sort($out);
+    return $out;
+}
+
+function wcwp_log_size_bytes() {
+    $file = wcwp_get_log_file();
+    if (!is_file($file)) return 0;
+    $size = @filesize($file);
+    return $size === false ? 0 : (int) $size;
+}
+
+function wcwp_log_download_handler() {
+    if (!current_user_can('manage_options')) {
+        wp_die(esc_html__('Unauthorized', 'woochat-pro'), '', ['response' => 403]);
+    }
+    check_admin_referer('wcwp_log_download', 'wcwp_log_download_nonce');
+
+    $file = wcwp_get_log_file();
+    if (!is_file($file) || !is_readable($file)) {
+        wp_safe_redirect(add_query_arg(['page' => 'wcwp-settings', 'tab' => 'logs', 'wcwp_log_msg' => 'empty'], admin_url('admin.php')));
+        exit;
+    }
+
+    $filename = 'woochat-pro-' . gmdate('Ymd-His') . '.log';
+    nocache_headers();
+    header('Content-Type: text/plain; charset=utf-8');
+    header('Content-Disposition: attachment; filename="' . $filename . '"');
+    header('Content-Length: ' . (string) filesize($file));
+    @readfile($file); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_readfile -- streaming a controlled path inside uploads/, capability + nonce gated.
+    exit;
+}
+
+function wcwp_log_clear_handler() {
+    if (!current_user_can('manage_options')) {
+        wp_die(esc_html__('Unauthorized', 'woochat-pro'), '', ['response' => 403]);
+    }
+    check_admin_referer('wcwp_log_clear', 'wcwp_log_clear_nonce');
+
+    $file = wcwp_get_log_file();
+    $msg  = 'cleared';
+    if (is_file($file)) {
+        // Truncate in place (vs. unlink) so concurrent fds in messaging.php
+        // / cart-recovery.php stay valid and the .htaccess/index.php
+        // siblings created by wcwp_get_log_file() are preserved.
+        $fp = @fopen($file, 'wb');
+        if ($fp) {
+            @ftruncate($fp, 0);
+            fclose($fp);
+        } else {
+            $msg = 'fail';
+        }
+    }
+
+    wp_safe_redirect(add_query_arg([
+        'page'         => 'wcwp-settings',
+        'tab'          => 'logs',
+        'wcwp_log_msg' => $msg,
+    ], admin_url('admin.php')));
+    exit;
+}

--- a/tests/Unit/LogViewerTest.php
+++ b/tests/Unit/LogViewerTest.php
@@ -1,0 +1,182 @@
+<?php
+declare(strict_types=1);
+
+namespace WooChatPro\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class LogViewerTest extends TestCase
+{
+    /** @var string|null */
+    private $tmp_file = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->tmp_file !== null && file_exists($this->tmp_file)) {
+            unlink($this->tmp_file);
+        }
+        $this->tmp_file = null;
+    }
+
+    private function write_tmp(string $contents): string
+    {
+        $this->tmp_file = tempnam(sys_get_temp_dir(), 'wcwp-log-test-');
+        file_put_contents($this->tmp_file, $contents);
+        return $this->tmp_file;
+    }
+
+    public function test_parse_line_returns_tag_and_message(): void
+    {
+        $parsed = \wcwp_log_parse_line('[WooChat Pro] Sent message to ••••1234');
+        $this->assertSame('WooChat Pro', $parsed['tag']);
+        $this->assertSame('Sent message to ••••1234', $parsed['message']);
+        $this->assertSame('[WooChat Pro] Sent message to ••••1234', $parsed['raw']);
+    }
+
+    public function test_parse_line_preserves_subtag(): void
+    {
+        $parsed = \wcwp_log_parse_line('[WooChat Pro - Cart Recovery] Attempt evt_xyz to ••••1234: Hi!');
+        $this->assertSame('WooChat Pro - Cart Recovery', $parsed['tag']);
+        $this->assertSame('Attempt evt_xyz to ••••1234: Hi!', $parsed['message']);
+    }
+
+    public function test_parse_line_handles_unprefixed_lines(): void
+    {
+        $parsed = \wcwp_log_parse_line('Stray line without prefix');
+        $this->assertSame('', $parsed['tag']);
+        $this->assertSame('Stray line without prefix', $parsed['message']);
+    }
+
+    public function test_parse_line_handles_empty_input(): void
+    {
+        $parsed = \wcwp_log_parse_line('');
+        $this->assertSame('', $parsed['tag']);
+        $this->assertSame('', $parsed['message']);
+        $this->assertSame('', $parsed['raw']);
+    }
+
+    public function test_tail_returns_empty_for_missing_file(): void
+    {
+        $this->assertSame([], \wcwp_log_tail_lines('/no/such/file.log', 10));
+    }
+
+    public function test_tail_returns_empty_for_zero_max_lines(): void
+    {
+        $file = $this->write_tmp("a\nb\nc\n");
+        $this->assertSame([], \wcwp_log_tail_lines($file, 0));
+    }
+
+    public function test_tail_returns_empty_for_empty_file(): void
+    {
+        $file = $this->write_tmp('');
+        $this->assertSame([], \wcwp_log_tail_lines($file, 10));
+    }
+
+    public function test_tail_reads_all_lines_when_within_limit(): void
+    {
+        $file = $this->write_tmp("first\nsecond\nthird\n");
+        $lines = \wcwp_log_tail_lines($file, 10);
+        $this->assertSame(['first', 'second', 'third'], $lines);
+    }
+
+    public function test_tail_returns_only_last_n_when_file_is_larger(): void
+    {
+        $contents = '';
+        for ($i = 1; $i <= 1000; $i++) {
+            $contents .= "line {$i}\n";
+        }
+        $file = $this->write_tmp($contents);
+
+        $lines = \wcwp_log_tail_lines($file, 5);
+
+        // Lines come back oldest → newest within the window
+        $this->assertSame(
+            ['line 996', 'line 997', 'line 998', 'line 999', 'line 1000'],
+            $lines
+        );
+    }
+
+    public function test_tail_handles_file_without_trailing_newline(): void
+    {
+        $file = $this->write_tmp("alpha\nbravo");
+        $lines = \wcwp_log_tail_lines($file, 10);
+        $this->assertSame(['alpha', 'bravo'], $lines);
+    }
+
+    public function test_tail_strips_blank_lines(): void
+    {
+        $file = $this->write_tmp("a\n\nb\n\n\nc\n");
+        $lines = \wcwp_log_tail_lines($file, 10);
+        $this->assertSame(['a', 'b', 'c'], $lines);
+    }
+
+    public function test_filter_lines_applies_keyword_case_insensitively(): void
+    {
+        $lines = [
+            '[WooChat Pro] Sent OK',
+            '[WooChat Pro] Send failed: timeout',
+            '[WooChat Pro - Cart Recovery] Sent reminder',
+        ];
+        $filtered = \wcwp_log_filter_lines($lines, 'sent');
+
+        $this->assertCount(2, $filtered);
+        $this->assertSame('Sent OK', $filtered[0]['message']);
+        $this->assertSame('Sent reminder', $filtered[1]['message']);
+    }
+
+    public function test_filter_lines_applies_tag_filter(): void
+    {
+        $lines = [
+            '[WooChat Pro] Sent OK',
+            '[WooChat Pro - Cart Recovery] Sent reminder',
+            '[WooChat Pro - MANUAL] Sent manual',
+        ];
+        $filtered = \wcwp_log_filter_lines($lines, '', 'WooChat Pro - Cart Recovery');
+
+        $this->assertCount(1, $filtered);
+        $this->assertSame('WooChat Pro - Cart Recovery', $filtered[0]['tag']);
+    }
+
+    public function test_filter_lines_combines_keyword_and_tag(): void
+    {
+        $lines = [
+            '[WooChat Pro] Sent OK',
+            '[WooChat Pro - Cart Recovery] Sent reminder',
+            '[WooChat Pro - Cart Recovery] Skipped opted-out number',
+        ];
+        $filtered = \wcwp_log_filter_lines($lines, 'opted', 'WooChat Pro - Cart Recovery');
+
+        $this->assertCount(1, $filtered);
+        $this->assertSame('Skipped opted-out number', $filtered[0]['message']);
+    }
+
+    public function test_filter_lines_returns_all_when_filters_empty(): void
+    {
+        $lines = ['[WooChat Pro] One', '[WooChat Pro] Two'];
+        $filtered = \wcwp_log_filter_lines($lines, '', '');
+
+        $this->assertCount(2, $filtered);
+    }
+
+    public function test_tags_present_returns_distinct_sorted_tags(): void
+    {
+        $entries = [
+            ['tag' => 'WooChat Pro - Cart Recovery'],
+            ['tag' => 'WooChat Pro'],
+            ['tag' => 'WooChat Pro - Cart Recovery'],
+            ['tag' => ''],
+            ['tag' => 'WooChat Pro - MANUAL'],
+        ];
+        $tags = \wcwp_log_tags_present($entries);
+
+        $this->assertSame(
+            ['WooChat Pro', 'WooChat Pro - Cart Recovery', 'WooChat Pro - MANUAL'],
+            $tags
+        );
+    }
+
+    public function test_tags_present_handles_empty_input(): void
+    {
+        $this->assertSame([], \wcwp_log_tags_present([]));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -89,3 +89,4 @@ require_once __DIR__ . '/../includes/analytics.php';
 require_once __DIR__ . '/../includes/template-library.php';
 require_once __DIR__ . '/../includes/ab-testing.php';
 require_once __DIR__ . '/../includes/privacy.php';
+require_once __DIR__ . '/../includes/log-viewer.php';


### PR DESCRIPTION
## Summary

Tier 3 #12 of the premium roadmap — and the closing item of Tier 3. Surfaces the plugin's log file (`wp-content/uploads/woochat-pro/woochat-pro.log`, see `wcwp_get_log_file()`) inside the WooChat Settings page so admins don't have to SFTP into `uploads/` to debug a failed send.

## What changed

**New "Logs" tab** between Analytics and License. Tab UI offers:
- Keyword filter (case-insensitive substring on the raw line).
- Source dropdown (only tags actually present in the current window are listed — no dead options).
- Lines selector (100 / 200 / 500 / 1000 / 2000), defaults to 200.
- Apply button — rebuilds the URL with current filter values, mirrors the Analytics filter pattern.
- Download log button — `admin_post_wcwp_log_download`, capability + nonce gated, streams as `text/plain` attachment.
- Clear log button — `admin_post_wcwp_log_clear`, capability + nonce gated, JS `confirm()` before submit.

**Reading** — `wcwp_log_tail_lines($file, $max_lines)` reads in reverse-chunked 4 KB blocks from EOF, accumulating until at least `$max_lines` newlines are buffered, then explodes once and returns oldest-first. Strips empty lines *before* slicing so the trailing newline + partial-leading-line don't eat real entries (regression-tested against a 1000-line synthetic file). Peak memory is ~`chunk_size + max_lines × avg_line_length`, never the whole file.

**Parsing** — `wcwp_log_parse_line()` extracts the bracketed prefix from each line:
- `[WooChat Pro]` → tag = `"WooChat Pro"`
- `[WooChat Pro - Cart Recovery]` → tag = `"WooChat Pro - Cart Recovery"`
- `[WooChat Pro - MANUAL]` → tag = `"WooChat Pro - MANUAL"`

Lines without a recognised prefix get an empty tag and the whole line as the message — better than dropping them.

**Filtering** — `wcwp_log_filter_lines()` and `wcwp_log_tags_present()` are both pure. Tag filter is exact match; keyword filter is case-insensitive substring.

**Clearing** — Truncate-in-place (`fopen 'wb'` + `ftruncate`) rather than unlink. Concurrent fds in `messaging.php` / `cart-recovery.php` stay valid and the `.htaccess` + `index.php` siblings created by `wcwp_get_log_file()` are preserved. Status rides back via a `wcwp_log_msg` query arg (`cleared` / `fail` / `empty`) and renders as a dismissible WP notice.

## What stays the same

- All log *write* paths in `messaging.php` / `cart-recovery.php` are untouched — this PR only adds read.
- No new tables, no new options. No migration.
- `wcwp_get_log_file()` is unchanged. The `.htaccess`/`index.php` files it creates inside `uploads/woochat-pro/` continue to block direct browsing.
- Tab order on the settings page is unchanged for the existing seven tabs (Logs is inserted between Analytics and License).

## Test plan

- [x] PHPUnit: 81 tests / 454 assertions green (`composer test`).
- [x] PHPCS: clean against project ruleset (`composer lint`).
- [x] Open the Logs tab — recent log entries render with parsed Source / Message columns.
- [x] Apply a keyword filter — only matching lines remain.
- [x] Pick a source from the dropdown — only that tag's entries remain.
- [x] Bump Lines to 1000 with a long log file — page stays responsive (memory-safe tail).
- [x] Click Download log — browser downloads a `.log` attachment matching the on-disk file.
- [x] Click Clear log → JS confirm appears → confirm → log file is empty, success notice shows, subsequent send re-creates the file via the existing `error_log()` write paths.
- [x] Without write permissions on `uploads/woochat-pro/`, Clear shows the error notice instead of success.

## Risk / rollback

Low risk. New file plus one new tab; no changes to existing write paths, options, or schema. The Clear handler truncates rather than deletes, which is the safest destructive op given concurrent writers. Nonce + `manage_options` cap on both Download and Clear. Rollback = revert the merge commit; nothing to clean up.