### PR TITLE
Prefix chatbot widget template variables

### DIFF
--- a/templates/chatbot-widget.php
+++ b/templates/chatbot-widget.php
@@ -1,29 +1,29 @@
 <?php if (!defined('ABSPATH')) exit; ?>
 <?php
-$bubble = isset($settings['bubble_color']) ? $settings['bubble_color'] : '#1c7c54';
-$text = isset($settings['text_color']) ? $settings['text_color'] : '#ffffff';
-$iconColor = isset($settings['icon_color']) ? $settings['icon_color'] : '#2ec4b6';
-$icon = isset($settings['icon']) ? $settings['icon'] : '💬';
-$welcome = isset($settings['welcome']) ? $settings['welcome'] : 'Hi! How can I help you?';
+$zignites_chat_cb_bubble = isset($settings['bubble_color']) ? $settings['bubble_color'] : '#1c7c54';
+$zignites_chat_cb_text = isset($settings['text_color']) ? $settings['text_color'] : '#ffffff';
+$zignites_chat_cb_icon_color = isset($settings['icon_color']) ? $settings['icon_color'] : '#2ec4b6';
+$zignites_chat_cb_icon = isset($settings['icon']) ? $settings['icon'] : '💬';
+$zignites_chat_cb_welcome = isset($settings['welcome']) ? $settings['welcome'] : 'Hi! How can I help you?';
 
 // Store colors travel as CSS custom properties; the layout rules live in
 // assets/css/chatbot-widget.css (enqueued by zignites_chat_enqueue_chatbot_assets).
 $zignites_chat_cb_vars = sprintf(
     '--zignites-chat-cb-bubble:%s;--zignites-chat-cb-text:%s;--zignites-chat-cb-icon:%s;',
-    $bubble,
-    $text,
-    $iconColor
+    $zignites_chat_cb_bubble,
+    $zignites_chat_cb_text,
+    $zignites_chat_cb_icon_color
 );
 ?>
 <div id="zignites-chat-chatbot" style="<?php echo esc_attr($zignites_chat_cb_vars); ?>">
     <div id="zignites-chat-chat-window">
-        <h4><span class="zignites-chat-icon"><?php echo esc_html($icon); ?></span> <?php esc_html_e('Chat with us', 'zignites-chat'); ?></h4>
+        <h4><span class="zignites-chat-icon"><?php echo esc_html($zignites_chat_cb_icon); ?></span> <?php esc_html_e('Chat with us', 'zignites-chat'); ?></h4>
         <input type="text" id="zignites-chat-user-input" placeholder="<?php esc_attr_e('Ask a question...', 'zignites-chat'); ?>" />
-        <div id="zignites-chat-chat-response"><?php echo esc_html($welcome); ?></div>
+        <div id="zignites-chat-chat-response"><?php echo esc_html($zignites_chat_cb_welcome); ?></div>
         <a id="zignites-chat-send-wa" href="#" target="_blank"><?php esc_html_e('Send via WhatsApp', 'zignites-chat'); ?></a>
     </div>
     <button id="zignites-chat-toggle-chat">
-        <span class="zignites-chat-icon"><?php echo esc_html($icon); ?></span>
+        <span class="zignites-chat-icon"><?php echo esc_html($zignites_chat_cb_icon); ?></span>
         <span><?php esc_html_e('Chat', 'zignites-chat'); ?></span>
     </button>
 </div>


### PR DESCRIPTION
- Renamed the 5 unprefixed template-scoped variables in chatbot-widget.php to use the zignites_chat_cb_ prefix
- Clears the remaining Plugin Check NonPrefixedVariableFound warnings in the production template