### PR TITLE
Gate Pro features for the free release

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -82,11 +82,23 @@ Current branch: `free`
 
 ---
 
-## PHASE 4 — Free Version Preparation — 🟡 Partial
+## PHASE 4 — Free Version Preparation — ✅ Done
 - [x] 4.1 `free` branch created
-- [ ] 4.2 Pro feature gating behind `wcwp_is_pro_active()`
-- [ ] 4.3 In-plugin Pro upsell notices (5 touchpoints)
-- [ ] 4.4 Update upgrade modal comparison table
+- [x] 4.2 Pro feature gating behind `wcwp_is_pro_active()`:
+  - Cart Recovery / Scheduler / Campaigns / Analytics / Webhooks — page-gated (Phase 1)
+  - Chatbot — basic widget + FAQ + single agent are Free; GPT replies,
+    color/icon customizer and multi-agent routing are Pro
+  - A/B testing — gated in the Messaging view and in the `wcwp_ab_get_template`
+    runtime
+  - Logs — Free capped at last 50 entries; download/export is Pro (handler
+    also rejects non-Pro)
+- [x] 4.3 Upsell notices: dismissible post-activation admin notice; Pro cards
+    on gated pages; A/B upsell in the message editor; log-viewer upsell.
+    (Order-list touchpoint skipped — no clean per-edit-screen hook)
+- [x] 4.4 Upgrade modal comparison table rewritten to the final Free/Pro split
+
+> Decision recap: chatbot split = "basic Free, AI Pro"; free-tier caps applied
+> for logs (50, no export), A/B testing, and single-agent routing.
 
 ---
 

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -459,15 +459,20 @@ function wcwp_render_upgrade_modal() {
             <p><?php esc_html_e("Unlock all premium features and maximize your store's potential!", 'woochat'); ?></p>
             <table class="wcwp-comparison-table">
                 <tr><th><?php esc_html_e('Feature', 'woochat'); ?></th><th><?php esc_html_e('Free', 'woochat'); ?></th><th class="pro"><?php esc_html_e('Pro', 'woochat'); ?></th></tr>
-                <tr><td><?php esc_html_e('Order Confirmation via WhatsApp', 'woochat'); ?></td><td>✔️</td><td class="pro">✔️</td></tr>
+                <tr><td><?php esc_html_e('Order Notifications via WhatsApp', 'woochat'); ?></td><td>✔️</td><td class="pro">✔️</td></tr>
                 <tr><td><?php esc_html_e('Manual Message Button', 'woochat'); ?></td><td>✔️</td><td class="pro">✔️</td></tr>
+                <tr><td><?php esc_html_e('WhatsApp Chat Widget', 'woochat'); ?></td><td>✔️</td><td class="pro">✔️</td></tr>
+                <tr><td><?php esc_html_e('Gutenberg Blocks', 'woochat'); ?></td><td>✔️</td><td class="pro">✔️</td></tr>
+                <tr><td><?php esc_html_e('Twilio &amp; Cloud API', 'woochat'); ?></td><td>✔️</td><td class="pro">✔️</td></tr>
+                <tr><td><?php esc_html_e('Message Logs', 'woochat'); ?></td><td><?php esc_html_e('Last 50', 'woochat'); ?></td><td class="pro"><?php esc_html_e('Unlimited + export', 'woochat'); ?></td></tr>
                 <tr><td><?php esc_html_e('Cart Recovery', 'woochat'); ?></td><td></td><td class="pro">✔️</td></tr>
                 <tr><td><?php esc_html_e('Follow-up Scheduler', 'woochat'); ?></td><td></td><td class="pro">✔️</td></tr>
                 <tr><td><?php esc_html_e('Bulk Campaigns', 'woochat'); ?></td><td></td><td class="pro">✔️</td></tr>
                 <tr><td><?php esc_html_e('Analytics Dashboard', 'woochat'); ?></td><td></td><td class="pro">✔️</td></tr>
-                <tr><td><?php esc_html_e('Webhooks &amp; Integrations', 'woochat'); ?></td><td></td><td class="pro">✔️</td></tr>
                 <tr><td><?php esc_html_e('A/B Testing', 'woochat'); ?></td><td></td><td class="pro">✔️</td></tr>
-                <tr><td><?php esc_html_e('GPT/AI Auto Replies', 'woochat'); ?></td><td></td><td class="pro">✔️</td></tr>
+                <tr><td><?php esc_html_e('GPT/AI Chatbot Replies', 'woochat'); ?></td><td></td><td class="pro">✔️</td></tr>
+                <tr><td><?php esc_html_e('Chatbot Customizer &amp; Multi-Agent', 'woochat'); ?></td><td></td><td class="pro">✔️</td></tr>
+                <tr><td><?php esc_html_e('Webhooks &amp; Integrations', 'woochat'); ?></td><td></td><td class="pro">✔️</td></tr>
                 <tr><td><?php esc_html_e('Premium Support', 'woochat'); ?></td><td></td><td class="pro">✔️</td></tr>
             </table>
             <a href="https://zignites.com/woochat" target="_blank" rel="noopener"><button class="wcwp-upgrade-btn"><?php esc_html_e('Upgrade Now', 'woochat'); ?></button></a>
@@ -484,6 +489,53 @@ function wcwp_render_admin_footer_modals() {
         return;
     }
     wcwp_render_upgrade_modal();
+}
+
+/**
+ * One-time, dismissible Pro upsell notice shown after activation.
+ */
+add_action('admin_notices', 'wcwp_pro_upsell_admin_notice');
+function wcwp_pro_upsell_admin_notice() {
+    if (!current_user_can('manage_options') || wcwp_is_pro_active()) {
+        return;
+    }
+    if (get_option('wcwp_pro_notice_dismissed') === 'yes') {
+        return;
+    }
+
+    $dismiss_url = wp_nonce_url(
+        add_query_arg('wcwp_dismiss_pro_notice', '1'),
+        'wcwp_dismiss_pro_notice'
+    );
+    ?>
+    <div class="notice notice-info wcwp-pro-upsell-notice">
+        <p>
+            <strong><?php esc_html_e('WooChat is active.', 'woochat'); ?></strong>
+            <?php esc_html_e('Upgrade to WooChat Pro for cart recovery, analytics, bulk campaigns and A/B testing.', 'woochat'); ?>
+        </p>
+        <p>
+            <a href="https://zignites.com/woochat" class="button button-primary" target="_blank" rel="noopener"><?php esc_html_e('Upgrade Now', 'woochat'); ?></a>
+            <a href="<?php echo esc_url($dismiss_url); ?>" class="button"><?php esc_html_e('Dismiss', 'woochat'); ?></a>
+        </p>
+    </div>
+    <?php
+}
+
+/**
+ * Persist dismissal of the Pro upsell notice.
+ */
+add_action('admin_init', 'wcwp_handle_pro_notice_dismiss');
+function wcwp_handle_pro_notice_dismiss() {
+    if (!isset($_GET['wcwp_dismiss_pro_notice']) || !current_user_can('manage_options')) {
+        return;
+    }
+    $nonce = isset($_GET['_wpnonce']) ? sanitize_text_field(wp_unslash($_GET['_wpnonce'])) : '';
+    if (!wp_verify_nonce($nonce, 'wcwp_dismiss_pro_notice')) {
+        return;
+    }
+    update_option('wcwp_pro_notice_dismissed', 'yes', false);
+    wp_safe_redirect(remove_query_arg(['wcwp_dismiss_pro_notice', '_wpnonce']));
+    exit;
 }
 
 /**

--- a/admin/views/tab-chatbot.php
+++ b/admin/views/tab-chatbot.php
@@ -1,23 +1,36 @@
 <?php
 if (!defined('ABSPATH')) exit;
+
+// The Chatbot page is reachable on the free plan, but the color/icon
+// customizer, GPT fallback and multi-agent routing are Pro features. For
+// non-Pro users those controls render disabled; a hidden input preserves any
+// previously saved value so a Save on this page never wipes it.
+$wcwp_cb_pro = wcwp_is_pro_active();
 ?>
+<?php if (!$wcwp_cb_pro) : ?>
+    <div class="wcwp-pro-banner"><span class="dashicons dashicons-admin-customizer"></span> <?php esc_html_e('The chatbot color/icon customizer, GPT auto-replies and multi-agent routing are Pro features. The basic chat widget and FAQ replies are included free.', 'woochat'); ?> <button type="button" class="wcwp-open-upgrade-modal" style="margin-left:12px;"><?php esc_html_e('Upgrade', 'woochat'); ?></button></div>
+<?php endif; ?>
 <div class="wcwp-chatbot-customizer">
         <div class="wcwp-chatbot-customizer-controls">
-            <label for="wcwp-chatbot-bg"><?php esc_html_e('Chatbot Bubble Color', 'woochat'); ?></label>
-            <input type="color" id="wcwp-chatbot-bg" name="wcwp_chatbot_bg" value="<?php echo esc_attr(get_option('wcwp_chatbot_bg', '#1c7c54')); ?>">
-            <label for="wcwp-chatbot-color"><?php esc_html_e('Text Color', 'woochat'); ?></label>
-            <input type="color" id="wcwp-chatbot-color" name="wcwp_chatbot_text" value="<?php echo esc_attr(get_option('wcwp_chatbot_text', '#ffffff')); ?>">
-            <label for="wcwp-chatbot-icon"><?php esc_html_e('Icon Color', 'woochat'); ?></label>
-            <input type="color" id="wcwp-chatbot-icon" name="wcwp_chatbot_icon_color" value="<?php echo esc_attr(get_option('wcwp_chatbot_icon_color', '#2ec4b6')); ?>">
-            <label><?php esc_html_e('Choose Icon', 'woochat'); ?></label>
-            <div class="wcwp-icon-select">
+            <label for="wcwp-chatbot-bg"><?php esc_html_e('Chatbot Bubble Color', 'woochat'); ?><?php if (!$wcwp_cb_pro) : ?> <span class="wcwp-pro-tag"><?php esc_html_e('Pro', 'woochat'); ?></span><?php endif; ?></label>
+            <input type="color" id="wcwp-chatbot-bg" <?php echo $wcwp_cb_pro ? 'name="wcwp_chatbot_bg"' : ''; ?> value="<?php echo esc_attr(get_option('wcwp_chatbot_bg', '#1c7c54')); ?>" <?php disabled(!$wcwp_cb_pro); ?>>
+            <label for="wcwp-chatbot-color"><?php esc_html_e('Text Color', 'woochat'); ?><?php if (!$wcwp_cb_pro) : ?> <span class="wcwp-pro-tag"><?php esc_html_e('Pro', 'woochat'); ?></span><?php endif; ?></label>
+            <input type="color" id="wcwp-chatbot-color" <?php echo $wcwp_cb_pro ? 'name="wcwp_chatbot_text"' : ''; ?> value="<?php echo esc_attr(get_option('wcwp_chatbot_text', '#ffffff')); ?>" <?php disabled(!$wcwp_cb_pro); ?>>
+            <label for="wcwp-chatbot-icon"><?php esc_html_e('Icon Color', 'woochat'); ?><?php if (!$wcwp_cb_pro) : ?> <span class="wcwp-pro-tag"><?php esc_html_e('Pro', 'woochat'); ?></span><?php endif; ?></label>
+            <input type="color" id="wcwp-chatbot-icon" <?php echo $wcwp_cb_pro ? 'name="wcwp_chatbot_icon_color"' : ''; ?> value="<?php echo esc_attr(get_option('wcwp_chatbot_icon_color', '#2ec4b6')); ?>" <?php disabled(!$wcwp_cb_pro); ?>>
+            <label><?php esc_html_e('Choose Icon', 'woochat'); ?><?php if (!$wcwp_cb_pro) : ?> <span class="wcwp-pro-tag"><?php esc_html_e('Pro', 'woochat'); ?></span><?php endif; ?></label>
+            <div class="wcwp-icon-select <?php echo esc_attr($wcwp_cb_pro ? '' : 'wcwp-pro-locked'); ?>">
                 <?php $icon_option = get_option('wcwp_chatbot_icon', '💬'); ?>
                 <span class="wcwp-icon-option <?php echo esc_attr( $icon_option === '💬' ? 'selected' : '' ); ?>">💬</span>
                 <span class="wcwp-icon-option <?php echo esc_attr( $icon_option === '🤖' ? 'selected' : '' ); ?>">🤖</span>
                 <span class="wcwp-icon-option <?php echo esc_attr( $icon_option === '🟢' ? 'selected' : '' ); ?>">🟢</span>
                 <span class="wcwp-icon-option <?php echo esc_attr( $icon_option === '📞' ? 'selected' : '' ); ?>">📞</span>
             </div>
-            <input type="hidden" id="wcwp-chatbot-icon-value" name="wcwp_chatbot_icon" value="<?php echo esc_attr($icon_option); ?>" />
+            <?php if ($wcwp_cb_pro) : ?>
+                <input type="hidden" id="wcwp-chatbot-icon-value" name="wcwp_chatbot_icon" value="<?php echo esc_attr($icon_option); ?>" />
+            <?php else : ?>
+                <input type="hidden" id="wcwp-chatbot-icon-value" value="<?php echo esc_attr($icon_option); ?>" />
+            <?php endif; ?>
             <label for="wcwp-chatbot-welcome"><?php esc_html_e('Welcome Message', 'woochat'); ?></label>
             <input type="text" id="wcwp-chatbot-welcome" name="wcwp_chatbot_welcome" value="<?php echo esc_attr(get_option('wcwp_chatbot_welcome', 'Hi! How can I help you?')); ?>">
         </div>
@@ -45,19 +58,32 @@ if (!defined('ABSPATH')) exit;
             </td>
         </tr>
         <tr>
-            <th scope="row"><label for="wcwp_chatbot_gpt_enabled"><?php esc_html_e('GPT Fallback', 'woochat'); ?></label><span class="wcwp-help-icon">?<span class="wcwp-tooltip"><?php esc_html_e('When the FAQ matcher finds no answer, ask the configured GPT endpoint for a reply. Requires GPT API endpoint and key set under the Scheduler tab.', 'woochat'); ?></span></span></th>
+            <th scope="row"><label for="wcwp_chatbot_gpt_enabled"><?php esc_html_e('GPT Fallback', 'woochat'); ?><?php if (!$wcwp_cb_pro) : ?> <span class="wcwp-pro-tag"><?php esc_html_e('Pro', 'woochat'); ?></span><?php endif; ?></label><span class="wcwp-help-icon">?<span class="wcwp-tooltip"><?php esc_html_e('When the FAQ matcher finds no answer, ask the configured GPT endpoint for a reply. Requires GPT API endpoint and key set on the Scheduler page.', 'woochat'); ?></span></span></th>
             <td>
-                <select name="wcwp_chatbot_gpt_enabled" id="wcwp_chatbot_gpt_enabled">
-                    <option value="no" <?php selected(get_option('wcwp_chatbot_gpt_enabled', 'no'), 'no'); ?>><?php esc_html_e('No', 'woochat'); ?></option>
-                    <option value="yes" <?php selected(get_option('wcwp_chatbot_gpt_enabled', 'no'), 'yes'); ?>><?php esc_html_e('Yes', 'woochat'); ?></option>
+                <?php $wcwp_gpt_enabled = get_option('wcwp_chatbot_gpt_enabled', 'no'); ?>
+                <select <?php echo $wcwp_cb_pro ? 'name="wcwp_chatbot_gpt_enabled"' : ''; ?> id="wcwp_chatbot_gpt_enabled" <?php disabled(!$wcwp_cb_pro); ?>>
+                    <option value="no" <?php selected($wcwp_gpt_enabled, 'no'); ?>><?php esc_html_e('No', 'woochat'); ?></option>
+                    <option value="yes" <?php selected($wcwp_gpt_enabled, 'yes'); ?>><?php esc_html_e('Yes', 'woochat'); ?></option>
                 </select>
-                <p class="description"><?php esc_html_e('Each call costs your GPT account. Rate-limited to 10 requests per hour per visitor IP.', 'woochat'); ?></p>
+                <?php if (!$wcwp_cb_pro) : ?>
+                    <input type="hidden" name="wcwp_chatbot_gpt_enabled" value="<?php echo esc_attr($wcwp_gpt_enabled); ?>" />
+                    <p class="description"><?php esc_html_e('GPT-powered auto-replies are a Pro feature.', 'woochat'); ?></p>
+                <?php else : ?>
+                    <p class="description"><?php esc_html_e('Each call costs your GPT account. Rate-limited to 10 requests per hour per visitor IP.', 'woochat'); ?></p>
+                <?php endif; ?>
             </td>
         </tr>
     </table>
 
-    <h3><?php esc_html_e('Agents (multi-agent routing)', 'woochat'); ?></h3>
-    <p class="description"><?php esc_html_e('Add the team members who can receive customer chats. The chatbot widget routes "Send via WhatsApp" clicks to one of these numbers using the routing mode below.', 'woochat'); ?></p>
+    <h3><?php esc_html_e('Agents', 'woochat'); ?><?php if (!$wcwp_cb_pro) : ?> <span class="wcwp-pro-tag"><?php esc_html_e('Multi-agent is Pro', 'woochat'); ?></span><?php endif; ?></h3>
+    <p class="description">
+        <?php if ($wcwp_cb_pro) : ?>
+            <?php esc_html_e('Add the team members who can receive customer chats. The chatbot widget routes "Send via WhatsApp" clicks to one of these numbers using the routing mode below.', 'woochat'); ?>
+        <?php else : ?>
+            <?php esc_html_e('The free plan routes every chat to a single agent. Upgrade to Pro to add more agents and load-balance between them.', 'woochat'); ?>
+        <?php endif; ?>
+    </p>
+    <?php if ($wcwp_cb_pro) : ?>
     <table class="form-table">
         <tr>
             <th scope="row"><label for="wcwp_agent_routing_mode"><?php esc_html_e('Routing mode', 'woochat'); ?></label></th>
@@ -71,7 +97,17 @@ if (!defined('ABSPATH')) exit;
             </td>
         </tr>
     </table>
+    <?php else : ?>
+        <input type="hidden" name="wcwp_agent_routing_mode" value="<?php echo esc_attr(get_option('wcwp_agent_routing_mode', 'single')); ?>" />
+    <?php endif; ?>
 
+    <?php
+    $wcwp_agents = wcwp_get_agents();
+    // Free plan edits a single agent only.
+    if (!$wcwp_cb_pro) {
+        $wcwp_agents = array_slice($wcwp_agents, 0, 1);
+    }
+    ?>
     <table class="widefat striped" id="wcwp-agents-table">
         <thead>
             <tr>
@@ -81,25 +117,24 @@ if (!defined('ABSPATH')) exit;
             </tr>
         </thead>
         <tbody>
-            <?php
-            $wcwp_agents = wcwp_get_agents();
-            if (empty($wcwp_agents)) :
-                ?>
+            <?php if (empty($wcwp_agents)) : ?>
                 <tr class="wcwp-agent-row">
                     <td><input type="text" class="wcwp-agent-name regular-text" placeholder="<?php esc_attr_e('e.g. Sales', 'woochat'); ?>" value="" /></td>
                     <td><input type="text" class="wcwp-agent-phone regular-text" placeholder="<?php esc_attr_e('e.g. +14155550100', 'woochat'); ?>" value="" /></td>
-                    <td><button type="button" class="button-link wcwp-agent-remove" aria-label="<?php esc_attr_e('Remove agent', 'woochat'); ?>">&times;</button></td>
+                    <td><?php if ($wcwp_cb_pro) : ?><button type="button" class="button-link wcwp-agent-remove" aria-label="<?php esc_attr_e('Remove agent', 'woochat'); ?>">&times;</button><?php endif; ?></td>
                 </tr>
             <?php else : foreach ($wcwp_agents as $wcwp_agent) : ?>
                 <tr class="wcwp-agent-row">
                     <td><input type="text" class="wcwp-agent-name regular-text" placeholder="<?php esc_attr_e('e.g. Sales', 'woochat'); ?>" value="<?php echo esc_attr($wcwp_agent['name']); ?>" /></td>
                     <td><input type="text" class="wcwp-agent-phone regular-text" placeholder="<?php esc_attr_e('e.g. +14155550100', 'woochat'); ?>" value="<?php echo esc_attr($wcwp_agent['phone']); ?>" /></td>
-                    <td><button type="button" class="button-link wcwp-agent-remove" aria-label="<?php esc_attr_e('Remove agent', 'woochat'); ?>">&times;</button></td>
+                    <td><?php if ($wcwp_cb_pro) : ?><button type="button" class="button-link wcwp-agent-remove" aria-label="<?php esc_attr_e('Remove agent', 'woochat'); ?>">&times;</button><?php endif; ?></td>
                 </tr>
             <?php endforeach; endif; ?>
         </tbody>
     </table>
+    <?php if ($wcwp_cb_pro) : ?>
     <p>
         <button type="button" class="button" id="wcwp-agent-add">+ <?php esc_html_e('Add agent', 'woochat'); ?></button>
     </p>
+    <?php endif; ?>
     <input type="hidden" name="wcwp_agents" id="wcwp_agents_input" value="<?php echo esc_attr(get_option('wcwp_agents', '[]')); ?>" />

--- a/admin/views/tab-logs.php
+++ b/admin/views/tab-logs.php
@@ -3,8 +3,14 @@ if (!defined('ABSPATH')) exit;
 
 $wcwp_log_keyword  = isset($_GET['wcwp_log_q'])     ? sanitize_text_field(wp_unslash($_GET['wcwp_log_q']))     : '';
 $wcwp_log_tag      = isset($_GET['wcwp_log_tag'])   ? sanitize_text_field(wp_unslash($_GET['wcwp_log_tag']))   : '';
-$wcwp_log_lines    = isset($_GET['wcwp_log_lines']) ? max(50, min(2000, (int) $_GET['wcwp_log_lines']))        : 200;
 $wcwp_log_message  = isset($_GET['wcwp_log_msg'])   ? sanitize_text_field(wp_unslash($_GET['wcwp_log_msg']))   : '';
+
+// Free plan: last 50 entries only, and no log export. Pro lifts the cap.
+$wcwp_log_pro      = wcwp_is_pro_active();
+$wcwp_log_lines    = isset($_GET['wcwp_log_lines']) ? max(50, min(2000, (int) $_GET['wcwp_log_lines']))        : 200;
+if (!$wcwp_log_pro) {
+    $wcwp_log_lines = 50;
+}
 
 $wcwp_log_file     = wcwp_get_log_file();
 $wcwp_log_exists   = is_file($wcwp_log_file);
@@ -73,6 +79,7 @@ $wcwp_log_clear_url = wp_nonce_url(
                 <?php endforeach; ?>
             </select>
         </div>
+        <?php if ($wcwp_log_pro) : ?>
         <div>
             <label for="wcwp_log_lines"><?php esc_html_e('Lines', 'woochat'); ?></label><br>
             <select id="wcwp_log_lines" name="wcwp_log_lines">
@@ -81,12 +88,15 @@ $wcwp_log_clear_url = wp_nonce_url(
                 <?php endforeach; ?>
             </select>
         </div>
+        <?php endif; ?>
         <div>
             <button type="button" class="button button-primary" id="wcwp-log-filter-button"><?php esc_html_e('Apply', 'woochat'); ?></button>
         </div>
+        <?php if ($wcwp_log_pro) : ?>
         <div>
             <a class="button" href="<?php echo esc_url($wcwp_log_download_url); ?>"><span class="dashicons dashicons-download" style="vertical-align:middle;line-height:28px;"></span> <?php esc_html_e('Download log', 'woochat'); ?></a>
         </div>
+        <?php endif; ?>
         <div>
             <a class="button" href="<?php echo esc_url($wcwp_log_clear_url); ?>" id="wcwp-log-clear-button" style="color:#b32d2e;"><span class="dashicons dashicons-trash" style="vertical-align:middle;line-height:28px;"></span> <?php esc_html_e('Clear log', 'woochat'); ?></a>
         </div>
@@ -106,7 +116,11 @@ $wcwp_log_clear_url = wp_nonce_url(
         );
         ?>
         <?php if ($wcwp_log_total_shown >= $wcwp_log_lines) : ?>
-            <em><?php esc_html_e('Older entries are not shown — increase "Lines" or download the full log.', 'woochat'); ?></em>
+            <?php if ($wcwp_log_pro) : ?>
+                <em><?php esc_html_e('Older entries are not shown — increase "Lines" or download the full log.', 'woochat'); ?></em>
+            <?php else : ?>
+                <em><?php esc_html_e('The free plan shows the last 50 entries. Upgrade to WooChat Pro for unlimited log history and CSV export.', 'woochat'); ?> <button type="button" class="button-link wcwp-open-upgrade-modal"><?php esc_html_e('Upgrade', 'woochat'); ?></button></em>
+            <?php endif; ?>
         <?php endif; ?>
     </p>
 

--- a/admin/views/tab-messaging.php
+++ b/admin/views/tab-messaging.php
@@ -35,7 +35,20 @@ if (!defined('ABSPATH')) exit;
         <?php
         $order_ab_enabled = get_option('wcwp_order_message_ab_enabled', 'no');
         $order_template_b = get_option('wcwp_order_message_template_b', '');
+        $wcwp_msg_pro     = wcwp_is_pro_active();
         ?>
+        <?php if (!$wcwp_msg_pro) : ?>
+        <tr>
+            <th scope="row"><?php esc_html_e('A/B test this message', 'woochat'); ?> <span class="wcwp-pro-tag"><?php esc_html_e('Pro', 'woochat'); ?></span></th>
+            <td>
+                <p class="description"><?php esc_html_e('A/B testing compares two message templates and tracks which converts better. Upgrade to WooChat Pro to split-test your messages.', 'woochat'); ?></p>
+                <p><button type="button" class="button wcwp-open-upgrade-modal"><?php esc_html_e('Learn about Pro', 'woochat'); ?></button></p>
+                <?php // Force A/B off on the free plan and preserve any template B saved while on Pro. ?>
+                <input type="hidden" name="wcwp_order_message_ab_enabled" value="no" />
+                <input type="hidden" name="wcwp_order_message_template_b" value="<?php echo esc_attr($order_template_b); ?>" />
+            </td>
+        </tr>
+        <?php else : ?>
         <tr class="wcwp-ab-row" data-ab-kind="order">
             <th scope="row"><label for="wcwp_order_message_ab_enabled"><?php esc_html_e('A/B test this message', 'woochat'); ?></label><span class="wcwp-help-icon">?<span class="wcwp-tooltip"><?php esc_html_e('Send a 50/50 split between this template and Variant B. Each customer is assigned the same variant deterministically. View results on the Analytics tab.', 'woochat'); ?></span></span></th>
             <td>
@@ -62,4 +75,5 @@ if (!defined('ABSPATH')) exit;
                 </p>
             </td>
         </tr>
+        <?php endif; ?>
     </table>

--- a/assets/css/admin-premium.css
+++ b/assets/css/admin-premium.css
@@ -68,6 +68,25 @@
   margin-top: 12px;
 }
 
+/* Inline "Pro" tag on gated controls + locked control styling */
+.wcwp-pro-tag {
+  display: inline-block;
+  background: #1c7c54;
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 7px;
+  border-radius: 10px;
+  vertical-align: middle;
+  margin-left: 4px;
+}
+.wcwp-pro-locked {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
 /* Dashboard Pro feature teasers */
 .wcwp-dashboard-teasers {
   display: flex;

--- a/includes/ab-testing.php
+++ b/includes/ab-testing.php
@@ -109,7 +109,9 @@ function wcwp_ab_get_template($kind, $stable_key) {
     $cfg = $kinds[$kind];
 
     $a_template = (string) get_option($cfg['option_a'], $cfg['default_a']);
-    $enabled    = get_option($cfg['option_enabled'], 'no') === 'yes';
+    // A/B testing is a Pro feature — never split-test on the free plan,
+    // regardless of any option values left over from a prior Pro license.
+    $enabled    = wcwp_is_pro_active() && get_option($cfg['option_enabled'], 'no') === 'yes';
     $b_template = $enabled ? (string) get_option($cfg['option_b'], '') : '';
 
     if (!$enabled || trim($b_template) === '') {

--- a/includes/chatbot-engine.php
+++ b/includes/chatbot-engine.php
@@ -12,7 +12,7 @@ add_action('wp_enqueue_scripts', 'wcwp_enqueue_chatbot_assets');
  * @since 1.0.0
  */
 function wcwp_enqueue_chatbot_assets() {
-    if (is_admin() || !wcwp_is_pro_active()) {
+    if (is_admin()) {
         return;
     }
     if (get_option('wcwp_chatbot_enabled', 'yes') !== 'yes') {
@@ -24,8 +24,8 @@ function wcwp_enqueue_chatbot_assets() {
 function wcwp_render_chatbot_widget() {
     if (is_admin()) return;
 
-    if (!wcwp_is_pro_active()) return;
-
+    // The basic chat widget is a free feature; GPT replies, the color/icon
+    // customizer and multi-agent routing are gated downstream (Pro only).
     $enabled = get_option('wcwp_chatbot_enabled', 'yes');
     if ($enabled !== 'yes') return;
 
@@ -44,7 +44,6 @@ function wcwp_render_chatbot_widget() {
 }
 
 function wcwp_chatbot_shortcode() {
-    if (!wcwp_is_pro_active()) return '';
     $enabled = get_option('wcwp_chatbot_enabled', 'yes');
     if ($enabled !== 'yes') return '';
 
@@ -69,11 +68,20 @@ function wcwp_chatbot_localized_data() {
     $faq_pairs = json_decode(get_option('wcwp_faq_pairs', '[]'), true);
     if (!is_array($faq_pairs)) $faq_pairs = [];
 
+    $is_pro = wcwp_is_pro_active();
+
+    // Free tier is single-agent: keep only the first agent and force the
+    // 'single' routing mode so multi-agent load-balancing stays Pro-only.
+    $agents = wcwp_get_agents();
+    if (!$is_pro) {
+        $agents = array_slice($agents, 0, 1);
+    }
+
     return [
         'faq_pairs'    => $faq_pairs,
         'noAnswerText' => __( "Sorry, I don't have an answer for that.", 'woochat' ),
         'gpt'          => [
-            'enabled'  => get_option('wcwp_chatbot_gpt_enabled', 'no') === 'yes',
+            'enabled'  => $is_pro && get_option('wcwp_chatbot_gpt_enabled', 'no') === 'yes',
             'url'      => admin_url('admin-ajax.php'),
             'nonce'    => wp_create_nonce('wcwp_chatbot_gpt'),
             'action'   => 'wcwp_chatbot_gpt',
@@ -81,12 +89,26 @@ function wcwp_chatbot_localized_data() {
         ],
         // Agents are picked client-side so a full-page cache can't pin every
         // visitor to the same agent under 'random' mode.
-        'agents'        => wcwp_get_agents(),
-        'routing_mode'  => get_option('wcwp_agent_routing_mode', 'single') === 'random' ? 'random' : 'single',
+        'agents'        => $agents,
+        'routing_mode'  => ($is_pro && get_option('wcwp_agent_routing_mode', 'single') === 'random') ? 'random' : 'single',
     ];
 }
 
 function wcwp_get_chatbot_settings() {
+    $welcome = get_option('wcwp_chatbot_welcome', 'Hi! How can I help you?');
+
+    // The color/icon customizer is Pro — the free widget always renders with
+    // the default palette regardless of any values saved while on Pro.
+    if (!wcwp_is_pro_active()) {
+        return [
+            'bubble_color' => '#1c7c54',
+            'text_color'   => '#ffffff',
+            'icon_color'   => '#2ec4b6',
+            'icon'         => '💬',
+            'welcome'      => $welcome,
+        ];
+    }
+
     // Hex colors are also validated at write-time via the register_setting
     // sanitize_callback; this is the read-time defense-in-depth that
     // guarantees the chatbot template never sees an invalid color, even
@@ -96,7 +118,7 @@ function wcwp_get_chatbot_settings() {
         'text_color'   => wcwp_sanitize_hex_color(get_option('wcwp_chatbot_text', '#ffffff'), '#ffffff'),
         'icon_color'   => wcwp_sanitize_hex_color(get_option('wcwp_chatbot_icon_color', '#2ec4b6'), '#2ec4b6'),
         'icon'         => get_option('wcwp_chatbot_icon', '💬'),
-        'welcome'      => get_option('wcwp_chatbot_welcome', 'Hi! How can I help you?'),
+        'welcome'      => $welcome,
     ];
 }
 

--- a/includes/log-viewer.php
+++ b/includes/log-viewer.php
@@ -183,6 +183,10 @@ function wcwp_log_download_handler() {
     if (!current_user_can('manage_options')) {
         wp_die(esc_html__('Unauthorized', 'woochat'), '', ['response' => 403]);
     }
+    // Log export is a Pro feature.
+    if (!wcwp_is_pro_active()) {
+        wp_die(esc_html__('Log export is a WooChat Pro feature.', 'woochat'), '', ['response' => 403]);
+    }
     check_admin_referer('wcwp_log_download', 'wcwp_log_download_nonce');
 
     $file = wcwp_get_log_file();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -117,6 +117,15 @@ if (!defined('DAY_IN_SECONDS')) {
     define('DAY_IN_SECONDS', 86400);
 }
 
+// license-manager.php is not loaded in unit tests; stub the Pro gate so
+// feature code under test runs. Defaults to true (Pro behaviour); a test can
+// set $GLOBALS['wcwp_test_is_pro'] = false to exercise the free-tier path.
+if (!function_exists('wcwp_is_pro_active')) {
+    function wcwp_is_pro_active() {
+        return $GLOBALS['wcwp_test_is_pro'] ?? true;
+    }
+}
+
 require_once __DIR__ . '/../includes/helpers.php';
 require_once __DIR__ . '/../includes/cart-recovery.php';
 require_once __DIR__ . '/../includes/campaigns.php';


### PR DESCRIPTION
- Make the basic chat widget free: the floating widget, FAQ replies and a single agent now work without a license, while GPT auto-replies, the colour/icon customizer and multi-agent routing stay Pro
- Gate A/B testing — hide the Variant B fields on the free Messaging page and never split-test at runtime without a license
- Cap the free Logs page at the last 50 entries and make log export Pro, with the download handler rejecting non-Pro requests
- Add a dismissible post-activation upgrade notice and Pro upsell prompts on the gated pages, the message editor and the log viewer
- Refresh the upgrade modal comparison table to match the final split
- Stub wcwp_is_pro_active in the test bootstrap so the suite still runs