### PR TITLE
Outbound webhooks — five lifecycle events, HMAC signed, retry queue

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -223,7 +223,11 @@ function wcwp_render_settings_page() {
             'inactive'           => __('Inactive', 'woochat-pro'),
             'deactivationFailed' => __('Deactivation failed', 'woochat-pro'),
         ],
-        'logClearConfirm' => __('Clear the log file? This cannot be undone.', 'woochat-pro'),
+        'logClearConfirm'    => __('Clear the log file? This cannot be undone.', 'woochat-pro'),
+        'webhookTestNonce'   => wp_create_nonce('wcwp_webhook_test'),
+        'webhookDeleteConfirm' => __('Delete this webhook? Receivers will stop getting events immediately.', 'woochat-pro'),
+        'webhookTesting'     => __('Testing…', 'woochat-pro'),
+        'webhookTestLabel'   => __('Test fire', 'woochat-pro'),
     ]);
     // Onboarding wizard renders once per install — Skip/Finish persists the
     // dismissal flag via admin-ajax, after which the modal stops re-mounting.
@@ -381,6 +385,7 @@ function wcwp_render_settings_page() {
             <button type="button" class="wcwp-tab" data-tab="campaigns"><?php esc_html_e('Campaigns', 'woochat-pro'); ?></button>
             <button type="button" class="wcwp-tab" data-tab="analytics"><?php esc_html_e('Analytics', 'woochat-pro'); ?></button>
             <button type="button" class="wcwp-tab" data-tab="logs"><?php esc_html_e('Logs', 'woochat-pro'); ?></button>
+            <button type="button" class="wcwp-tab" data-tab="webhooks"><?php esc_html_e('Webhooks', 'woochat-pro'); ?></button>
             <button type="button" class="wcwp-tab" data-tab="license"><?php esc_html_e('License', 'woochat-pro'); ?></button>
         </div>
         <div class="wcwp-plugin-splash">
@@ -398,6 +403,7 @@ function wcwp_render_settings_page() {
             <?php require $views . '/tab-scheduler.php'; ?>
             <?php require $views . '/tab-campaigns.php'; ?>
             <?php require $views . '/tab-logs.php'; ?>
+            <?php require $views . '/tab-webhooks.php'; ?>
             <?php require $views . '/tab-license.php'; ?>
             <?php submit_button(); ?>
         </form>

--- a/admin/views/tab-webhooks.php
+++ b/admin/views/tab-webhooks.php
@@ -1,0 +1,143 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+$wcwp_wh_list      = wcwp_get_webhooks();
+$wcwp_wh_events    = wcwp_webhook_event_keys();
+$wcwp_wh_recent    = wcwp_webhook_log_recent('', 25);
+$wcwp_wh_msg       = isset($_GET['wcwp_webhook_msg']) ? sanitize_text_field(wp_unslash($_GET['wcwp_webhook_msg'])) : '';
+$wcwp_wh_post_url  = admin_url('admin-post.php');
+?>
+<div id="wcwp-tab-content-webhooks" class="wcwp-tab-content" style="display:none;">
+    <h2><?php esc_html_e('Webhooks', 'woochat-pro'); ?></h2>
+    <p class="description">
+        <?php esc_html_e('Pipe plugin events to Zapier, Make, n8n, or your own backend. Each request is signed with HMAC-SHA256 — receivers verify by recomputing the signature with the per-webhook secret.', 'woochat-pro'); ?>
+    </p>
+
+    <?php if ($wcwp_wh_msg === 'added') : ?>
+        <div class="notice notice-success is-dismissible" style="margin:10px 0;"><p><?php esc_html_e('Webhook saved.', 'woochat-pro'); ?></p></div>
+    <?php elseif ($wcwp_wh_msg === 'deleted') : ?>
+        <div class="notice notice-success is-dismissible" style="margin:10px 0;"><p><?php esc_html_e('Webhook deleted.', 'woochat-pro'); ?></p></div>
+    <?php elseif ($wcwp_wh_msg === 'invalid') : ?>
+        <div class="notice notice-error is-dismissible" style="margin:10px 0;"><p><?php esc_html_e('Could not save the webhook. Check that the URL is valid and at least one event is selected.', 'woochat-pro'); ?></p></div>
+    <?php endif; ?>
+
+    <h3 style="margin-top:18px;"><?php esc_html_e('Add a webhook', 'woochat-pro'); ?></h3>
+    <form method="post" action="<?php echo esc_url($wcwp_wh_post_url); ?>" style="margin-top:8px;max-width:780px;">
+        <?php wp_nonce_field('wcwp_webhook_add', 'wcwp_webhook_add_nonce'); ?>
+        <input type="hidden" name="action" value="wcwp_webhook_add" />
+        <table class="form-table">
+            <tr>
+                <th scope="row"><label for="wcwp_webhook_url"><?php esc_html_e('Endpoint URL', 'woochat-pro'); ?></label></th>
+                <td>
+                    <input type="url" name="wcwp_webhook_url" id="wcwp_webhook_url" class="regular-text" placeholder="https://hooks.example.com/wcwp" required />
+                    <p class="description"><?php esc_html_e('Must be HTTP or HTTPS. The receiver will get a JSON POST with X-WCWP-Event and X-WCWP-Signature headers.', 'woochat-pro'); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php esc_html_e('Events', 'woochat-pro'); ?></th>
+                <td>
+                    <fieldset>
+                        <?php foreach ($wcwp_wh_events as $wcwp_wh_event_key => $wcwp_wh_event_label) : ?>
+                            <label style="display:block;margin-bottom:4px;">
+                                <input type="checkbox" name="wcwp_webhook_events[]" value="<?php echo esc_attr($wcwp_wh_event_key); ?>" />
+                                <code style="font-size:0.92em;"><?php echo esc_html($wcwp_wh_event_key); ?></code>
+                                — <?php echo esc_html($wcwp_wh_event_label); ?>
+                            </label>
+                        <?php endforeach; ?>
+                    </fieldset>
+                    <p class="description"><?php esc_html_e('Select at least one event. A secret is generated automatically when the webhook is saved.', 'woochat-pro'); ?></p>
+                </td>
+            </tr>
+        </table>
+        <?php submit_button(__('Save webhook', 'woochat-pro'), 'primary', 'wcwp_webhook_submit', false); ?>
+    </form>
+
+    <h3 style="margin-top:24px;"><?php esc_html_e('Active webhooks', 'woochat-pro'); ?></h3>
+    <?php if (empty($wcwp_wh_list)) : ?>
+        <p><em><?php esc_html_e('No webhooks configured yet.', 'woochat-pro'); ?></em></p>
+    <?php else : ?>
+        <table class="widefat striped" style="margin-top:8px;">
+            <thead>
+                <tr>
+                    <th><?php esc_html_e('Endpoint', 'woochat-pro'); ?></th>
+                    <th><?php esc_html_e('Events', 'woochat-pro'); ?></th>
+                    <th><?php esc_html_e('Secret', 'woochat-pro'); ?></th>
+                    <th><?php esc_html_e('Created', 'woochat-pro'); ?></th>
+                    <th><?php esc_html_e('Actions', 'woochat-pro'); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($wcwp_wh_list as $wcwp_wh) :
+                    $wcwp_wh_id     = isset($wcwp_wh['id']) ? (string) $wcwp_wh['id'] : '';
+                    $wcwp_wh_url    = isset($wcwp_wh['url']) ? (string) $wcwp_wh['url'] : '';
+                    $wcwp_wh_events_list = isset($wcwp_wh['events']) && is_array($wcwp_wh['events']) ? $wcwp_wh['events'] : [];
+                    $wcwp_wh_secret = isset($wcwp_wh['secret']) ? (string) $wcwp_wh['secret'] : '';
+                    $wcwp_wh_created = isset($wcwp_wh['created_at']) ? (string) $wcwp_wh['created_at'] : '';
+
+                    $wcwp_wh_delete_url = wp_nonce_url(
+                        add_query_arg([
+                            'action'     => 'wcwp_webhook_delete',
+                            'webhook_id' => $wcwp_wh_id,
+                        ], admin_url('admin-post.php')),
+                        'wcwp_webhook_delete',
+                        'wcwp_webhook_delete_nonce'
+                    );
+                ?>
+                    <tr data-webhook-id="<?php echo esc_attr($wcwp_wh_id); ?>">
+                        <td><code style="word-break:break-all;font-size:0.92em;"><?php echo esc_html($wcwp_wh_url); ?></code></td>
+                        <td>
+                            <?php foreach ($wcwp_wh_events_list as $wcwp_wh_e) : ?>
+                                <code style="font-size:0.85em;display:inline-block;margin:1px 2px;padding:1px 6px;background:#f0f3f1;border-radius:3px;"><?php echo esc_html($wcwp_wh_e); ?></code>
+                            <?php endforeach; ?>
+                        </td>
+                        <td><code style="font-size:0.82em;word-break:break-all;"><?php echo esc_html($wcwp_wh_secret); ?></code></td>
+                        <td><?php echo esc_html($wcwp_wh_created); ?></td>
+                        <td>
+                            <button type="button" class="button wcwp-webhook-test" data-webhook-id="<?php echo esc_attr($wcwp_wh_id); ?>"><?php esc_html_e('Test fire', 'woochat-pro'); ?></button>
+                            <a class="button wcwp-webhook-delete" href="<?php echo esc_url($wcwp_wh_delete_url); ?>" style="color:#b32d2e;"><?php esc_html_e('Delete', 'woochat-pro'); ?></a>
+                            <span class="wcwp-webhook-test-result" style="display:block;margin-top:4px;font-size:0.92em;"></span>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    <?php endif; ?>
+
+    <h3 style="margin-top:24px;"><?php esc_html_e('Recent dispatches', 'woochat-pro'); ?></h3>
+    <?php if (empty($wcwp_wh_recent)) : ?>
+        <p><em><?php esc_html_e('Nothing dispatched yet.', 'woochat-pro'); ?></em></p>
+    <?php else : ?>
+        <table class="widefat striped" style="margin-top:8px;">
+            <thead>
+                <tr>
+                    <th><?php esc_html_e('Time', 'woochat-pro'); ?></th>
+                    <th><?php esc_html_e('Event', 'woochat-pro'); ?></th>
+                    <th><?php esc_html_e('Webhook', 'woochat-pro'); ?></th>
+                    <th><?php esc_html_e('Status', 'woochat-pro'); ?></th>
+                    <th><?php esc_html_e('HTTP', 'woochat-pro'); ?></th>
+                    <th><?php esc_html_e('Attempt', 'woochat-pro'); ?></th>
+                    <th><?php esc_html_e('Error', 'woochat-pro'); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($wcwp_wh_recent as $wcwp_wh_row) : ?>
+                    <tr>
+                        <td><?php echo esc_html($wcwp_wh_row['ts'] ?? ''); ?></td>
+                        <td><code style="font-size:0.9em;"><?php echo esc_html($wcwp_wh_row['event'] ?? ''); ?></code></td>
+                        <td><code style="font-size:0.85em;"><?php echo esc_html($wcwp_wh_row['webhook_id'] ?? ''); ?></code></td>
+                        <td>
+                            <?php
+                            $wcwp_wh_status = (string) ($wcwp_wh_row['status'] ?? '');
+                            $wcwp_wh_color  = $wcwp_wh_status === 'sent' ? '#1c7c54' : '#b32d2e';
+                            ?>
+                            <span style="color:<?php echo esc_attr($wcwp_wh_color); ?>;font-weight:600;"><?php echo esc_html($wcwp_wh_status); ?></span>
+                        </td>
+                        <td><?php echo esc_html((string) (int) ($wcwp_wh_row['code'] ?? 0)); ?></td>
+                        <td><?php echo esc_html((string) (int) ($wcwp_wh_row['attempt'] ?? 1)); ?></td>
+                        <td><?php echo esc_html((string) ($wcwp_wh_row['error'] ?? '')); ?></td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    <?php endif; ?>
+</div>

--- a/assets/js/admin-premium.js
+++ b/assets/js/admin-premium.js
@@ -344,6 +344,60 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 });
 
+// Webhooks tab — confirm-on-delete + AJAX test-fire button.
+document.addEventListener('DOMContentLoaded', function () {
+    const data = window.wcwpAdminData || {};
+
+    document.querySelectorAll('.wcwp-webhook-delete').forEach(function (a) {
+        a.addEventListener('click', function (e) {
+            const msg = data.webhookDeleteConfirm || 'Delete this webhook?';
+            if (!window.confirm(msg)) e.preventDefault();
+        });
+    });
+
+    document.querySelectorAll('.wcwp-webhook-test').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            const row = btn.closest('tr');
+            const id = btn.getAttribute('data-webhook-id') || '';
+            const result = row ? row.querySelector('.wcwp-webhook-test-result') : null;
+            if (!id || !data.ajaxUrl || !data.webhookTestNonce) return;
+
+            const originalLabel = btn.textContent;
+            btn.disabled = true;
+            btn.textContent = data.webhookTesting || 'Testing…';
+            if (result) { result.textContent = ''; result.style.color = ''; }
+
+            const form = new FormData();
+            form.append('action', 'wcwp_webhook_test');
+            form.append('nonce', data.webhookTestNonce);
+            form.append('webhook_id', id);
+
+            fetch(data.ajaxUrl, { method: 'POST', credentials: 'same-origin', body: form })
+                .then(function (r) { return r.json().catch(function () { return { success: false, data: { message: 'invalid response' } }; }); })
+                .then(function (body) {
+                    btn.disabled = false;
+                    btn.textContent = data.webhookTestLabel || originalLabel;
+                    if (!result) return;
+                    if (body && body.success) {
+                        result.textContent = (body.data && body.data.message) ? body.data.message : 'OK';
+                        result.style.color = '#1c7c54';
+                    } else {
+                        result.textContent = (body && body.data && body.data.message) ? body.data.message : 'Test failed';
+                        result.style.color = '#b32d2e';
+                    }
+                })
+                .catch(function () {
+                    btn.disabled = false;
+                    btn.textContent = data.webhookTestLabel || originalLabel;
+                    if (result) {
+                        result.textContent = 'Network error';
+                        result.style.color = '#b32d2e';
+                    }
+                });
+        });
+    });
+});
+
 // Logs tab — Apply button rebuilds the URL with current filter values,
 // Clear button asks for explicit confirmation before destructive action.
 document.addEventListener('DOMContentLoaded', function () {

--- a/includes/analytics.php
+++ b/includes/analytics.php
@@ -538,6 +538,9 @@ function wcwp_handle_tracking_request() {
 
     if ($type === 'click' && $event_id) {
         wcwp_analytics_update_event($event_id, ['status' => 'clicked']);
+        if (function_exists('wcwp_dispatch_webhook')) {
+            wcwp_dispatch_webhook('message.clicked', ['event_id' => $event_id]);
+        }
     }
 
     $redirect_raw = isset($_GET['redirect']) ? esc_url_raw(wp_unslash($_GET['redirect'])) : '';
@@ -557,6 +560,9 @@ function wcwp_track_event_ajax() {
     }
     if ($type === 'delivered') {
         wcwp_analytics_update_event($event_id, ['status' => 'delivered']);
+        if (function_exists('wcwp_dispatch_webhook')) {
+            wcwp_dispatch_webhook('message.delivered', ['event_id' => $event_id]);
+        }
     }
     wp_send_json_success();
 }

--- a/includes/class-wcwp-plugin.php
+++ b/includes/class-wcwp-plugin.php
@@ -84,6 +84,7 @@ final class Plugin {
         require_once WCWP_PATH . 'includes/ab-testing.php';
         require_once WCWP_PATH . 'includes/privacy.php';
         require_once WCWP_PATH . 'includes/log-viewer.php';
+        require_once WCWP_PATH . 'includes/webhooks.php';
         require_once WCWP_PATH . 'admin/settings-page.php';
         require_once WCWP_PATH . 'includes/chatbot-engine.php';
         require_once WCWP_PATH . 'includes/license-manager.php';

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -50,6 +50,8 @@ function wcwp_get_secret_option_keys() {
         'wcwp_gpt_model',
         'wcwp_optout_webhook_token',
         'wcwp_license_key',
+        'wcwp_webhooks',
+        'wcwp_webhook_log',
     ];
 }
 
@@ -384,9 +386,14 @@ function wcwp_add_optout($phone) {
     $phone = wcwp_normalize_phone($phone);
     if (!$phone) return false;
     $list = wcwp_get_optout_list();
+    $newly_added = false;
     if (!in_array($phone, $list, true)) {
         $list[] = $phone;
         update_option('wcwp_optout_list', $list, false);
+        $newly_added = true;
+    }
+    if ($newly_added && function_exists('wcwp_dispatch_webhook')) {
+        wcwp_dispatch_webhook('customer.opted_out', ['phone' => $phone]);
     }
     return true;
 }

--- a/includes/messaging.php
+++ b/includes/messaging.php
@@ -162,6 +162,16 @@ function wcwp_send_whatsapp_message( $to, $message, $manual = false, $context = 
         if ( $event_id ) {
             wcwp_analytics_update_event( $event_id, [ 'status' => 'failed' ] );
         }
+        if ( function_exists( 'wcwp_dispatch_webhook' ) ) {
+            wcwp_dispatch_webhook( 'message.failed', [
+                'event_id' => $event_id,
+                'type'     => $event_type,
+                'phone'    => $to,
+                'order_id' => isset( $context['order_id'] ) ? (int) $context['order_id'] : 0,
+                'provider' => $provider_id,
+                'error'    => (string) ( $result['error'] ?? 'unknown' ),
+            ] );
+        }
         return false;
     }
 
@@ -176,6 +186,19 @@ function wcwp_send_whatsapp_message( $to, $message, $manual = false, $context = 
             'message_id' => $result['message_id'] ?? '',
         ] );
     }
+
+    if ( function_exists( 'wcwp_dispatch_webhook' ) ) {
+        wcwp_dispatch_webhook( 'message.sent', [
+            'event_id'   => $event_id,
+            'type'       => $event_type,
+            'phone'      => $to,
+            'order_id'   => isset( $context['order_id'] ) ? (int) $context['order_id'] : 0,
+            'provider'   => $provider_id,
+            'message_id' => (string) ( $result['message_id'] ?? '' ),
+            'ab_variant' => isset( $context['ab_variant'] ) ? (string) $context['ab_variant'] : '',
+        ] );
+    }
+
     return true;
 }
 

--- a/includes/webhooks.php
+++ b/includes/webhooks.php
@@ -1,0 +1,427 @@
+<?php
+/**
+ * Outbound webhooks.
+ *
+ * Lets stores subscribe an external URL (Zapier / Make / n8n / their
+ * own backend) to plugin lifecycle events. Each registered webhook
+ * receives a signed JSON POST whenever one of its subscribed events
+ * fires:
+ *
+ *   - message.sent          — wcwp_send_whatsapp_message succeeded.
+ *   - message.delivered     — provider webhook flipped status to
+ *                             delivered (currently surfaced via the
+ *                             wcwp_track_event AJAX endpoint).
+ *   - message.clicked       — recipient clicked the tracked link.
+ *   - message.failed        — provider returned an error or send was
+ *                             rejected before reaching the provider.
+ *   - customer.opted_out    — a phone number was added to the
+ *                             suppression list.
+ *
+ * Storage: option `wcwp_webhooks` (autoload off — contains secrets).
+ * Each entry is `{id, url, secret, events[], active, created_at}`.
+ *
+ * Signing: each request carries `X-WCWP-Event` plus
+ * `X-WCWP-Signature: sha256=<hmac>` where the HMAC is over the raw
+ * request body using the per-webhook secret. Receivers verify by
+ * recomputing — same scheme as GitHub / Stripe.
+ *
+ * Delivery model: first attempt is synchronous (so admins see immediate
+ * feedback when sending a test event). Failures (non-2xx or transport
+ * error) reschedule a retry via `wp_schedule_single_event` — same
+ * primitive used for follow-up retries (PR #36) and order-confirmation
+ * retries (PR #37). Backoff [5min, 15min], cap at 3 attempts.
+ *
+ * Logging: a 100-entry FIFO under `wcwp_webhook_log` (autoload off)
+ * captures recent dispatches with timestamp / webhook_id / event /
+ * status / HTTP code / attempt — surfaced on the Webhooks tab so admins
+ * can see what fired without standing up an external listener.
+ */
+
+if (!defined('ABSPATH')) exit;
+
+add_action('wcwp_webhook_retry', 'wcwp_webhook_retry_handler', 10, 4);
+add_action('admin_post_wcwp_webhook_add', 'wcwp_webhook_add_handler');
+add_action('admin_post_wcwp_webhook_delete', 'wcwp_webhook_delete_handler');
+add_action('wp_ajax_wcwp_webhook_test', 'wcwp_webhook_test_ajax');
+
+/**
+ * Registry of supported event keys → human labels.
+ *
+ * Filterable so a third party can register additional events alongside
+ * the dispatch points it has wired up.
+ *
+ * @return array<string, string>
+ */
+function wcwp_webhook_event_keys() {
+    $keys = [
+        'message.sent'        => __('Message sent', 'woochat-pro'),
+        'message.delivered'   => __('Message delivered', 'woochat-pro'),
+        'message.clicked'     => __('Tracked link clicked', 'woochat-pro'),
+        'message.failed'      => __('Message send failed', 'woochat-pro'),
+        'customer.opted_out'  => __('Customer opted out', 'woochat-pro'),
+    ];
+    return (array) apply_filters('wcwp_webhook_event_keys', $keys);
+}
+
+/**
+ * Compute a `sha256=<hex>` signature for a webhook payload.
+ *
+ * Pure helper — separated so the test suite can pin the wire format
+ * (matching GitHub/Stripe's `sha256=hex` convention) without rebuilding
+ * the dispatcher.
+ *
+ * @param string $body   The raw JSON body that will be POSTed.
+ * @param string $secret The per-webhook secret.
+ * @return string `sha256=<hexdigest>`, or '' if either input is empty.
+ */
+function wcwp_webhook_signature($body, $secret) {
+    $body   = (string) $body;
+    $secret = (string) $secret;
+    if ($body === '' || $secret === '') return '';
+    return 'sha256=' . hash_hmac('sha256', $body, $secret);
+}
+
+/**
+ * Sanitise + normalise a webhook configuration before save.
+ *
+ * Drops invalid URLs, dedupes/filters events to the supported set,
+ * generates an id + secret if missing. Returns null when the URL is
+ * unusable.
+ *
+ * Pure-ish: uses esc_url_raw / wp_generate_password / current_time but
+ * has no DB or option access. Tests set $GLOBALS['wcwp_test_*'] to
+ * make those deterministic where needed.
+ *
+ * @param array $args Caller-supplied values (`url`, `events`, etc.).
+ * @return array|null Sanitised webhook, or null when the URL is invalid.
+ */
+function wcwp_sanitize_webhook($args) {
+    if (!is_array($args)) return null;
+
+    $url = isset($args['url']) ? esc_url_raw(trim((string) $args['url'])) : '';
+    if ($url === '') return null;
+    $parts = wp_parse_url($url);
+    if (!is_array($parts) || empty($parts['scheme']) || empty($parts['host'])) return null;
+    if (!in_array(strtolower($parts['scheme']), ['http', 'https'], true)) return null;
+
+    $valid_events = array_keys(wcwp_webhook_event_keys());
+    $requested = isset($args['events']) && is_array($args['events']) ? $args['events'] : [];
+    $events = [];
+    foreach ($requested as $e) {
+        $e = is_string($e) ? trim($e) : '';
+        if ($e !== '' && in_array($e, $valid_events, true)) $events[$e] = true;
+    }
+    $events = array_keys($events);
+    if (empty($events)) return null;
+
+    $id     = isset($args['id']) && $args['id'] !== '' ? (string) $args['id'] : 'wh_' . wp_generate_password(12, false, false);
+    $secret = isset($args['secret']) && $args['secret'] !== '' ? (string) $args['secret'] : wp_generate_password(40, false, false);
+    $active = isset($args['active']) ? (bool) $args['active'] : true;
+    $created_at = isset($args['created_at']) && $args['created_at'] !== '' ? (string) $args['created_at'] : current_time('mysql');
+
+    return [
+        'id'         => $id,
+        'url'        => $url,
+        'secret'     => $secret,
+        'events'     => $events,
+        'active'     => $active,
+        'created_at' => $created_at,
+    ];
+}
+
+function wcwp_get_webhooks() {
+    $list = get_option('wcwp_webhooks', []);
+    if (!is_array($list)) return [];
+    return array_values($list);
+}
+
+function wcwp_save_webhooks($list) {
+    if (!is_array($list)) $list = [];
+    update_option('wcwp_webhooks', array_values($list), false);
+}
+
+function wcwp_get_webhook($id) {
+    $id = (string) $id;
+    if ($id === '') return null;
+    foreach (wcwp_get_webhooks() as $wh) {
+        if (isset($wh['id']) && $wh['id'] === $id) return $wh;
+    }
+    return null;
+}
+
+function wcwp_add_webhook($args) {
+    $sanitized = wcwp_sanitize_webhook($args);
+    if (!$sanitized) return null;
+    $list = wcwp_get_webhooks();
+    $list[] = $sanitized;
+    wcwp_save_webhooks($list);
+    return $sanitized;
+}
+
+function wcwp_delete_webhook($id) {
+    $id = (string) $id;
+    if ($id === '') return false;
+    $list = wcwp_get_webhooks();
+    $kept = [];
+    $found = false;
+    foreach ($list as $wh) {
+        if (isset($wh['id']) && $wh['id'] === $id) {
+            $found = true;
+            continue;
+        }
+        $kept[] = $wh;
+    }
+    if ($found) wcwp_save_webhooks($kept);
+    return $found;
+}
+
+/**
+ * Filter a webhook list down to the entries subscribed to one event.
+ *
+ * Pure helper, so the dispatcher's "who do I send to?" rule is
+ * unit-testable without DB.
+ *
+ * @param array  $webhooks   Sanitised webhook entries.
+ * @param string $event_name Event key.
+ * @return array<int, array> Active webhooks subscribed to $event_name.
+ */
+function wcwp_filter_webhooks_for_event($webhooks, $event_name) {
+    if (!is_array($webhooks) || $event_name === '') return [];
+    $out = [];
+    foreach ($webhooks as $wh) {
+        if (empty($wh['active'])) continue;
+        $events = isset($wh['events']) && is_array($wh['events']) ? $wh['events'] : [];
+        if (in_array($event_name, $events, true)) $out[] = $wh;
+    }
+    return $out;
+}
+
+/**
+ * Public dispatch entry point.
+ *
+ * Called from messaging.php / analytics.php / helpers.php at the
+ * lifecycle touch points. No-op when no webhooks are subscribed —
+ * cheap to call from hot paths.
+ *
+ * @param string $event_name One of wcwp_webhook_event_keys() keys.
+ * @param array  $data       Event-specific payload.
+ */
+function wcwp_dispatch_webhook($event_name, $data = []) {
+    $event_name = (string) $event_name;
+    if ($event_name === '') return;
+    $matches = wcwp_filter_webhooks_for_event(wcwp_get_webhooks(), $event_name);
+    if (empty($matches)) return;
+    foreach ($matches as $wh) {
+        wcwp_send_webhook($wh, $event_name, $data, 1);
+    }
+}
+
+/**
+ * Build the JSON envelope sent for one event.
+ *
+ * Pure helper — separated so the wire shape is unit-testable and
+ * stays stable across releases (receivers depend on it).
+ *
+ * @param string $event_name
+ * @param array  $data
+ * @return array{event:string, fired_at:string, data:array}
+ */
+function wcwp_webhook_payload($event_name, $data) {
+    return [
+        'event'    => (string) $event_name,
+        'fired_at' => gmdate('Y-m-d\TH:i:s\Z'),
+        'data'     => is_array($data) ? $data : [],
+    ];
+}
+
+/**
+ * POST one event to one webhook, then either log success or schedule
+ * a retry. Synchronous on the first attempt so admins see immediate
+ * feedback from the Test button; retries land via cron.
+ *
+ * @param array  $webhook
+ * @param string $event_name
+ * @param array  $data
+ * @param int    $attempt 1-indexed.
+ * @return array{ok:bool, code:int, error:string}
+ */
+function wcwp_send_webhook($webhook, $event_name, $data, $attempt = 1) {
+    $url    = isset($webhook['url']) ? (string) $webhook['url'] : '';
+    $secret = isset($webhook['secret']) ? (string) $webhook['secret'] : '';
+    $id     = isset($webhook['id']) ? (string) $webhook['id'] : '';
+    if ($url === '') return ['ok' => false, 'code' => 0, 'error' => 'missing url'];
+
+    $payload = wcwp_webhook_payload($event_name, $data);
+    $body    = wp_json_encode($payload);
+    if ($body === false) $body = '{}';
+
+    $signature = wcwp_webhook_signature($body, $secret);
+
+    $response = wp_remote_post($url, [
+        'timeout' => (int) apply_filters('wcwp_webhook_timeout', 8),
+        'headers' => [
+            'Content-Type'    => 'application/json',
+            'User-Agent'      => 'WooChatPro/' . (defined('WCWP_VERSION') ? WCWP_VERSION : 'dev'),
+            'X-WCWP-Event'    => $event_name,
+            'X-WCWP-Signature' => $signature,
+        ],
+        'body'    => $body,
+    ]);
+
+    if (is_wp_error($response)) {
+        $error = $response->get_error_message();
+        wcwp_webhook_log_dispatch($id, $event_name, 'failed', 0, $attempt, $error);
+        wcwp_maybe_schedule_webhook_retry($id, $event_name, $data, $attempt);
+        return ['ok' => false, 'code' => 0, 'error' => $error];
+    }
+
+    $code = (int) wp_remote_retrieve_response_code($response);
+    if ($code >= 200 && $code < 300) {
+        wcwp_webhook_log_dispatch($id, $event_name, 'sent', $code, $attempt, '');
+        return ['ok' => true, 'code' => $code, 'error' => ''];
+    }
+
+    wcwp_webhook_log_dispatch($id, $event_name, 'failed', $code, $attempt, '');
+    wcwp_maybe_schedule_webhook_retry($id, $event_name, $data, $attempt);
+    return ['ok' => false, 'code' => $code, 'error' => 'http ' . $code];
+}
+
+function wcwp_maybe_schedule_webhook_retry($webhook_id, $event_name, $data, $attempt) {
+    $max_attempts = (int) apply_filters('wcwp_webhook_max_attempts', 3);
+    if ($attempt >= $max_attempts) return;
+
+    $backoffs = (array) apply_filters('wcwp_webhook_backoff_minutes', [5, 15]);
+    $idx = max(0, $attempt - 1);
+    $delay = isset($backoffs[$idx]) ? (int) $backoffs[$idx] : (int) end($backoffs);
+    if ($delay < 1) $delay = 5;
+
+    wp_schedule_single_event(
+        time() + ($delay * MINUTE_IN_SECONDS),
+        'wcwp_webhook_retry',
+        [(string) $webhook_id, (string) $event_name, $data, $attempt + 1]
+    );
+}
+
+function wcwp_webhook_retry_handler($webhook_id, $event_name, $data, $attempt) {
+    $webhook = wcwp_get_webhook($webhook_id);
+    if (!$webhook || empty($webhook['active'])) return;
+    wcwp_send_webhook($webhook, $event_name, $data, (int) $attempt);
+}
+
+/**
+ * Append one dispatch row to the FIFO log option.
+ *
+ * @return void
+ */
+function wcwp_webhook_log_dispatch($webhook_id, $event_name, $status, $code, $attempt, $error = '') {
+    $cap = (int) apply_filters('wcwp_webhook_log_cap', 100);
+    if ($cap < 1) $cap = 100;
+    $log = get_option('wcwp_webhook_log', []);
+    if (!is_array($log)) $log = [];
+    $log[] = [
+        'ts'         => current_time('mysql'),
+        'webhook_id' => (string) $webhook_id,
+        'event'      => (string) $event_name,
+        'status'     => (string) $status,
+        'code'       => (int) $code,
+        'attempt'    => (int) $attempt,
+        'error'      => (string) $error,
+    ];
+    if (count($log) > $cap) {
+        $log = array_slice($log, -$cap);
+    }
+    update_option('wcwp_webhook_log', $log, false);
+}
+
+function wcwp_webhook_log_recent($webhook_id = '', $limit = 20) {
+    $log = get_option('wcwp_webhook_log', []);
+    if (!is_array($log)) return [];
+    if ($webhook_id !== '') {
+        $log = array_values(array_filter($log, static function ($row) use ($webhook_id) {
+            return isset($row['webhook_id']) && $row['webhook_id'] === $webhook_id;
+        }));
+    }
+    $log = array_reverse($log);
+    if ($limit > 0 && count($log) > $limit) {
+        $log = array_slice($log, 0, $limit);
+    }
+    return $log;
+}
+
+/* -------------------------------------------------------------------------
+ * Admin handlers
+ * ----------------------------------------------------------------------- */
+
+function wcwp_webhook_add_handler() {
+    if (!current_user_can('manage_options')) {
+        wp_die(esc_html__('Unauthorized', 'woochat-pro'), '', ['response' => 403]);
+    }
+    check_admin_referer('wcwp_webhook_add', 'wcwp_webhook_add_nonce');
+
+    $url    = isset($_POST['wcwp_webhook_url']) ? sanitize_text_field(wp_unslash($_POST['wcwp_webhook_url'])) : '';
+    $events = isset($_POST['wcwp_webhook_events']) && is_array($_POST['wcwp_webhook_events'])
+        ? array_map('sanitize_text_field', wp_unslash($_POST['wcwp_webhook_events']))
+        : [];
+
+    $created = wcwp_add_webhook(['url' => $url, 'events' => $events]);
+
+    $msg = $created ? 'added' : 'invalid';
+    wp_safe_redirect(add_query_arg(['page' => 'wcwp-settings', 'tab' => 'webhooks', 'wcwp_webhook_msg' => $msg], admin_url('admin.php')));
+    exit;
+}
+
+function wcwp_webhook_delete_handler() {
+    if (!current_user_can('manage_options')) {
+        wp_die(esc_html__('Unauthorized', 'woochat-pro'), '', ['response' => 403]);
+    }
+    check_admin_referer('wcwp_webhook_delete', 'wcwp_webhook_delete_nonce');
+
+    $id = isset($_REQUEST['webhook_id']) ? sanitize_text_field(wp_unslash($_REQUEST['webhook_id'])) : '';
+    $deleted = wcwp_delete_webhook($id);
+
+    wp_safe_redirect(add_query_arg([
+        'page'              => 'wcwp-settings',
+        'tab'               => 'webhooks',
+        'wcwp_webhook_msg'  => $deleted ? 'deleted' : 'invalid',
+    ], admin_url('admin.php')));
+    exit;
+}
+
+function wcwp_webhook_test_ajax() {
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error(['message' => __('Unauthorized', 'woochat-pro')], 403);
+    }
+    if (!check_ajax_referer('wcwp_webhook_test', 'nonce', false)) {
+        wp_send_json_error(['message' => __('Bad nonce', 'woochat-pro')], 400);
+    }
+
+    $id = isset($_POST['webhook_id']) ? sanitize_text_field(wp_unslash($_POST['webhook_id'])) : '';
+    $webhook = wcwp_get_webhook($id);
+    if (!$webhook) {
+        wp_send_json_error(['message' => __('Webhook not found.', 'woochat-pro')], 404);
+    }
+
+    $result = wcwp_send_webhook($webhook, 'webhook.test', [
+        'note' => 'This is a test event triggered from the WooChat Pro admin.',
+    ], 1);
+
+    if (!empty($result['ok'])) {
+        wp_send_json_success([
+            'code'    => $result['code'],
+            'message' => sprintf(
+                /* translators: %d is the HTTP response code */
+                __('Test fired — receiver responded %d.', 'woochat-pro'),
+                (int) $result['code']
+            ),
+        ]);
+    }
+
+    wp_send_json_error([
+        'code'    => $result['code'],
+        'message' => sprintf(
+            /* translators: %s is the failure reason (HTTP code or transport error) */
+            __('Test failed: %s', 'woochat-pro'),
+            $result['error'] !== '' ? $result['error'] : 'unknown'
+        ),
+    ], 502);
+}

--- a/tests/Unit/WebhooksTest.php
+++ b/tests/Unit/WebhooksTest.php
@@ -1,0 +1,137 @@
+<?php
+declare(strict_types=1);
+
+namespace WooChatPro\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class WebhooksTest extends TestCase
+{
+    public function test_signature_uses_sha256_hmac_with_prefix(): void
+    {
+        $body = '{"event":"message.sent","data":{}}';
+        $secret = 'shhh-this-is-a-test-secret';
+        $expected = 'sha256=' . hash_hmac('sha256', $body, $secret);
+
+        $this->assertSame($expected, \wcwp_webhook_signature($body, $secret));
+    }
+
+    public function test_signature_returns_empty_for_empty_body_or_secret(): void
+    {
+        $this->assertSame('', \wcwp_webhook_signature('', 'secret'));
+        $this->assertSame('', \wcwp_webhook_signature('body', ''));
+    }
+
+    public function test_signature_is_stable_for_same_inputs(): void
+    {
+        $a = \wcwp_webhook_signature('payload', 'k');
+        $b = \wcwp_webhook_signature('payload', 'k');
+        $this->assertSame($a, $b);
+    }
+
+    public function test_signature_changes_with_body(): void
+    {
+        $a = \wcwp_webhook_signature('payload-a', 'k');
+        $b = \wcwp_webhook_signature('payload-b', 'k');
+        $this->assertNotSame($a, $b);
+    }
+
+    public function test_signature_changes_with_secret(): void
+    {
+        $a = \wcwp_webhook_signature('payload', 'k1');
+        $b = \wcwp_webhook_signature('payload', 'k2');
+        $this->assertNotSame($a, $b);
+    }
+
+    public function test_event_keys_includes_known_lifecycle_events(): void
+    {
+        $keys = array_keys(\wcwp_webhook_event_keys());
+        $this->assertContains('message.sent', $keys);
+        $this->assertContains('message.delivered', $keys);
+        $this->assertContains('message.clicked', $keys);
+        $this->assertContains('message.failed', $keys);
+        $this->assertContains('customer.opted_out', $keys);
+    }
+
+    public function test_payload_envelope_has_event_fired_at_data(): void
+    {
+        $env = \wcwp_webhook_payload('message.sent', ['order_id' => 42]);
+
+        $this->assertSame('message.sent', $env['event']);
+        $this->assertArrayHasKey('fired_at', $env);
+        $this->assertNotSame('', $env['fired_at']);
+        // ISO 8601 with trailing Z
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/', $env['fired_at']);
+        $this->assertSame(['order_id' => 42], $env['data']);
+    }
+
+    public function test_payload_coerces_non_array_data_to_array(): void
+    {
+        $env = \wcwp_webhook_payload('message.sent', null);
+        $this->assertSame([], $env['data']);
+    }
+
+    public function test_sanitize_drops_invalid_url(): void
+    {
+        $this->assertNull(\wcwp_sanitize_webhook(['url' => '', 'events' => ['message.sent']]));
+        $this->assertNull(\wcwp_sanitize_webhook(['url' => 'not-a-url', 'events' => ['message.sent']]));
+        $this->assertNull(\wcwp_sanitize_webhook(['url' => 'ftp://example.com', 'events' => ['message.sent']]));
+    }
+
+    public function test_sanitize_drops_when_no_valid_events(): void
+    {
+        $this->assertNull(\wcwp_sanitize_webhook(['url' => 'https://example.com', 'events' => []]));
+        $this->assertNull(\wcwp_sanitize_webhook(['url' => 'https://example.com', 'events' => ['nonsense.event']]));
+    }
+
+    public function test_sanitize_dedupes_and_filters_events(): void
+    {
+        $clean = \wcwp_sanitize_webhook([
+            'url'    => 'https://example.com/wcwp',
+            'events' => ['message.sent', 'message.sent', 'nonsense.event', 'message.delivered'],
+            'id'     => 'wh_fixed',
+            'secret' => 'static-secret',
+            'created_at' => '2026-05-09 12:34:56',
+        ]);
+
+        $this->assertNotNull($clean);
+        $this->assertSame(['message.sent', 'message.delivered'], $clean['events']);
+        $this->assertSame('https://example.com/wcwp', $clean['url']);
+        $this->assertSame('wh_fixed', $clean['id']);
+        $this->assertSame('static-secret', $clean['secret']);
+        $this->assertTrue($clean['active']);
+    }
+
+    public function test_sanitize_generates_id_and_secret_when_missing(): void
+    {
+        $clean = \wcwp_sanitize_webhook([
+            'url'    => 'https://example.com/wcwp',
+            'events' => ['message.sent'],
+        ]);
+
+        $this->assertNotNull($clean);
+        $this->assertStringStartsWith('wh_', $clean['id']);
+        $this->assertNotSame('', $clean['secret']);
+    }
+
+    public function test_filter_webhooks_for_event_returns_only_active_subscribed(): void
+    {
+        $webhooks = [
+            ['id' => 'a', 'active' => true,  'events' => ['message.sent']],
+            ['id' => 'b', 'active' => true,  'events' => ['customer.opted_out']],
+            ['id' => 'c', 'active' => false, 'events' => ['message.sent']], // inactive — drop
+            ['id' => 'd', 'active' => true,  'events' => ['message.sent', 'message.delivered']],
+        ];
+
+        $matches = \wcwp_filter_webhooks_for_event($webhooks, 'message.sent');
+
+        $this->assertCount(2, $matches);
+        $this->assertSame(['a', 'd'], array_column($matches, 'id'));
+    }
+
+    public function test_filter_webhooks_for_event_returns_empty_for_unknown(): void
+    {
+        $this->assertSame([], \wcwp_filter_webhooks_for_event([], 'message.sent'));
+        $this->assertSame([], \wcwp_filter_webhooks_for_event([['id' => 'a', 'active' => true, 'events' => ['x']]], ''));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -76,6 +76,42 @@ if (!function_exists('add_query_arg')) {
         return $url . $sep . $key . '=' . urlencode((string) $value);
     }
 }
+if (!function_exists('esc_url_raw')) {
+    function esc_url_raw($url) { return is_string($url) ? trim($url) : ''; }
+}
+if (!function_exists('wp_parse_url')) {
+    function wp_parse_url($url, $component = -1) {
+        $parts = parse_url((string) $url);
+        if ($component === -1) return $parts === false ? false : $parts;
+        $key_map = [
+            PHP_URL_SCHEME => 'scheme', PHP_URL_HOST => 'host', PHP_URL_PORT => 'port',
+            PHP_URL_USER => 'user', PHP_URL_PASS => 'pass', PHP_URL_PATH => 'path',
+            PHP_URL_QUERY => 'query', PHP_URL_FRAGMENT => 'fragment',
+        ];
+        $key = $key_map[$component] ?? null;
+        return $key && is_array($parts) && isset($parts[$key]) ? $parts[$key] : null;
+    }
+}
+if (!function_exists('wp_generate_password')) {
+    function wp_generate_password($length = 12, $special_chars = true, $extra_special_chars = false) {
+        // Deterministic stub: counter-prefixed string up to $length.
+        static $counter = 0;
+        $counter++;
+        $base = 'testpw' . $counter . str_repeat('x', max(0, (int) $length - 8));
+        return substr($base, 0, max(1, (int) $length));
+    }
+}
+if (!function_exists('current_time')) {
+    function current_time($type = 'mysql', $gmt = 0) {
+        return $GLOBALS['wcwp_test_current_time'] ?? '2026-05-09 12:34:56';
+    }
+}
+if (!defined('MINUTE_IN_SECONDS')) {
+    define('MINUTE_IN_SECONDS', 60);
+}
+if (!defined('HOUR_IN_SECONDS')) {
+    define('HOUR_IN_SECONDS', 3600);
+}
 
 if (!defined('DAY_IN_SECONDS')) {
     define('DAY_IN_SECONDS', 86400);
@@ -90,3 +126,4 @@ require_once __DIR__ . '/../includes/template-library.php';
 require_once __DIR__ . '/../includes/ab-testing.php';
 require_once __DIR__ . '/../includes/privacy.php';
 require_once __DIR__ . '/../includes/log-viewer.php';
+require_once __DIR__ . '/../includes/webhooks.php';

--- a/uninstall.php
+++ b/uninstall.php
@@ -69,6 +69,8 @@ $option_keys = [
     'wcwp_order_message_ab_enabled',
     'wcwp_cart_recovery_ab_enabled',
     'wcwp_followup_ab_enabled',
+    'wcwp_webhooks',
+    'wcwp_webhook_log',
 ];
 
 foreach ($option_keys as $key) {


### PR DESCRIPTION
## Summary

Tier 4 #13 — first item of the infrastructure-for-scale tier. Lets stores subscribe an external URL (Zapier / Make / n8n / their own backend) to plugin lifecycle events. Each registered webhook receives a signed JSON POST whenever one of its subscribed events fires.

## What changed

**Five lifecycle events shipped**
- `message.sent` — `wcwp_send_whatsapp_message` succeeded.
- `message.delivered` — provider webhook flipped status to delivered (via `wcwp_track_event` AJAX).
- `message.clicked` — recipient clicked a tracked link (`wcwp_handle_tracking_request`).
- `message.failed` — provider error or rejection before send.
- `customer.opted_out` — `wcwp_add_optout` newly added a phone.

Dispatch points guard with `function_exists('wcwp_dispatch_webhook')` so the messaging path stays intact even if webhooks.php isn't loaded.

**Storage** — Single option `wcwp_webhooks` (autoload off via `wcwp_get_secret_option_keys()` — contains secrets). Each entry is `{id, url, secret, events[], active, created_at}`. ID + secret auto-generated via `wp_generate_password`. `wcwp_webhook_log` is a separate FIFO option capped at 100 entries (filterable via `wcwp_webhook_log_cap`) tracking recent dispatches: ts / webhook_id / event / status / HTTP code / attempt / error. Both keys added to `uninstall.php`'s delete list.

**Signing** — `X-WCWP-Signature: sha256=<hex>` header, computed via `hash_hmac` over the raw JSON body using the per-webhook secret — same scheme as GitHub / Stripe so receivers can use existing libraries. Plus `X-WCWP-Event` for cheap routing.

**Delivery** — First attempt is synchronous (so the Test button gives immediate feedback). Failures (transport error or non-2xx) reschedule via `wp_schedule_single_event` + `wcwp_webhook_retry` handler — same primitive used for follow-up retries (PR #36) and order-confirmation retries (PR #37). Backoff `[5min, 15min]` (filterable), cap at 3 attempts (filterable), 8s `wp_remote_post` timeout (filterable). Inactive webhooks are skipped on retry too.

**Admin UI** — New "Webhooks" tab between Logs and License. Three sections:
1. Add-a-webhook form (URL + per-event checkboxes; posts to `admin_post_wcwp_webhook_add`).
2. Active-webhooks table with per-row Test fire button (AJAX `wp_ajax_wcwp_webhook_test`, returns the receiver's HTTP code inline) and Delete link (`admin_post_wcwp_webhook_delete` with JS confirm).
3. Recent-dispatches table reading off the FIFO log with colour-coded status.

Secret displays in plaintext on the row — `manage_options`-gated.

## What stays the same

- All existing message-sending paths preserve byte-identical behavior when no webhooks are registered (the dispatcher is a fast-path no-op).
- No schema changes — webhooks live in two new options, recent dispatches in a third.
- The events table from PR #23 / per-template breakdown / conversion attribution / A/B results are untouched. Webhook dispatches do *not* log to the analytics events table — they have their own FIFO so they don't pollute the per-template performance / CVR semantics.
- Existing function signatures unchanged; webhook dispatch is additive at four hook sites (one in messaging.php for sent + failed, two in analytics.php for delivered + clicked, one in helpers.php for opted_out).

## Test plan

- [ ] PHPUnit: 95 tests / 489 assertions green (`composer test`).
- [ ] PHPCS: clean against project ruleset (`composer lint`).
- [ ] Open Webhooks tab → "No webhooks configured yet."
- [ ] Add a webhook to https://webhook.site or a similar receiver, check `message.sent`, save → row appears with secret, no errors.
- [ ] Click Test fire → receiver gets a `webhook.test` event with `X-WCWP-Signature: sha256=…` and `X-WCWP-Event: webhook.test` headers; row's inline result reads "Test fired — receiver responded 200".
- [ ] Recompute the signature on the receiver side using the displayed secret — bytes match.
- [ ] Place a test order → receiver gets a `message.sent` event with `event_id`, `type`, `phone`, `order_id`, `provider`, `message_id`, `ab_variant` (optional) in `data`.
- [ ] Send to a known opt-out phone → receiver gets `message.failed`. Trigger an opt-out via the REST endpoint → receiver gets `customer.opted_out`.
- [ ] Configure a 500-returning receiver → "Recent dispatches" shows attempt 1 status `failed`. After ~5 min cron tick, attempt 2 fires; after another 15 min, attempt 3. After 3 failures, no further attempts.
- [ ] Delete a webhook → JS confirm appears, row disappears, no further events arrive at that receiver.

## Risk / rollback

Low–medium. Touches several hot paths (every message send fires a dispatch hook now), but each call site short-circuits on "no webhooks subscribed" before any work, and the dispatcher itself is gated on `function_exists('wcwp_dispatch_webhook')` for paranoid safety. The synchronous first attempt does add up to 8s of latency per registered webhook on the message-send path — admins running many webhooks should configure receivers that respond fast (or we add async-from-the-start in a follow-up if this becomes a real concern). Rollback = revert the merge commit; webhook options stay in DB but are harmless.