### PR TITLE
Scheduled campaigns: send-at time + recent-recipient exclusion

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -225,9 +225,25 @@ endpoint). Now wired end-to-end:
 Ingest inbound Cloud API / Twilio messages (signatures already verified in
 `optout.php`) into a conversation view so agents can reply in-window. — ⬜
 
-### P1 — Scheduled & recurring campaigns
-Campaigns are send-now only; add "send at <datetime>" + recent-recipient
-exclusion. — ⬜
+### P1 — Scheduled campaigns — ✅ Code complete (`feat/pro-scheduled-campaigns`; smoke test pending)
+Campaigns were send-now only; added "send at <datetime>" + recent-recipient
+exclusion.
+- [x] schema: campaigns.scheduled_at column (migration v4, dbDelta)
+- [x] campaign_create() respects a future send time → status 'scheduled'
+      (pure resolve_schedule() + validating normalize_datetime())
+- [x] promoter cron (every 5 min) flips due 'scheduled' campaigns to queued
+      and kicks off the first chunk; unscheduled on deactivate, cleared on
+      uninstall
+- [x] recent-recipient exclusion: skip phones that got a bulk message in the
+      last N days (pure filter_excluded() + analytics lookup)
+- [x] UI: schedule (datetime-local) + skip-recent fields, Scheduled column in
+      the list, AJAX handler wired
+- [x] fixed a latent bug: campaigns.js guarded on a stale wrapper id
+      (`zignites-chat-tab-content-campaigns`) that no longer existed, so the
+      create form's JS never ran — restored the wrapper
+- [x] 11 unit tests (normalize/resolve/filter); 129 pass, PHPCS green
+- [ ] live smoke test (create a scheduled campaign on a real store)
+- Note: "recurring" (repeat weekly/monthly) deferred to a later enhancement
 
 ### P2 — Richer campaign segments
 By product/category purchased, lifetime spend, location, and win-back
@@ -251,6 +267,5 @@ context for the chatbot. — ⬜
 ---
 
 ## Next Action
-**P1 / 8.1.7** — smoke-test receipts against live Twilio + Meta sandboxes,
-then merge `feat/pro-p1-delivery-receipts` into `pro`. After that, start
-**P1 (two-way team inbox)** or **scheduled campaigns** — pick next priority.
+Merge `feat/pro-scheduled-campaigns` into `pro`, then start **two-way team
+inbox** (P1, the big one) or **richer campaign segments** (P2, smaller).

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -809,14 +809,20 @@ function zignites_chat_ajax_create_campaign() {
     $template     = isset($_POST['template']) ? sanitize_textarea_field(wp_unslash($_POST['template'])) : '';
     $segment_type = isset($_POST['segment_type']) ? sanitize_key(wp_unslash($_POST['segment_type'])) : '';
     $days         = isset($_POST['segment_days']) ? max(1, (int) $_POST['segment_days']) : 30;
+    $scheduled_at = isset($_POST['scheduled_at']) ? sanitize_text_field(wp_unslash($_POST['scheduled_at'])) : '';
+    $exclude_days = isset($_POST['exclude_recent_days']) ? max(0, (int) $_POST['exclude_recent_days']) : 0;
 
     $segment_meta = $segment_type === 'recent_orders' ? ['days' => $days] : [];
+    if ($exclude_days > 0) {
+        $segment_meta['exclude_recent_days'] = $exclude_days;
+    }
 
     $result = zignites_chat_campaign_create([
         'name'         => $name,
         'template'     => $template,
         'segment_type' => $segment_type,
         'segment_meta' => $segment_meta,
+        'scheduled_at' => $scheduled_at,
     ]);
 
     if (is_wp_error($result)) {

--- a/admin/views/tab-campaigns.php
+++ b/admin/views/tab-campaigns.php
@@ -10,6 +10,7 @@ $zignites_chat_recent_campaigns = zignites_chat_campaign_list(20);
         <?php esc_html_e('Send a one-shot WhatsApp message to a customer segment. Sends are throttled to 10 per minute by default and skip anyone on the suppression list.', 'zignites-chat'); ?>
     </p>
 
+<div id="zignites-chat-tab-content-campaigns">
     <div class="zignites-chat-campaign-create" id="zignites-chat-campaign-create">
         <h3><?php esc_html_e('New campaign', 'zignites-chat'); ?></h3>
         <table class="form-table">
@@ -43,6 +44,22 @@ $zignites_chat_recent_campaigns = zignites_chat_campaign_list(20);
                 </td>
             </tr>
             <tr>
+                <th scope="row"><label for="zignites-chat-campaign-schedule"><?php esc_html_e('Schedule send', 'zignites-chat'); ?></label></th>
+                <td>
+                    <input type="datetime-local" id="zignites-chat-campaign-schedule" />
+                    <p class="description"><?php esc_html_e('Leave blank to send now. A future time queues the campaign until then (checked every 5 minutes).', 'zignites-chat'); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="zignites-chat-campaign-exclude-days"><?php esc_html_e('Skip recently messaged', 'zignites-chat'); ?></label></th>
+                <td>
+                    <?php esc_html_e('Skip customers who got a campaign in the last', 'zignites-chat'); ?>
+                    <input type="number" id="zignites-chat-campaign-exclude-days" min="0" max="3650" value="0" class="small-text" />
+                    <?php esc_html_e('days', 'zignites-chat'); ?>
+                    <p class="description"><?php esc_html_e('Set to 0 to message everyone in the segment.', 'zignites-chat'); ?></p>
+                </td>
+            </tr>
+            <tr>
                 <td colspan="2">
                     <button type="button" class="button button-primary" id="zignites-chat-campaign-submit"><?php esc_html_e('Create campaign', 'zignites-chat'); ?></button>
                     <span class="zignites-chat-campaign-feedback" id="zignites-chat-campaign-feedback" role="status"></span>
@@ -64,6 +81,7 @@ $zignites_chat_recent_campaigns = zignites_chat_campaign_list(20);
                     <th><?php esc_html_e('Failed', 'zignites-chat'); ?></th>
                     <th><?php esc_html_e('Skipped', 'zignites-chat'); ?></th>
                     <th><?php esc_html_e('Total', 'zignites-chat'); ?></th>
+                    <th><?php esc_html_e('Scheduled', 'zignites-chat'); ?></th>
                     <th><?php esc_html_e('Created', 'zignites-chat'); ?></th>
                 </tr>
             </thead>
@@ -76,9 +94,12 @@ $zignites_chat_recent_campaigns = zignites_chat_campaign_list(20);
                         <td class="zignites-chat-campaign-failed"><?php echo esc_html(number_format_i18n((int) $c['failed_count'])); ?></td>
                         <td class="zignites-chat-campaign-skipped"><?php echo esc_html(number_format_i18n((int) $c['skipped_count'])); ?></td>
                         <td class="zignites-chat-campaign-total"><?php echo esc_html(number_format_i18n((int) $c['total_count'])); ?></td>
+                        <td><?php echo !empty($c['scheduled_at']) ? esc_html(mysql2date(get_option('date_format') . ' ' . get_option('time_format'), $c['scheduled_at'])) : '—'; ?></td>
                         <td><?php echo esc_html(mysql2date(get_option('date_format') . ' ' . get_option('time_format'), $c['created_at'])); ?></td>
                     </tr>
                 <?php endforeach; ?>
             </tbody>
         </table>
     <?php endif; ?>
+</div>
+<?php // end #zignites-chat-tab-content-campaigns ?>

--- a/assets/js/campaigns.js
+++ b/assets/js/campaigns.js
@@ -12,6 +12,8 @@
         var nameEl    = document.getElementById('zignites-chat-campaign-name');
         var tmplEl    = document.getElementById('zignites-chat-campaign-template');
         var daysEl    = document.getElementById('zignites-chat-campaign-days');
+        var scheduleEl = document.getElementById('zignites-chat-campaign-schedule');
+        var excludeEl  = document.getElementById('zignites-chat-campaign-exclude-days');
         var submit    = document.getElementById('zignites-chat-campaign-submit');
         var feedback  = document.getElementById('zignites-chat-campaign-feedback');
 
@@ -56,6 +58,12 @@
             body.append('segment_type', segmentEl.value);
             if (segmentEl.value === 'recent_orders') {
                 body.append('segment_days', daysEl.value || '30');
+            }
+            if (scheduleEl && scheduleEl.value) {
+                body.append('scheduled_at', scheduleEl.value);
+            }
+            if (excludeEl && excludeEl.value) {
+                body.append('exclude_recent_days', excludeEl.value);
             }
 
             fetch(config.ajaxUrl, {

--- a/includes/campaigns.php
+++ b/includes/campaigns.php
@@ -22,6 +22,54 @@ if (!defined('ABSPATH')) exit;
 
 add_action('zignites_chat_process_campaign', 'zignites_chat_campaign_process_chunk');
 
+// Promote scheduled campaigns to running once their send time arrives. Reuses
+// the 5-minute schedule registered by cart-recovery.php.
+add_action('init', 'zignites_chat_schedule_campaign_promoter_cron');
+add_action('zignites_chat_promote_scheduled_campaigns', 'zignites_chat_promote_due_campaigns');
+
+/**
+ * Ensure the recurring promoter event is scheduled.
+ */
+function zignites_chat_schedule_campaign_promoter_cron() {
+    if (!wp_next_scheduled('zignites_chat_promote_scheduled_campaigns')) {
+        wp_schedule_event(time() + 60, 'zignites_chat_five_minutes', 'zignites_chat_promote_scheduled_campaigns');
+    }
+}
+
+/**
+ * Clear the promoter event (deactivation / uninstall).
+ */
+function zignites_chat_unschedule_campaign_promoter_cron() {
+    $timestamp = wp_next_scheduled('zignites_chat_promote_scheduled_campaigns');
+    if ($timestamp) {
+        wp_unschedule_event($timestamp, 'zignites_chat_promote_scheduled_campaigns');
+    }
+}
+
+/**
+ * Cron callback: flip any due 'scheduled' campaigns to 'queued' and kick off
+ * their first chunk. Bounded per run so a backlog can't stall the cron.
+ */
+function zignites_chat_promote_due_campaigns() {
+    if (!zignites_chat_is_pro_active()) return;
+
+    global $wpdb;
+    $table = zignites_chat_campaigns_table_name();
+    $now   = current_time('mysql');
+
+    $ids = $wpdb->get_col($wpdb->prepare(
+        "SELECT id FROM {$table} WHERE status = 'scheduled' AND scheduled_at IS NOT NULL AND scheduled_at <= %s ORDER BY scheduled_at ASC LIMIT 20",
+        $now
+    ));
+    if (!$ids) return;
+
+    foreach ($ids as $id) {
+        $id = (int) $id;
+        $wpdb->update($table, ['status' => 'queued'], ['id' => $id], ['%s'], ['%d']);
+        wp_schedule_single_event(time() + 5, 'zignites_chat_process_campaign', [$id]);
+    }
+}
+
 /* -------------------------------------------------------------------------
  * Schema
  * ----------------------------------------------------------------------- */
@@ -53,6 +101,7 @@ function zignites_chat_create_campaign_tables() {
         template TEXT NOT NULL,
         segment_type VARCHAR(40) NOT NULL,
         segment_meta TEXT NULL,
+        scheduled_at DATETIME NULL,
         status VARCHAR(20) NOT NULL DEFAULT 'queued',
         total_count INT UNSIGNED NOT NULL DEFAULT 0,
         sent_count INT UNSIGNED NOT NULL DEFAULT 0,
@@ -116,16 +165,24 @@ function zignites_chat_campaign_create($args) {
         return new WP_Error('zignites_chat_campaign_no_recipients', __('No matching customers — campaign not created.', 'zignites-chat'));
     }
 
-    $now = current_time('mysql');
-    $wpdb->insert(zignites_chat_campaigns_table_name(), [
+    $now      = current_time('mysql');
+    $schedule = zignites_chat_campaign_resolve_schedule($args['scheduled_at'] ?? '', $now);
+
+    $data = [
         'name'         => $name,
         'template'     => $template,
         'segment_type' => $segment_type,
         'segment_meta' => wp_json_encode($segment_meta),
-        'status'       => 'queued',
+        'status'       => $schedule['status'],
         'total_count'  => count($recipients),
         'created_at'   => $now,
-    ], ['%s', '%s', '%s', '%s', '%s', '%d', '%s']);
+    ];
+    $format = ['%s', '%s', '%s', '%s', '%s', '%d', '%s'];
+    if ($schedule['scheduled_at'] !== null) {
+        $data['scheduled_at'] = $schedule['scheduled_at'];
+        $format[] = '%s';
+    }
+    $wpdb->insert(zignites_chat_campaigns_table_name(), $data, $format);
 
     $campaign_id = (int) $wpdb->insert_id;
     if ($campaign_id <= 0) {
@@ -144,10 +201,107 @@ function zignites_chat_campaign_create($args) {
     }
 
     // Kick off the first chunk shortly after return so the admin sees
-    // immediate progress without sitting through an HTTP fan-out.
-    wp_schedule_single_event(time() + 5, 'zignites_chat_process_campaign', [$campaign_id]);
+    // immediate progress without sitting through an HTTP fan-out. Scheduled
+    // campaigns instead wait for the promoter cron to flip them to 'queued'
+    // at their send time.
+    if ($schedule['status'] === 'queued') {
+        wp_schedule_single_event(time() + 5, 'zignites_chat_process_campaign', [$campaign_id]);
+    }
 
     return $campaign_id;
+}
+
+/**
+ * Decide a new campaign's initial status from a requested send time. Pure.
+ *
+ * Times are compared as site-local 'Y-m-d H:i:s' strings (lexicographically
+ * chronological), matching how created_at / scheduled_at are stored.
+ *
+ * @param string $scheduled_at_raw Requested send time ('Y-m-d H:i', with or
+ *                                 without seconds, 'T' or space separator), or
+ *                                 '' to send immediately.
+ * @param string $now_mysql        Current site time as 'Y-m-d H:i:s'.
+ * @return array{status:string, scheduled_at:?string} 'scheduled' + normalized
+ *         time when a valid future time was given, else 'queued' + null.
+ */
+function zignites_chat_campaign_resolve_schedule($scheduled_at_raw, $now_mysql) {
+    $normalized = zignites_chat_normalize_datetime($scheduled_at_raw);
+    if ($normalized === '' || $normalized <= (string) $now_mysql) {
+        return ['status' => 'queued', 'scheduled_at' => null];
+    }
+    return ['status' => 'scheduled', 'scheduled_at' => $normalized];
+}
+
+/**
+ * Normalize a datetime-ish input to 'Y-m-d H:i:s', or '' if unparseable.
+ *
+ * Accepts the HTML datetime-local shape ('Y-m-d\TH:i') and space-separated
+ * forms with or without seconds. Deliberately does NOT shift timezone — the
+ * value is treated as site-local, same frame as current_time('mysql').
+ *
+ * @param string $raw
+ * @return string
+ */
+function zignites_chat_normalize_datetime($raw) {
+    $raw = trim(str_replace('T', ' ', (string) $raw));
+    if ($raw === '') return '';
+    if (!preg_match('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}(:\d{2})?$/', $raw)) return '';
+    if (strlen($raw) === 16) $raw .= ':00';
+    // Reject impossible dates/times: createFromFormat overflows (e.g. month
+    // 13 → next year), so a value that doesn't round-trip is invalid.
+    $dt = DateTime::createFromFormat('Y-m-d H:i:s', $raw);
+    if (!$dt || $dt->format('Y-m-d H:i:s') !== $raw) return '';
+    return $raw;
+}
+
+/**
+ * Remove recipients whose normalized phone is in the exclusion set. Pure.
+ *
+ * @param array $recipients      List of {phone, name} dicts.
+ * @param array $excluded_phones Normalized phone numbers to drop.
+ * @return array Filtered recipients.
+ */
+function zignites_chat_campaign_filter_excluded($recipients, $excluded_phones) {
+    if (!is_array($recipients)) return [];
+    if (empty($excluded_phones) || !is_array($excluded_phones)) return $recipients;
+
+    $set = array_flip(array_map('strval', $excluded_phones));
+    $out = [];
+    foreach ($recipients as $r) {
+        $phone = isset($r['phone']) ? (string) $r['phone'] : '';
+        if ($phone !== '' && isset($set[$phone])) continue;
+        $out[] = $r;
+    }
+    return $out;
+}
+
+/**
+ * Normalized phone numbers that received a bulk-campaign message within the
+ * last $days — used to skip over-messaging the same customers.
+ *
+ * @param int $days Look-back window in days.
+ * @return string[] Normalized phone numbers.
+ */
+function zignites_chat_campaign_recently_messaged_phones($days) {
+    $days = (int) $days;
+    if ($days < 1 || !function_exists('zignites_chat_get_analytics_table_name')) {
+        return [];
+    }
+    global $wpdb;
+    $table  = zignites_chat_get_analytics_table_name();
+    $cutoff = gmdate('Y-m-d H:i:s', time() - ($days * DAY_IN_SECONDS));
+    $rows   = $wpdb->get_col($wpdb->prepare(
+        "SELECT DISTINCT phone FROM {$table} WHERE type = 'bulk' AND status IN ('sent','delivered','read') AND created_at >= %s",
+        $cutoff
+    ));
+    if (!$rows) return [];
+
+    $out = [];
+    foreach ($rows as $phone) {
+        $norm = zignites_chat_normalize_phone($phone);
+        if ($norm !== '') $out[] = $norm;
+    }
+    return $out;
 }
 
 /**
@@ -239,6 +393,16 @@ function zignites_chat_campaign_resolve_segment($segment_type, $segment_meta = [
         // Hard cap to prevent runaway memory on giant stores; campaigns
         // with > 25k recipients are out of scope for this UI.
         if (count($recipients) >= 25000) break;
+    }
+
+    // Optionally skip anyone who already received a bulk message recently,
+    // so back-to-back campaigns don't over-message the same customers.
+    $exclude_days = isset($segment_meta['exclude_recent_days']) ? (int) $segment_meta['exclude_recent_days'] : 0;
+    if ($exclude_days > 0) {
+        $recipients = zignites_chat_campaign_filter_excluded(
+            $recipients,
+            zignites_chat_campaign_recently_messaged_phones($exclude_days)
+        );
     }
 
     return $recipients;

--- a/includes/class-zignites-chat-plugin.php
+++ b/includes/class-zignites-chat-plugin.php
@@ -117,6 +117,9 @@ final class Plugin {
         if (function_exists('zignites_chat_unschedule_cart_recovery_cron')) {
             zignites_chat_unschedule_cart_recovery_cron();
         }
+        if (function_exists('zignites_chat_unschedule_campaign_promoter_cron')) {
+            zignites_chat_unschedule_campaign_promoter_cron();
+        }
         wp_clear_scheduled_hook('zignites_chat_cleanup_analytics');
     }
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -114,6 +114,7 @@ function zignites_chat_get_migrations() {
         1 => 'zignites_chat_migration_v1_secrets_autoload',
         2 => 'zignites_chat_migration_v2_analytics_to_table',
         3 => 'zignites_chat_migration_v3_campaign_tables',
+        4 => 'zignites_chat_migration_v4_campaign_scheduled_at',
     ];
 }
 
@@ -165,6 +166,19 @@ function zignites_chat_migration_v2_analytics_to_table() {
  * creator, so a re-activation rebuilds the tables if WC is added later.
  */
 function zignites_chat_migration_v3_campaign_tables() {
+    if (function_exists('zignites_chat_create_campaign_tables')) {
+        zignites_chat_create_campaign_tables();
+    }
+}
+
+/**
+ * v4: add the campaigns.scheduled_at column for send-at scheduling.
+ *
+ * Re-runs the dbDelta-based table creator, which is idempotent and adds the
+ * new column to existing installs without touching data. Same WC-state guard
+ * shape as v3 — the function is only defined once campaigns.php is loaded.
+ */
+function zignites_chat_migration_v4_campaign_scheduled_at() {
     if (function_exists('zignites_chat_create_campaign_tables')) {
         zignites_chat_create_campaign_tables();
     }

--- a/tests/Unit/CampaignsTest.php
+++ b/tests/Unit/CampaignsTest.php
@@ -43,4 +43,70 @@ final class CampaignsTest extends TestCase
         $this->assertArrayHasKey('all_customers', $types);
         $this->assertArrayHasKey('recent_orders', $types);
     }
+
+    public function test_normalize_datetime(): void
+    {
+        $this->assertSame('2026-06-10 09:30:00', \zignites_chat_normalize_datetime('2026-06-10T09:30'));
+        $this->assertSame('2026-06-10 09:30:00', \zignites_chat_normalize_datetime('2026-06-10 09:30'));
+        $this->assertSame('2026-06-10 09:30:45', \zignites_chat_normalize_datetime('2026-06-10 09:30:45'));
+        $this->assertSame('', \zignites_chat_normalize_datetime(''));
+        $this->assertSame('', \zignites_chat_normalize_datetime('not a date'));
+        $this->assertSame('', \zignites_chat_normalize_datetime('2026-13-40 99:99'));
+    }
+
+    public function test_resolve_schedule_future_is_scheduled(): void
+    {
+        $result = \zignites_chat_campaign_resolve_schedule('2026-06-10T09:30', '2026-06-01 12:00:00');
+        $this->assertSame('scheduled', $result['status']);
+        $this->assertSame('2026-06-10 09:30:00', $result['scheduled_at']);
+    }
+
+    public function test_resolve_schedule_past_or_now_is_queued(): void
+    {
+        $past = \zignites_chat_campaign_resolve_schedule('2026-05-01 09:30', '2026-06-01 12:00:00');
+        $this->assertSame('queued', $past['status']);
+        $this->assertNull($past['scheduled_at']);
+
+        // Exactly now (not strictly future) sends immediately.
+        $now = \zignites_chat_campaign_resolve_schedule('2026-06-01 12:00:00', '2026-06-01 12:00:00');
+        $this->assertSame('queued', $now['status']);
+    }
+
+    public function test_resolve_schedule_blank_is_queued(): void
+    {
+        $result = \zignites_chat_campaign_resolve_schedule('', '2026-06-01 12:00:00');
+        $this->assertSame('queued', $result['status']);
+        $this->assertNull($result['scheduled_at']);
+    }
+
+    public function test_resolve_schedule_invalid_is_queued(): void
+    {
+        $result = \zignites_chat_campaign_resolve_schedule('garbage', '2026-06-01 12:00:00');
+        $this->assertSame('queued', $result['status']);
+        $this->assertNull($result['scheduled_at']);
+    }
+
+    public function test_filter_excluded_removes_matching_phones(): void
+    {
+        $recipients = [
+            ['phone' => '15551110001', 'name' => 'A'],
+            ['phone' => '15551110002', 'name' => 'B'],
+            ['phone' => '15551110003', 'name' => 'C'],
+        ];
+        $out = \zignites_chat_campaign_filter_excluded($recipients, ['15551110002']);
+        $this->assertCount(2, $out);
+        $this->assertSame('15551110001', $out[0]['phone']);
+        $this->assertSame('15551110003', $out[1]['phone']);
+    }
+
+    public function test_filter_excluded_empty_exclusion_returns_all(): void
+    {
+        $recipients = [['phone' => '15551110001', 'name' => 'A']];
+        $this->assertSame($recipients, \zignites_chat_campaign_filter_excluded($recipients, []));
+    }
+
+    public function test_filter_excluded_handles_non_array(): void
+    {
+        $this->assertSame([], \zignites_chat_campaign_filter_excluded('nope', ['1']));
+    }
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -103,6 +103,7 @@ $zignites_chat_cron_hooks = array(
 	'zignites_chat_cleanup_analytics',
 	'zignites_chat_process_cart_recovery_queue',
 	'zignites_chat_process_campaign',
+	'zignites_chat_promote_scheduled_campaigns',
 	'zignites_chat_send_order_message',
 	'zignites_chat_send_followup_message',
 	'zignites_chat_webhook_retry',


### PR DESCRIPTION
Campaigns were send-now only. Add scheduling and an over-messaging guard:

- schema: campaigns.scheduled_at (migration v4, idempotent dbDelta).
- campaign_create() honours a future send time -> status 'scheduled' via the pure resolve_schedule() + a validating normalize_datetime() (rejects impossible dates by round-trip).
- promoter cron (reuses the 5-min schedule) flips due scheduled campaigns to queued and starts their first chunk; unscheduled on deactivate, cleared on uninstall.
- recent-recipient exclusion: skip phones that received a bulk message in the last N days (pure filter_excluded() + analytics lookup), wired into the segment resolver.
- UI: schedule (datetime-local) + skip-recent fields, a Scheduled column in the campaigns list, AJAX handler passes both through.
- fix: campaigns.js guarded on the stale #zignites-chat-tab-content-campaigns wrapper id (removed in the submenu refactor), so the create form's JS never ran — restored the wrapper so the page works.

11 new unit tests; 129 pass, PHPCS green; logic smoke-tested through the loaded code.