### PR TITLE
Media messages: image/document sends + campaign attachments

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -258,8 +258,21 @@ resolver to aggregate per customer:
 - [x] 13 new unit tests; 142 pass, PHPCS green; logic smoke-tested
 - [ ] live smoke test against a store with real orders (user action)
 
-### P2 — Media messages
-Images / PDF (receipts, product images) via provider media endpoints. — ⬜
+### P2 — Media messages — ✅ Code complete (`feat/pro-media-messages`; smoke test pending)
+Send images / documents over WhatsApp by public URL.
+- [x] reusable plumbing: includes/media.php (normalize_media_type,
+      validate_media_url with same-site host allowlist to block SSRF,
+      build_media_descriptor), provider send_media() (Cloud link envelope +
+      Twilio MediaUrl via a shared request()), dispatcher media-first routing
+- [x] consumer: campaign attachment — schema v5 (media_url/media_type),
+      campaign_create stores a validated descriptor, send attaches it with
+      the rendered text as caption (mutually exclusive with the bulk template)
+- [x] UI: WP Media Library picker on the campaign form (wp_enqueue_media),
+      AJAX passes media_url + mime
+- [x] 3 unit tests (type/host helpers); 148 pass, PHPCS green; smoke-tested
+- [ ] live send test of an image + a PDF campaign (user action)
+- Note: manual order-screen attachment + product-image auto-attach reuse the
+  same plumbing — left as later enhancements
 
 ### P2 — Revenue dashboard widget — ✅ Code complete (`feat/pro-revenue-widget`; smoke test pending)
 Surface attributed revenue per channel on Analytics.
@@ -284,6 +297,5 @@ context for the chatbot. — ⬜
 ---
 
 ## Next Action
-Merge `feat/pro-revenue-widget` into `pro`. Remaining: **two-way team
-inbox** (P1, the big one), **media messages** (P2), **GPT modernization**
-(P3).
+Merge `feat/pro-media-messages` into `pro`. Remaining: **two-way team
+inbox** (P1, the big one) and **GPT modernization** (P3).

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -188,6 +188,7 @@ function zignites_chat_enqueue_admin_scripts($hook) {
 
     // Campaigns page.
     if (strpos($hook, 'zignites-chat-campaigns') !== false) {
+        wp_enqueue_media(); // WP media library frame for the campaign attachment picker.
         wp_enqueue_script('zignites-chat-campaigns-js', ZIGNITES_CHAT_URL . 'assets/js/campaigns.js', [], ZIGNITES_CHAT_VERSION, true);
         wp_localize_script('zignites-chat-campaigns-js', 'zignitesChatCampaigns', [
             'ajaxUrl' => admin_url('admin-ajax.php'),
@@ -824,12 +825,17 @@ function zignites_chat_ajax_create_campaign() {
         $segment_meta['exclude_recent_days'] = $exclude_days;
     }
 
+    $media_url  = isset($_POST['media_url']) ? esc_url_raw(wp_unslash($_POST['media_url'])) : '';
+    $media_mime = isset($_POST['media_mime']) ? sanitize_text_field(wp_unslash($_POST['media_mime'])) : '';
+
     $result = zignites_chat_campaign_create([
         'name'         => $name,
         'template'     => $template,
         'segment_type' => $segment_type,
         'segment_meta' => $segment_meta,
         'scheduled_at' => $scheduled_at,
+        'media_url'    => $media_url,
+        'media_mime'   => $media_mime,
     ]);
 
     if (is_wp_error($result)) {

--- a/admin/views/tab-campaigns.php
+++ b/admin/views/tab-campaigns.php
@@ -97,6 +97,17 @@ $zignites_chat_wc_countries = (function_exists('WC') && WC()->countries) ? WC()-
                 </td>
             </tr>
             <tr>
+                <th scope="row"><?php esc_html_e('Attachment', 'zignites-chat'); ?></th>
+                <td>
+                    <input type="hidden" id="zignites-chat-campaign-media-url" value="" />
+                    <input type="hidden" id="zignites-chat-campaign-media-mime" value="" />
+                    <button type="button" class="button" id="zignites-chat-campaign-media-select"><?php esc_html_e('Select image or document', 'zignites-chat'); ?></button>
+                    <button type="button" class="button-link" id="zignites-chat-campaign-media-remove" style="display:none; margin-left:8px;"><?php esc_html_e('Remove', 'zignites-chat'); ?></button>
+                    <span id="zignites-chat-campaign-media-name" style="margin-left:8px; color:#555;"></span>
+                    <p class="description"><?php esc_html_e('Optional. Sends the message as an image/document with your text as the caption. The file must be in this site\'s Media Library.', 'zignites-chat'); ?></p>
+                </td>
+            </tr>
+            <tr>
                 <th scope="row"><label for="zignites-chat-campaign-schedule"><?php esc_html_e('Schedule send', 'zignites-chat'); ?></label></th>
                 <td>
                     <input type="datetime-local" id="zignites-chat-campaign-schedule" />

--- a/assets/js/campaigns.js
+++ b/assets/js/campaigns.js
@@ -14,8 +14,37 @@
         var daysEl    = document.getElementById('zignites-chat-campaign-days');
         var scheduleEl = document.getElementById('zignites-chat-campaign-schedule');
         var excludeEl  = document.getElementById('zignites-chat-campaign-exclude-days');
+        var mediaUrlEl  = document.getElementById('zignites-chat-campaign-media-url');
+        var mediaMimeEl = document.getElementById('zignites-chat-campaign-media-mime');
+        var mediaNameEl = document.getElementById('zignites-chat-campaign-media-name');
+        var mediaSelect = document.getElementById('zignites-chat-campaign-media-select');
+        var mediaRemove = document.getElementById('zignites-chat-campaign-media-remove');
         var submit    = document.getElementById('zignites-chat-campaign-submit');
         var feedback  = document.getElementById('zignites-chat-campaign-feedback');
+
+        // WP Media Library picker for the optional campaign attachment.
+        var mediaFrame = null;
+        function setMedia(url, mime, name) {
+            if (mediaUrlEl) mediaUrlEl.value = url || '';
+            if (mediaMimeEl) mediaMimeEl.value = mime || '';
+            if (mediaNameEl) mediaNameEl.textContent = name || '';
+            if (mediaRemove) mediaRemove.style.display = url ? 'inline' : 'none';
+        }
+        if (mediaSelect && window.wp && wp.media) {
+            mediaSelect.addEventListener('click', function () {
+                if (!mediaFrame) {
+                    mediaFrame = wp.media({ title: mediaSelect.textContent, multiple: false });
+                    mediaFrame.on('select', function () {
+                        var a = mediaFrame.state().get('selection').first().toJSON();
+                        setMedia(a.url, a.mime, a.filename || a.title || '');
+                    });
+                }
+                mediaFrame.open();
+            });
+        }
+        if (mediaRemove) {
+            mediaRemove.addEventListener('click', function () { setMedia('', '', ''); });
+        }
 
         function updateSegmentMeta() {
             if (!segmentEl) return;
@@ -101,6 +130,10 @@
             }
             if (excludeEl && excludeEl.value) {
                 body.append('exclude_recent_days', excludeEl.value);
+            }
+            if (mediaUrlEl && mediaUrlEl.value) {
+                body.append('media_url', mediaUrlEl.value);
+                body.append('media_mime', mediaMimeEl ? mediaMimeEl.value : '');
             }
 
             fetch(config.ajaxUrl, {

--- a/includes/campaigns.php
+++ b/includes/campaigns.php
@@ -102,6 +102,8 @@ function zignites_chat_create_campaign_tables() {
         segment_type VARCHAR(40) NOT NULL,
         segment_meta TEXT NULL,
         scheduled_at DATETIME NULL,
+        media_url VARCHAR(500) NULL,
+        media_type VARCHAR(20) NULL,
         status VARCHAR(20) NOT NULL DEFAULT 'queued',
         total_count INT UNSIGNED NOT NULL DEFAULT 0,
         sent_count INT UNSIGNED NOT NULL DEFAULT 0,
@@ -182,6 +184,18 @@ function zignites_chat_campaign_create($args) {
         $data['scheduled_at'] = $schedule['scheduled_at'];
         $format[] = '%s';
     }
+
+    // Optional media attachment (validated against this site's host).
+    $media = function_exists('zignites_chat_build_media_descriptor')
+        ? zignites_chat_build_media_descriptor($args['media_url'] ?? '', $args['media_mime'] ?? '')
+        : null;
+    if (is_array($media)) {
+        $data['media_url']  = $media['url'];
+        $data['media_type'] = $media['type'];
+        $format[] = '%s';
+        $format[] = '%s';
+    }
+
     $wpdb->insert(zignites_chat_campaigns_table_name(), $data, $format);
 
     $campaign_id = (int) $wpdb->insert_id;
@@ -681,14 +695,23 @@ function zignites_chat_campaign_process_chunk($campaign_id) {
 
         $message = zignites_chat_campaign_render_message($campaign['template'], $row['customer_name']);
 
-        $context = zignites_chat_maybe_apply_template('bulk', [
-            '{name}'            => $row['customer_name'],
-            '{site}'            => function_exists('get_bloginfo') ? get_bloginfo('name') : '',
-            '{currency_symbol}' => function_exists('zignites_chat_currency_symbol_text') ? zignites_chat_currency_symbol_text() : '',
-        ], [
-            'type' => 'bulk',
-            'campaign_id' => $campaign_id,
-        ]);
+        $context = ['type' => 'bulk', 'campaign_id' => $campaign_id];
+        if (!empty($campaign['media_url'])) {
+            // Media campaigns send an image/document with the rendered text as
+            // the caption (mutually exclusive with the template path).
+            $context['media'] = [
+                'url'      => (string) $campaign['media_url'],
+                'type'     => (($campaign['media_type'] ?? '') === 'image') ? 'image' : 'document',
+                'caption'  => $message,
+                'filename' => basename((string) wp_parse_url($campaign['media_url'], PHP_URL_PATH)),
+            ];
+        } else {
+            $context = zignites_chat_maybe_apply_template('bulk', [
+                '{name}'            => $row['customer_name'],
+                '{site}'            => function_exists('get_bloginfo') ? get_bloginfo('name') : '',
+                '{currency_symbol}' => function_exists('zignites_chat_currency_symbol_text') ? zignites_chat_currency_symbol_text() : '',
+            ], $context);
+        }
 
         $ok = zignites_chat_send_whatsapp_message($phone, $message, false, $context);
 

--- a/includes/class-zignites-chat-plugin.php
+++ b/includes/class-zignites-chat-plugin.php
@@ -71,6 +71,7 @@ final class Plugin {
         require_once ZIGNITES_CHAT_PATH . 'includes/providers/class-zignites-chat-provider-twilio.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/providers/class-zignites-chat-provider-cloud.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/wa-templates.php';
+        require_once ZIGNITES_CHAT_PATH . 'includes/media.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/messaging.php';
 
         require_once ZIGNITES_CHAT_PATH . 'includes/analytics.php';

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -115,6 +115,7 @@ function zignites_chat_get_migrations() {
         2 => 'zignites_chat_migration_v2_analytics_to_table',
         3 => 'zignites_chat_migration_v3_campaign_tables',
         4 => 'zignites_chat_migration_v4_campaign_scheduled_at',
+        5 => 'zignites_chat_migration_v5_campaign_media',
     ];
 }
 
@@ -179,6 +180,16 @@ function zignites_chat_migration_v3_campaign_tables() {
  * shape as v3 — the function is only defined once campaigns.php is loaded.
  */
 function zignites_chat_migration_v4_campaign_scheduled_at() {
+    if (function_exists('zignites_chat_create_campaign_tables')) {
+        zignites_chat_create_campaign_tables();
+    }
+}
+
+/**
+ * v5: add the campaigns.media_url / media_type columns for image/document
+ * campaign attachments. Idempotent dbDelta re-run, same guard shape as v4.
+ */
+function zignites_chat_migration_v5_campaign_media() {
     if (function_exists('zignites_chat_create_campaign_tables')) {
         zignites_chat_create_campaign_tables();
     }

--- a/includes/media.php
+++ b/includes/media.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Media attachments for outbound WhatsApp messages.
+ *
+ * Both providers can attach a single image or document to a message by
+ * pointing at a publicly fetchable URL (Cloud API `link`, Twilio
+ * `MediaUrl`). To avoid turning the store into an SSRF proxy, only URLs on
+ * the site's own host are accepted — i.e. media uploaded to the WordPress
+ * media library.
+ *
+ * A media descriptor is the shape the dispatcher and providers consume:
+ *   [ 'url' => string, 'type' => 'image'|'document', 'caption' => string,
+ *     'filename' => string ]
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Map a MIME type to the WhatsApp media message type. Pure.
+ *
+ * Images send as 'image'; everything else (PDF, docs, audio…) as 'document'.
+ *
+ * @param string $mime
+ * @return string 'image'|'document'
+ */
+function zignites_chat_normalize_media_type( $mime ) {
+	return ( strpos( (string) $mime, 'image/' ) === 0 ) ? 'image' : 'document';
+}
+
+/**
+ * Whether a media URL is http(s) and its host is in the allowlist. Pure.
+ *
+ * @param string   $url
+ * @param string[] $allowed_hosts
+ * @return bool
+ */
+function zignites_chat_media_url_host_allowed( $url, $allowed_hosts ) {
+	if ( ! is_string( $url ) || $url === '' ) {
+		return false;
+	}
+	$parts = wp_parse_url( $url );
+	if ( ! is_array( $parts ) || empty( $parts['scheme'] ) || empty( $parts['host'] ) ) {
+		return false;
+	}
+	if ( ! in_array( strtolower( $parts['scheme'] ), array( 'http', 'https' ), true ) ) {
+		return false;
+	}
+	$allowed = array_map( 'strtolower', array_filter( (array) $allowed_hosts ) );
+	return in_array( strtolower( $parts['host'] ), $allowed, true );
+}
+
+/**
+ * Validate a media URL: must be http(s) and on this site (providers fetch it
+ * server-side, so only our own uploads are allowed).
+ *
+ * @param string $url
+ * @return string The URL on success, '' otherwise.
+ */
+function zignites_chat_validate_media_url( $url ) {
+	$url = is_string( $url ) ? trim( $url ) : '';
+	if ( $url === '' ) {
+		return '';
+	}
+
+	$allowed = array_filter( array(
+		wp_parse_url( home_url(), PHP_URL_HOST ),
+		wp_parse_url( site_url(), PHP_URL_HOST ),
+	) );
+
+	/**
+	 * Filter the host allowlist for outbound media URLs. Useful for stores
+	 * that serve uploads from a CDN / sister domain.
+	 *
+	 * @param string[] $allowed Default home/site hosts.
+	 * @param string   $url     The URL being validated.
+	 */
+	$allowed = (array) apply_filters( 'zignites_chat_media_allowed_hosts', $allowed, $url );
+
+	return zignites_chat_media_url_host_allowed( $url, $allowed ) ? $url : '';
+}
+
+/**
+ * Build a validated media descriptor for the dispatcher, or null when the
+ * URL is missing or not allowed.
+ *
+ * @param string $url      Public media URL (must be on this site).
+ * @param string $mime     MIME type used to pick image vs document.
+ * @param string $caption  Optional caption / message body.
+ * @param string $filename Optional filename (documents); derived from the URL
+ *                         when blank.
+ * @return array{url:string,type:string,caption:string,filename:string}|null
+ */
+function zignites_chat_build_media_descriptor( $url, $mime = '', $caption = '', $filename = '' ) {
+	$safe = zignites_chat_validate_media_url( $url );
+	if ( $safe === '' ) {
+		return null;
+	}
+
+	$filename = (string) $filename;
+	if ( $filename === '' ) {
+		$path     = (string) wp_parse_url( $safe, PHP_URL_PATH );
+		$filename = $path !== '' ? basename( $path ) : 'attachment';
+	}
+
+	return array(
+		'url'      => $safe,
+		'type'     => zignites_chat_normalize_media_type( $mime ),
+		'caption'  => (string) $caption,
+		'filename' => $filename,
+	);
+}

--- a/includes/messaging.php
+++ b/includes/messaging.php
@@ -160,7 +160,11 @@ function zignites_chat_send_whatsapp_message( $to, $message, $manual = false, $c
     // free-form text. The rendered $message still drives the log/analytics
     // preview above. Falls back to free-form if the provider can't do
     // templates.
-    if ( ! empty( $context['template'] ) && is_array( $context['template'] ) && method_exists( $provider, 'send_template' ) ) {
+    if ( ! empty( $context['media'] ) && is_array( $context['media'] ) && method_exists( $provider, 'send_media' ) ) {
+        // Media (image/document) message — caption carries the text. Takes
+        // precedence over the template/free-form paths.
+        $result = $provider->send_media( $to, $context['media'] );
+    } elseif ( ! empty( $context['template'] ) && is_array( $context['template'] ) && method_exists( $provider, 'send_template' ) ) {
         $tpl    = $context['template'];
         $result = $provider->send_template(
             $to,

--- a/includes/providers/class-zignites-chat-provider-cloud.php
+++ b/includes/providers/class-zignites-chat-provider-cloud.php
@@ -70,6 +70,33 @@ class ZIGNITES_CHAT_Provider_Cloud extends ZIGNITES_CHAT_Provider {
     }
 
     /**
+     * Send an image or document message by public URL.
+     *
+     * @param string $to         Raw destination phone number.
+     * @param array  $descriptor { url, type:'image'|'document', caption, filename }.
+     * @return array{ok:bool, message_id?:string, error?:string}
+     */
+    public function send_media( $to, $descriptor ) {
+        $to_number = preg_replace( '/[^0-9]/', '', (string) $to );
+        $type      = ( ( $descriptor['type'] ?? '' ) === 'image' ) ? 'image' : 'document';
+
+        $media = [ 'link' => (string) ( $descriptor['url'] ?? '' ) ];
+        if ( ! empty( $descriptor['caption'] ) ) {
+            $media['caption'] = (string) $descriptor['caption'];
+        }
+        if ( $type === 'document' && ! empty( $descriptor['filename'] ) ) {
+            $media['filename'] = (string) $descriptor['filename'];
+        }
+
+        return $this->dispatch( [
+            'messaging_product' => 'whatsapp',
+            'to'                => $to_number,
+            'type'              => $type,
+            $type               => $media,
+        ] );
+    }
+
+    /**
      * POST a message envelope to the Cloud API and normalise the response
      * into the uniform { ok, message_id, error } shape. Shared by send()
      * and send_template().

--- a/includes/providers/class-zignites-chat-provider-twilio.php
+++ b/includes/providers/class-zignites-chat-provider-twilio.php
@@ -28,16 +28,47 @@ class ZIGNITES_CHAT_Provider_Twilio extends ZIGNITES_CHAT_Provider {
     }
 
     public function send( $to, $message ) {
-        $sid       = (string) get_option( 'zignites_chat_twilio_sid' );
-        $token     = (string) get_option( 'zignites_chat_twilio_auth_token' );
-        $from      = (string) get_option( 'zignites_chat_twilio_from' );
         $to_number = 'whatsapp:+' . preg_replace( '/[^0-9]/', '', (string) $to );
 
-        $body = [
-            'From' => $from,
+        return $this->request( [
             'To'   => $to_number,
             'Body' => $message,
-        ];
+        ] );
+    }
+
+    /**
+     * Send an image or document message by public URL (Twilio MediaUrl).
+     *
+     * @param string $to         Raw destination phone number.
+     * @param array  $descriptor { url, type, caption, filename }.
+     * @return array{ok:bool, message_id?:string, error?:string}
+     */
+    public function send_media( $to, $descriptor ) {
+        $to_number = 'whatsapp:+' . preg_replace( '/[^0-9]/', '', (string) $to );
+
+        $body = [ 'To' => $to_number ];
+        if ( ! empty( $descriptor['caption'] ) ) {
+            $body['Body'] = (string) $descriptor['caption'];
+        }
+        $body['MediaUrl'] = (string) ( $descriptor['url'] ?? '' );
+
+        return $this->request( $body );
+    }
+
+    /**
+     * POST a message to the Twilio Messages endpoint and normalise the
+     * response. Fills in From + auth + the delivery StatusCallback. Shared by
+     * send() and send_media().
+     *
+     * @param array $body Partial body (must include To; From is added here).
+     * @return array{ok:bool, message_id?:string, error?:string}
+     */
+    private function request( array $body ) {
+        $sid   = (string) get_option( 'zignites_chat_twilio_sid' );
+        $token = (string) get_option( 'zignites_chat_twilio_auth_token' );
+        $from  = (string) get_option( 'zignites_chat_twilio_from' );
+
+        $body['From'] = $from;
 
         // Ask Twilio to POST delivery/read receipts back so the analytics
         // funnel can advance past "sent". Harmless if the receipt endpoint

--- a/tests/Unit/MediaTest.php
+++ b/tests/Unit/MediaTest.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace ZignitesChat\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class MediaTest extends TestCase
+{
+    public function test_normalize_media_type(): void
+    {
+        $this->assertSame('image', \zignites_chat_normalize_media_type('image/png'));
+        $this->assertSame('image', \zignites_chat_normalize_media_type('image/jpeg'));
+        $this->assertSame('document', \zignites_chat_normalize_media_type('application/pdf'));
+        $this->assertSame('document', \zignites_chat_normalize_media_type(''));
+        $this->assertSame('document', \zignites_chat_normalize_media_type('video/mp4'));
+    }
+
+    public function test_media_url_host_allowed(): void
+    {
+        $allowed = ['shop.example.com'];
+        $this->assertTrue(\zignites_chat_media_url_host_allowed('https://shop.example.com/wp-content/uploads/a.jpg', $allowed));
+        $this->assertTrue(\zignites_chat_media_url_host_allowed('http://shop.example.com/x.pdf', $allowed));
+        // Case-insensitive host match.
+        $this->assertTrue(\zignites_chat_media_url_host_allowed('https://SHOP.example.com/x.png', $allowed));
+    }
+
+    public function test_media_url_host_rejects_foreign_and_bad_schemes(): void
+    {
+        $allowed = ['shop.example.com'];
+        $this->assertFalse(\zignites_chat_media_url_host_allowed('https://evil.test/x.jpg', $allowed));
+        $this->assertFalse(\zignites_chat_media_url_host_allowed('ftp://shop.example.com/x.jpg', $allowed));
+        $this->assertFalse(\zignites_chat_media_url_host_allowed('javascript:alert(1)', $allowed));
+        $this->assertFalse(\zignites_chat_media_url_host_allowed('', $allowed));
+        $this->assertFalse(\zignites_chat_media_url_host_allowed('https://shop.example.com/x.jpg', []));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -128,6 +128,7 @@ if (!function_exists('zignites_chat_is_pro_active')) {
 
 require_once __DIR__ . '/../includes/helpers.php';
 require_once __DIR__ . '/../includes/wa-templates.php';
+require_once __DIR__ . '/../includes/media.php';
 require_once __DIR__ . '/../includes/cart-recovery.php';
 require_once __DIR__ . '/../includes/campaigns.php';
 require_once __DIR__ . '/../includes/blocks.php';


### PR DESCRIPTION
Add reusable media plumbing and surface it as campaign attachments.

Plumbing:
- includes/media.php: normalize_media_type() (image vs document), validate_media_url() restricted to this site's host (providers fetch the URL server-side, so a same-site allowlist blocks SSRF/abuse), and build_media_descriptor().
- provider send_media(): Cloud link envelope (image/document with caption + filename); Twilio MediaUrl via a new shared request() (also used by send(), keeping the StatusCallback wiring in one place).
- dispatcher routes to send_media() first when context.media is set, else template, else free-form text.

Campaign consumer:
- schema v5 adds media_url/media_type (idempotent dbDelta migration).
- campaign_create stores a validated descriptor; the sender attaches it with the rendered message as the caption (mutually exclusive with the bulk template path).
- WP Media Library picker on the campaign form (wp_enqueue_media); AJAX passes media_url + mime.

3 unit tests (type/host helpers); 148 pass, PHPCS green; wiring smoke-tested.