### PR TITLE
Central outbound rate limiter shared by bulk channels

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -366,24 +366,34 @@ context for the chatbot.
 
 ### Quality backlog (fold into the above as touched)
 - [ ] Retire legacy `license-manager.php` once Freemius migration completes
-- [ ] Central outbound rate limiter/queue shared by cart/scheduler/campaigns
+      (blocked: needs real Freemius credentials — user action)
+- [x] Central outbound rate limiter shared by cart/scheduler/campaigns —
+      done on `feat/pro-outbound-rate-limiter`. `includes/rate-limiter.php`:
+      pure fixed-window evaluator (`zignites_chat_rate_window_evaluate`) +
+      option-backed `zignites_chat_outbound_rate_acquire()`. Default 60/min
+      (~1 msg/sec), filterable (`zignites_chat_outbound_rate_per_minute` /
+      `_window` / `_limit_enabled`). **Advisory**: each bulk cron loop
+      (cart-recovery queue, campaign chunk, follow-up handler) consults
+      acquire() before a send and, when the cap is hit, stops the run / defers
+      the event so remaining rows are picked up next tick — nothing is marked
+      failed by the limiter. State option cleaned on uninstall. 6 unit tests;
+      176 pass, PHPCS green. (Order confirmations are intentionally not gated —
+      transactional, low-volume.)
 
 ---
 
 ## Next Action
-**GPT modernization (P3) — in progress on `feat/pro-gpt-modernization`.**
-Model bump + opt-in catalog context are done with tests; open the PR against
-`pro`, then run the live verification (enable GPT fallback + catalog context,
-ask the bot a product/price question).
+**Central outbound rate limiter — done on `feat/pro-outbound-rate-limiter`.**
+Open the PR against `pro`. The only remaining backlog item is retiring
+`license-manager.php`, which is **blocked** on the Freemius credentials
+migration (user action) — nothing actionable until those are in.
 
-Two-way inbox (P1) is **merged into `pro`** (PR #71); only its live Twilio/Meta
-smoke test remains (user action).
+Pending live verifications (user action): two-way inbox Twilio/Meta smoke test
+(PR #71, merged); GPT catalog context (PR #72, merged); and observing the rate
+limiter defer under a saturated burst.
 
-After P3 the open Pro backlog is the quality backlog only: retire
-`license-manager.php` post-Freemius; central outbound rate limiter shared by
-cart/scheduler/campaigns.
-
-Status snapshot (as of 2026-06-02): P0 + all P1/P2 items above + the two-way
-inbox (P1) are **merged into `pro`**; only live smoke tests remain on those.
-The free build shipped from `master`. Remaining Pro backlog: **GPT
-modernization (P3, in progress)** plus the quality backlog.
+Status snapshot (as of 2026-06-02): P0, all P1/P2, the two-way inbox (P1), and
+GPT modernization (P3) are **merged into `pro`**; the central rate limiter is
+the latest branch awaiting PR. The free build shipped from `master`. The Pro
+feature backlog is now empty apart from the Freemius-blocked license cleanup
+and the outstanding live smoke tests.

--- a/includes/campaigns.php
+++ b/includes/campaigns.php
@@ -693,6 +693,13 @@ function zignites_chat_campaign_process_chunk($campaign_id) {
             continue;
         }
 
+        // Central outbound budget: stop this chunk when the shared per-minute
+        // cap is hit. Remaining recipients stay 'pending', so the reschedule
+        // below fires another chunk on the next tick — nothing is marked failed.
+        if (function_exists('zignites_chat_outbound_rate_acquire') && !zignites_chat_outbound_rate_acquire()) {
+            break;
+        }
+
         $message = zignites_chat_campaign_render_message($campaign['template'], $row['customer_name']);
 
         $context = ['type' => 'bulk', 'campaign_id' => $campaign_id];

--- a/includes/cart-recovery.php
+++ b/includes/cart-recovery.php
@@ -338,6 +338,13 @@ function zignites_chat_process_cart_recovery_queue() {
             continue;
         }
 
+        // Central outbound budget: stop this run when the shared per-minute cap
+        // is hit. The row stays pending/retry (next_send_at unchanged) and is
+        // picked up on the next cron tick — never marked failed by the limiter.
+        if (function_exists('zignites_chat_outbound_rate_acquire') && !zignites_chat_outbound_rate_acquire()) {
+            break;
+        }
+
         $result = zignites_chat_send_cart_recovery_whatsapp($phone, $cart_items, $row->consent, $row->consent_time, ['event_id' => $row->event_id]);
 
         if ($result === true) {

--- a/includes/class-zignites-chat-plugin.php
+++ b/includes/class-zignites-chat-plugin.php
@@ -72,6 +72,7 @@ final class Plugin {
         require_once ZIGNITES_CHAT_PATH . 'includes/providers/class-zignites-chat-provider-cloud.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/wa-templates.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/media.php';
+        require_once ZIGNITES_CHAT_PATH . 'includes/rate-limiter.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/messaging.php';
 
         require_once ZIGNITES_CHAT_PATH . 'includes/analytics.php';

--- a/includes/rate-limiter.php
+++ b/includes/rate-limiter.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Central outbound rate limiter.
+ *
+ * The bulk send channels (cart recovery, follow-up scheduler, bulk campaigns)
+ * each run on their own cron and previously throttled independently, so a
+ * concurrent burst across all three could still exceed the provider's
+ * per-second WhatsApp throughput and hurt the sender number's quality rating.
+ *
+ * This module provides a single shared budget those channels consult before
+ * each send. It is advisory: when the budget is exhausted the caller stops its
+ * current run and resumes on the next cron tick — no message is ever marked
+ * failed because of the limiter.
+ *
+ * The window evaluator is pure (and unit-tested); acquire() wraps it with an
+ * option-backed counter.
+ *
+ * @package Zignites_Chat
+ */
+
+if (!defined('ABSPATH')) exit;
+
+/**
+ * Maximum outbound sends allowed per window across all bulk channels.
+ *
+ * Default 60/minute (~1 msg/sec — Twilio's default WhatsApp throughput and a
+ * safe Meta Cloud rate). Filterable so high-tier numbers can raise it and
+ * new/low-rated numbers can lower it.
+ *
+ * @return int
+ */
+function zignites_chat_outbound_rate_max() {
+    return max(1, (int) apply_filters('zignites_chat_outbound_rate_per_minute', 60));
+}
+
+/**
+ * Length of the rate window in seconds (default 60).
+ *
+ * @return int
+ */
+function zignites_chat_outbound_rate_window() {
+    return max(1, (int) apply_filters('zignites_chat_outbound_rate_window', MINUTE_IN_SECONDS));
+}
+
+/**
+ * Pure fixed-window evaluator.
+ *
+ * Given the current counter state, decides whether one more send is allowed
+ * and returns the next state. A window resets once $window seconds have passed
+ * since it started; within a live window, sends are allowed until $max is hit.
+ *
+ * @param array $state  ['count' => int, 'start' => int unix-ts] (may be empty).
+ * @param int   $now    Current unix timestamp.
+ * @param int   $max    Max sends per window.
+ * @param int   $window Window length in seconds.
+ * @return array{allowed: bool, state: array{count:int, start:int}}
+ */
+function zignites_chat_rate_window_evaluate($state, $now, $max, $window) {
+    $count = (is_array($state) && isset($state['count'])) ? (int) $state['count'] : 0;
+    $start = (is_array($state) && isset($state['start'])) ? (int) $state['start'] : 0;
+    $now   = (int) $now;
+    $max   = max(1, (int) $max);
+    $window = max(1, (int) $window);
+
+    // Fresh or expired window → start a new one and allow.
+    if ($start <= 0 || ($now - $start) >= $window) {
+        return ['allowed' => true, 'state' => ['count' => 1, 'start' => $now]];
+    }
+
+    // Live window with budget left.
+    if ($count < $max) {
+        return ['allowed' => true, 'state' => ['count' => $count + 1, 'start' => $start]];
+    }
+
+    // Budget exhausted — deny, state unchanged.
+    return ['allowed' => false, 'state' => ['count' => $count, 'start' => $start]];
+}
+
+/**
+ * Try to consume one unit of the shared outbound budget.
+ *
+ * Callers (the bulk cron loops) check this immediately before each send; when
+ * it returns false they should stop the current run and let the next cron tick
+ * resume. Returns true when sending is allowed.
+ *
+ * @return bool
+ */
+function zignites_chat_outbound_rate_acquire() {
+    /** @var bool $enabled Filter to false to disable the limiter entirely. */
+    if (!apply_filters('zignites_chat_outbound_rate_limit_enabled', true)) {
+        return true;
+    }
+
+    $state = get_option('zignites_chat_outbound_rate_state', []);
+    if (!is_array($state)) {
+        $state = [];
+    }
+
+    $eval = zignites_chat_rate_window_evaluate(
+        $state,
+        time(),
+        zignites_chat_outbound_rate_max(),
+        zignites_chat_outbound_rate_window()
+    );
+
+    // Only write when the state actually changed (a denial leaves it as-is).
+    if ($eval['state'] !== $state) {
+        update_option('zignites_chat_outbound_rate_state', $eval['state'], false);
+    }
+
+    return $eval['allowed'];
+}

--- a/includes/scheduler.php
+++ b/includes/scheduler.php
@@ -44,6 +44,16 @@ function zignites_chat_send_followup_message_handler($order_id) {
     // burns attempts on the same `false` return.
     if (zignites_chat_is_opted_out($to)) return;
 
+    // Central outbound budget: if the shared per-minute cap is hit, defer this
+    // follow-up by re-scheduling shortly. This is a deferral, not a failure —
+    // attempts are NOT incremented — so a saturated window can't burn the
+    // 3-attempt cap. Done before the (possibly paid) GPT call below.
+    if (function_exists('zignites_chat_outbound_rate_acquire') && !zignites_chat_outbound_rate_acquire()) {
+        $defer = max(1, (int) apply_filters('zignites_chat_outbound_rate_defer_seconds', MINUTE_IN_SECONDS));
+        wp_schedule_single_event(time() + $defer, 'zignites_chat_send_followup_message', [$order_id]);
+        return;
+    }
+
     $picked  = zignites_chat_ab_get_template('followup', $order_id);
     $message = zignites_chat_build_followup_message($order, $picked['template']);
 

--- a/tests/Unit/RateLimiterTest.php
+++ b/tests/Unit/RateLimiterTest.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace ZignitesChat\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class RateLimiterTest extends TestCase
+{
+    public function test_fresh_state_starts_a_window_and_allows(): void
+    {
+        $r = \zignites_chat_rate_window_evaluate([], 1000, 60, 60);
+        $this->assertTrue($r['allowed']);
+        $this->assertSame(['count' => 1, 'start' => 1000], $r['state']);
+    }
+
+    public function test_allows_until_max_within_window(): void
+    {
+        // 59 already used in a window that started at t=1000, now t=1010.
+        $r = \zignites_chat_rate_window_evaluate(['count' => 59, 'start' => 1000], 1010, 60, 60);
+        $this->assertTrue($r['allowed']);
+        $this->assertSame(['count' => 60, 'start' => 1000], $r['state']);
+    }
+
+    public function test_denies_when_max_reached_and_leaves_state_unchanged(): void
+    {
+        $state = ['count' => 60, 'start' => 1000];
+        $r = \zignites_chat_rate_window_evaluate($state, 1010, 60, 60);
+        $this->assertFalse($r['allowed']);
+        $this->assertSame($state, $r['state']);
+    }
+
+    public function test_window_resets_after_it_elapses(): void
+    {
+        // Saturated window from t=1000; now t=1060 (>= 60s later) → reset.
+        $r = \zignites_chat_rate_window_evaluate(['count' => 60, 'start' => 1000], 1060, 60, 60);
+        $this->assertTrue($r['allowed']);
+        $this->assertSame(['count' => 1, 'start' => 1060], $r['state']);
+    }
+
+    public function test_boundary_just_before_reset_still_denies(): void
+    {
+        // 1s before the window elapses, still saturated → deny.
+        $r = \zignites_chat_rate_window_evaluate(['count' => 60, 'start' => 1000], 1059, 60, 60);
+        $this->assertFalse($r['allowed']);
+    }
+
+    public function test_max_is_floored_to_one(): void
+    {
+        // A nonsensical max of 0 must not deny the very first send.
+        $r = \zignites_chat_rate_window_evaluate([], 1000, 0, 60);
+        $this->assertTrue($r['allowed']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -144,6 +144,7 @@ require_once __DIR__ . '/../includes/campaigns.php';
 require_once __DIR__ . '/../includes/inbox.php';
 require_once __DIR__ . '/../includes/inbox-capture.php';
 require_once __DIR__ . '/../includes/catalog-context.php';
+require_once __DIR__ . '/../includes/rate-limiter.php';
 require_once __DIR__ . '/../includes/blocks.php';
 require_once __DIR__ . '/../includes/analytics.php';
 require_once __DIR__ . '/../includes/delivery-receipts.php';

--- a/uninstall.php
+++ b/uninstall.php
@@ -77,6 +77,7 @@ $zignites_chat_option_keys = [
     'zignites_chat_followup_ab_enabled',
     'zignites_chat_webhooks',
     'zignites_chat_webhook_log',
+    'zignites_chat_outbound_rate_state',
 ];
 
 foreach ($zignites_chat_option_keys as $zignites_chat_key) {


### PR DESCRIPTION
The cart-recovery queue, follow-up scheduler, and bulk campaigns each throttled independently, so a concurrent burst across all three could exceed the provider's per-second WhatsApp throughput and hurt the sender number's quality rating. This adds one shared budget they consult.

- includes/rate-limiter.php: a pure fixed-window evaluator (zignites_chat_rate_window_evaluate) plus an option-backed zignites_chat_outbound_rate_acquire(). Default 60/min (~1 msg/sec), filterable via zignites_chat_outbound_rate_per_minute / _window / _limit_enabled.
- Advisory enforcement: each bulk cron loop calls acquire() before a send and, when the cap is hit, stops the current run (cart/campaign) or defers the event (follow-up, no attempt increment) so remaining work is picked up next tick. No message is ever marked failed by the limiter.
- Order confirmations are intentionally not gated — transactional and low-volume. State option cleaned on uninstall.

6 unit tests; full suite 176 pass, PHPCS + lint clean.