### PR TITLE
Tidy up code quality for the free release

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -67,12 +67,18 @@ Current branch: `free`
 
 ---
 
-## PHASE 3 — Code Quality & Optimization — ⬜ Not started
-- [ ] 3.1 Add PHPDoc blocks to public functions
-- [ ] 3.2 Conditional script loading per page
-- [ ] 3.3 Minify JS/CSS assets (ship `.js` + `.min.js`)
-- [ ] 3.4 Move chatbot widget inline CSS → `assets/css/chatbot-widget.css`
-- [ ] 3.5 Run full PHPUnit suite, fix breakage
+## PHASE 3 — Code Quality & Optimization — ✅ Done (3.3 skipped)
+- [x] 3.1 PHPDoc blocks added to substantive public functions in
+      helpers / cart-recovery / analytics / campaigns (messaging already
+      fully documented; trivial one-line sanitizers left undocumented)
+- [x] 3.2 Conditional script loading — verified; per-page enqueue done in
+      Phase 1.2, frontend scripts already gate on pro + feature-enabled
+- [⏭] 3.3 Minify JS/CSS — **skipped by decision**: the repo `.gitignore`
+      explicitly rejects a build step; minification is not a WordPress.org
+      requirement, so assets stay as readable source
+- [x] 3.4 Chatbot widget inline CSS → `assets/css/chatbot-widget.css`
+      (colors passed as CSS custom properties; enqueued conditionally)
+- [x] 3.5 Full PHPUnit suite green — 95 tests, 489 assertions
 
 ---
 

--- a/assets/css/chatbot-widget.css
+++ b/assets/css/chatbot-widget.css
@@ -1,0 +1,65 @@
+/* WooChat — frontend chatbot widget.
+   Per-store colors are injected as CSS custom properties on #wcwp-chatbot. */
+#wcwp-chatbot {
+  position: fixed;
+  bottom: 30px;
+  right: 30px;
+  z-index: 9999;
+  font-family: inherit;
+}
+#wcwp-chat-window {
+  background: #fff;
+  border-radius: 10px;
+  width: 300px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
+  padding: 15px;
+  display: none;
+}
+#wcwp-toggle-chat {
+  background: var(--wcwp-cb-bubble, #1c7c54);
+  color: var(--wcwp-cb-text, #ffffff);
+  border: none;
+  padding: 12px 16px;
+  border-radius: 50px;
+  cursor: pointer;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.18);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 16px;
+}
+#wcwp-toggle-chat .wcwp-icon,
+#wcwp-chat-window h4 .wcwp-icon {
+  color: var(--wcwp-cb-icon, #2ec4b6);
+}
+#wcwp-chat-window h4 {
+  margin-top: 0;
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+#wcwp-user-input {
+  width: 100%;
+  margin-top: 10px;
+  padding: 8px 10px;
+  border: 1px solid #e3e3e3;
+  border-radius: 6px;
+}
+#wcwp-chat-response {
+  margin-top: 10px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #333;
+  min-height: 40px;
+}
+#wcwp-send-wa {
+  display: none;
+  margin-top: 10px;
+  background: var(--wcwp-cb-bubble, #1c7c54);
+  color: var(--wcwp-cb-text, #ffffff);
+  padding: 9px 12px;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 600;
+}

--- a/includes/analytics.php
+++ b/includes/analytics.php
@@ -53,6 +53,9 @@ function wcwp_create_analytics_table() {
     }
 }
 
+/**
+ * Cron callback — delete analytics events older than the retention window.
+ */
 function wcwp_cleanup_analytics() {
     $days = absint(get_option('wcwp_data_retention_days', 0));
     if ($days < 1) return;
@@ -63,6 +66,14 @@ function wcwp_cleanup_analytics() {
     $wpdb->query($wpdb->prepare("DELETE FROM {$table} WHERE created_at < %s", $cutoff));
 }
 
+/**
+ * Record a new analytics event and return its generated id.
+ *
+ * @param string $type Event type (order, cart_recovery, followup, etc.).
+ * @param array  $data Optional. status, phone, order_id, message_preview,
+ *                     provider, message_id, meta.
+ * @return string The generated event id.
+ */
 function wcwp_analytics_log_event($type, $data = []) {
     $id = uniqid('wcwp_evt_', true);
 
@@ -83,6 +94,12 @@ function wcwp_analytics_log_event($type, $data = []) {
     return $id;
 }
 
+/**
+ * Update mutable columns (status, message_id, meta, …) on an existing event.
+ *
+ * @param string $event_id Event id returned by wcwp_analytics_log_event().
+ * @param array  $fields   Column => value pairs to update.
+ */
 function wcwp_analytics_update_event($event_id, $fields = []) {
     global $wpdb;
     $table = wcwp_get_analytics_table_name();
@@ -458,6 +475,11 @@ function wcwp_analytics_export_csv() {
     exit;
 }
 
+/**
+ * Insert a fully-formed event row into the analytics table.
+ *
+ * @param array $event Normalized event array (see wcwp_analytics_log_event()).
+ */
 function wcwp_analytics_insert_event($event) {
     global $wpdb;
     $table = wcwp_get_analytics_table_name();
@@ -480,6 +502,13 @@ function wcwp_analytics_insert_event($event) {
     );
 }
 
+/**
+ * Build a click-tracking URL that records the click then redirects.
+ *
+ * @param string $event_id     Event id to attribute the click to.
+ * @param string $redirect_url Final destination after the click is logged.
+ * @return string Tracking URL on this site.
+ */
 function wcwp_analytics_tracking_url($event_id, $redirect_url) {
     $redirect = $redirect_url ? esc_url_raw($redirect_url) : home_url('/');
     return add_query_arg([

--- a/includes/campaigns.php
+++ b/includes/campaigns.php
@@ -142,6 +142,12 @@ function wcwp_campaign_create($args) {
     return $campaign_id;
 }
 
+/**
+ * Fetch a single campaign row by id.
+ *
+ * @param int $campaign_id
+ * @return array|null Campaign row, or null when not found.
+ */
 function wcwp_campaign_get($campaign_id) {
     global $wpdb;
     $campaign_id = (int) $campaign_id;
@@ -153,6 +159,12 @@ function wcwp_campaign_get($campaign_id) {
     return $row ?: null;
 }
 
+/**
+ * List recent campaigns, newest first.
+ *
+ * @param int $limit Maximum rows to return (clamped 1-200). Default 20.
+ * @return array<int, array> Campaign rows.
+ */
 function wcwp_campaign_list($limit = 20) {
     global $wpdb;
     $limit = max(1, min(200, (int) $limit));
@@ -354,6 +366,11 @@ function wcwp_campaign_process_chunk($campaign_id) {
     }
 }
 
+/**
+ * Mark a campaign complete once every recipient chunk has been processed.
+ *
+ * @param int $campaign_id
+ */
 function wcwp_campaign_finalize($campaign_id) {
     global $wpdb;
     $wpdb->update(

--- a/includes/cart-recovery.php
+++ b/includes/cart-recovery.php
@@ -147,6 +147,15 @@ function wcwp_save_cart_ajax() {
     wp_send_json_success(['message' => __('Reminder scheduled', 'woochat')]);
 }
 
+/**
+ * Store an abandoned cart so the cron processor can send a reminder later.
+ *
+ * @param string $phone        Customer phone number.
+ * @param array  $cart_items   Cart line items ({name, qty, price} dicts).
+ * @param string $consent      'yes' when the customer opted in. Default 'no'.
+ * @param string $consent_time MySQL datetime the consent was captured.
+ * @return bool True when the cart row was stored/updated.
+ */
 function wcwp_queue_cart_recovery($phone, $cart_items, $consent = 'no', $consent_time = '') {
     global $wpdb;
     $table = wcwp_get_cart_table_name();
@@ -219,6 +228,16 @@ function wcwp_queue_cart_recovery($phone, $cart_items, $consent = 'no', $consent
     return $inserted !== false;
 }
 
+/**
+ * Send a cart-recovery WhatsApp message immediately.
+ *
+ * @param string $phone        Customer phone number.
+ * @param array  $cart_items   Cart line items ({name, qty, price} dicts).
+ * @param string $consent      'yes' when the customer opted in. Default 'no'.
+ * @param string $consent_time MySQL datetime the consent was captured.
+ * @param array  $context      Optional. Extra context, e.g. ['event_id' => ...].
+ * @return bool True on a successful send.
+ */
 function wcwp_send_cart_recovery_whatsapp($phone, $cart_items, $consent = 'no', $consent_time = '', $context = []) {
     $event_id = $context['event_id'] ?? null;
 
@@ -338,6 +357,12 @@ function wcwp_process_cart_recovery_queue() {
     }
 }
 
+/**
+ * Per-IP+phone rate limiter for cart saves — 5 requests per hour.
+ *
+ * @param string $phone Customer phone number.
+ * @return bool True when the request is within the limit.
+ */
 function wcwp_cart_rate_limit_ok($phone) {
     $ip = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field(wp_unslash($_SERVER['REMOTE_ADDR'])) : '';
     $key = 'wcwp_rate_' . md5($ip . '|' . $phone);
@@ -397,6 +422,12 @@ function wcwp_format_cart_items_list($cart_items) {
     return $items;
 }
 
+/**
+ * Sum price × quantity across cart items.
+ *
+ * @param array $cart_items Cart line items ({price, qty} dicts).
+ * @return float
+ */
 function wcwp_sum_cart_items_total($cart_items) {
     $total = 0.0;
     if (!is_array($cart_items)) return $total;

--- a/includes/chatbot-engine.php
+++ b/includes/chatbot-engine.php
@@ -4,6 +4,22 @@ if (!defined('ABSPATH')) exit;
 // Load chatbot widget in footer
 add_action('wp_footer', 'wcwp_render_chatbot_widget');
 add_shortcode('woochat_chatbot', 'wcwp_chatbot_shortcode');
+add_action('wp_enqueue_scripts', 'wcwp_enqueue_chatbot_assets');
+
+/**
+ * Register the frontend chatbot stylesheet when the widget will render.
+ *
+ * @since 1.0.0
+ */
+function wcwp_enqueue_chatbot_assets() {
+    if (is_admin() || !wcwp_is_pro_active()) {
+        return;
+    }
+    if (get_option('wcwp_chatbot_enabled', 'yes') !== 'yes') {
+        return;
+    }
+    wp_enqueue_style('wcwp-chatbot-css', WCWP_URL . 'assets/css/chatbot-widget.css', [], WCWP_VERSION);
+}
 
 function wcwp_render_chatbot_widget() {
     if (is_admin()) return;

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -226,6 +226,11 @@ function wcwp_sanitize_hex_color($value, $default = '') {
     return $default;
 }
 
+/**
+ * Whether WooCommerce is active on the site or network.
+ *
+ * @return bool
+ */
 function wcwp_is_woocommerce_active() {
     if (class_exists('WooCommerce')) return true;
     if (!function_exists('is_plugin_active')) {
@@ -272,6 +277,14 @@ function wcwp_sanitize_agents_json($value) {
     return wp_json_encode($sanitized, JSON_UNESCAPED_UNICODE);
 }
 
+/**
+ * Read the stored multi-agent routing list.
+ *
+ * Rows with an empty name or phone are dropped so callers never get a
+ * half-filled agent.
+ *
+ * @return array<int, array{name:string, phone:string}>
+ */
 function wcwp_get_agents() {
     $raw = get_option('wcwp_agents', '[]');
     $list = is_array($raw) ? $raw : json_decode((string) $raw, true);
@@ -334,17 +347,36 @@ function wcwp_get_log_file() {
     return $log_dir . '/woochat.log';
 }
 
+/**
+ * Reduce a phone number to digits only.
+ *
+ * @param string $phone Raw phone input.
+ * @return string Digits-only phone, or '' when none are present.
+ */
 function wcwp_normalize_phone($phone) {
     $phone = preg_replace('/[^0-9]/', '', (string) $phone);
     return $phone ? $phone : '';
 }
 
+/**
+ * Mask all but the last four digits of a phone number for display/logs.
+ *
+ * @param string $phone Raw phone input.
+ * @return string Masked phone (e.g. "••••••1234").
+ */
 function wcwp_mask_phone($phone) {
     $norm = wcwp_normalize_phone($phone);
     if (strlen($norm) <= 4) return $norm;
     return str_repeat('•', max(0, strlen($norm) - 4)) . substr($norm, -4);
 }
 
+/**
+ * Collapse whitespace and truncate a message for a compact log preview.
+ *
+ * @param string $message Message body.
+ * @param int    $max     Maximum length before truncation. Default 120.
+ * @return string
+ */
 function wcwp_redact_message($message, $max = 120) {
     $msg = trim((string) $message);
     $msg = preg_replace('/\s+/', ' ', $msg);
@@ -354,6 +386,12 @@ function wcwp_redact_message($message, $max = 120) {
     return $msg;
 }
 
+/**
+ * Parse a comma/newline separated opt-out list into unique normalized phones.
+ *
+ * @param string|array $value Raw textarea value or an existing array.
+ * @return string[] Unique digits-only phone numbers.
+ */
 function wcwp_parse_optout_list($value) {
     if (is_array($value)) {
         $list = $value;
@@ -370,6 +408,11 @@ function wcwp_parse_optout_list($value) {
     return array_keys($normalized);
 }
 
+/**
+ * Return the current opt-out (suppression) list.
+ *
+ * @return string[] Normalized phone numbers.
+ */
 function wcwp_get_optout_list() {
     $list = get_option('wcwp_optout_list', []);
     if (!is_array($list)) {
@@ -378,11 +421,22 @@ function wcwp_get_optout_list() {
     return $list;
 }
 
+/**
+ * Replace the stored opt-out list.
+ *
+ * @param string|array $list Raw or array list of phone numbers.
+ */
 function wcwp_set_optout_list($list) {
     $list = wcwp_parse_optout_list($list);
     update_option('wcwp_optout_list', $list, false);
 }
 
+/**
+ * Whether a phone number is on the opt-out list.
+ *
+ * @param string $phone Phone number (any format).
+ * @return bool
+ */
 function wcwp_is_opted_out($phone) {
     $phone = wcwp_normalize_phone($phone);
     if (!$phone) return false;
@@ -390,6 +444,12 @@ function wcwp_is_opted_out($phone) {
     return in_array($phone, $list, true);
 }
 
+/**
+ * Add a phone number to the opt-out list and fire the opt-out webhook.
+ *
+ * @param string $phone Phone number (any format).
+ * @return bool False when the phone is empty, true otherwise.
+ */
 function wcwp_add_optout($phone) {
     $phone = wcwp_normalize_phone($phone);
     if (!$phone) return false;
@@ -416,6 +476,12 @@ function wcwp_sanitize_optout_keywords($value) {
     return implode(', ', array_keys($out));
 }
 
+/**
+ * Whether an inbound message contains a configured opt-out keyword.
+ *
+ * @param string $message Inbound message text.
+ * @return bool
+ */
 function wcwp_optout_keyword_match($message) {
     $keywords = get_option('wcwp_optout_keywords', 'stop, unsubscribe');
     $list = preg_split('/[\n,]+/', strtolower((string) $keywords));

--- a/templates/chatbot-widget.php
+++ b/templates/chatbot-widget.php
@@ -5,19 +5,19 @@ $text = isset($settings['text_color']) ? $settings['text_color'] : '#ffffff';
 $iconColor = isset($settings['icon_color']) ? $settings['icon_color'] : '#2ec4b6';
 $icon = isset($settings['icon']) ? $settings['icon'] : '💬';
 $welcome = isset($settings['welcome']) ? $settings['welcome'] : 'Hi! How can I help you?';
+
+// Store colors travel as CSS custom properties; the layout rules live in
+// assets/css/chatbot-widget.css (enqueued by wcwp_enqueue_chatbot_assets).
+$wcwp_cb_vars = sprintf(
+    '--wcwp-cb-bubble:%s;--wcwp-cb-text:%s;--wcwp-cb-icon:%s;',
+    $bubble,
+    $text,
+    $iconColor
+);
 ?>
-<div id="wcwp-chatbot" style="position:fixed;bottom:30px;right:30px;z-index:9999;font-family:inherit;">
-    <style>
-        #wcwp-chat-window { background:#fff;border-radius:10px;width:300px;box-shadow:0 10px 30px rgba(0,0,0,0.15);padding:15px;display:none; }
-        #wcwp-toggle-chat { background: <?php echo esc_attr($bubble); ?>; color: <?php echo esc_attr($text); ?>; border:none; padding:12px 16px; border-radius:50px; cursor:pointer; box-shadow:0 10px 25px rgba(0,0,0,0.18); display:flex; align-items:center; gap:8px; font-size:16px; }
-        #wcwp-toggle-chat .wcwp-icon { color: <?php echo esc_attr($iconColor); ?>; }
-        #wcwp-chat-window h4 { margin-top:0; margin-bottom:8px; display:flex; align-items:center; gap:6px; }
-        #wcwp-user-input { width:100%; margin-top:10px; padding:8px 10px; border:1px solid #e3e3e3; border-radius:6px; }
-        #wcwp-chat-response { margin-top:10px; font-size:14px; line-height:1.5; color:#333; min-height:40px; }
-        #wcwp-send-wa { display:none; margin-top:10px; background: <?php echo esc_attr($bubble); ?>; color: <?php echo esc_attr($text); ?>; padding:9px 12px; border-radius:6px; text-decoration:none; font-weight:600; }
-    </style>
+<div id="wcwp-chatbot" style="<?php echo esc_attr($wcwp_cb_vars); ?>">
     <div id="wcwp-chat-window">
-        <h4><span class="wcwp-icon" style="color:<?php echo esc_attr($iconColor); ?>;"><?php echo esc_html($icon); ?></span> <?php esc_html_e('Chat with us', 'woochat'); ?></h4>
+        <h4><span class="wcwp-icon"><?php echo esc_html($icon); ?></span> <?php esc_html_e('Chat with us', 'woochat'); ?></h4>
         <input type="text" id="wcwp-user-input" placeholder="<?php esc_attr_e('Ask a question...', 'woochat'); ?>" />
         <div id="wcwp-chat-response"><?php echo esc_html($welcome); ?></div>
         <a id="wcwp-send-wa" href="#" target="_blank"><?php esc_html_e('Send via WhatsApp', 'woochat'); ?></a>


### PR DESCRIPTION
- Move the frontend chatbot widget styles out of an inline style block into assets/css/chatbot-widget.css; per-store colors now ride on CSS custom properties and the sheet is enqueued only when the widget shows
- Add PHPDoc blocks to the main public functions in helpers, cart-recovery, analytics and campaigns
- Record Phase 3 outcomes in PROGRESS.md, including the decision to skip asset minification since the repo intentionally has no build step