### PR TITLE
COD confirmation C2: inbound reply → order status transition

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -410,10 +410,16 @@ Planned increments:
       rendered text as fallback. Pure tested helpers: `is_cod_gateway`,
       `classify_reply` (whole-word, cancel-wins-ties), `sanitize_gateways`.
       Settings cleaned on uninstall. 6 unit tests; 182 pass, PHPCS green.
-- [ ] C2 — Inbound matching + status transition: map an inbound reply/button
-      from a phone to its most-recent pending COD order, classify
-      confirm/cancel, transition the order, add an order note, clear pending,
-      optionally send an acknowledgement. Reuse the inbox capture hook.
+- [x] C2 — Inbound matching + status transition: inbox capture now fires a
+      decoupled `zignites_chat_inbound_message` action per newly-recorded
+      inbound; `zignites_chat_cod_handle_inbound_reply` subscribes, matches the
+      sender to a pending COD order (`find_pending_order_by_phone` + pure
+      `cod_phone_matches`, suffix-tolerant for country-code differences),
+      classifies the reply, transitions the order to the configured
+      confirm/cancel status with an order note, sets
+      `_zignites_chat_cod_status = confirmed|cancelled`, and sends a filterable
+      ack in the now-open 24h window. 3 new unit tests (phone matching);
+      185 pass, PHPCS green.
 - [ ] C3 — Admin surface: COD-confirmation column/badge on the orders screen +
       a settings tab; analytics counters (sent / confirmed / cancelled / RTO-
       saved). Uninstall cleanup.
@@ -456,16 +462,12 @@ Build on the merged two-way inbox (P1):
 ---
 
 ## Next Action
-**COD order confirmation (T1.1) — C1 done on `feat/pro-cod-confirmation`.**
-Next: **C2 (inbound matching + status transition)** — when an inbound
-reply/button arrives (hook the existing inbox capture / opt-out webhook), find
-the sender's most-recent order with `_zignites_chat_cod_status = pending`,
-classify the reply via `zignites_chat_cod_classify_reply()`, transition the
-order to the configured on-confirm / on-cancel status, add an order note, set
-`_zignites_chat_cod_status = confirmed|cancelled`, and optionally send an ack.
-Then C3 (orders-screen column/badge + analytics counters). After T1.1: T1.2
-(status/tracking), T1.3 (opt-in capture), then Tiers 2–3 and the quick wins —
-see PHASE 9 above.
+**COD order confirmation (T1.1) — C1 + C2 done on `feat/pro-cod-confirmation-c2`.**
+Next: **C3 (admin surface)** — a COD-confirmation column/badge on the
+WooCommerce orders screen (pending / confirmed / cancelled / send-failed), and
+simple counters (sent / confirmed / cancelled, i.e. RTO saved). Then T1.2
+(status/tracking notifications), T1.3 (opt-in capture), then Tiers 2–3 and the
+quick wins — see PHASE 9 above.
 
 The original Pro backlog is otherwise cleared into `pro`; the only blocked item
 is retiring `license-manager.php` (needs the Freemius credentials migration —

--- a/admin/views/tab-cod.php
+++ b/admin/views/tab-cod.php
@@ -107,7 +107,7 @@ $zignites_chat_cod_statuses = function_exists('wc_get_order_statuses') ? wc_get_
             <?php else : ?>
                 <input type="text" name="zignites_chat_cod_on_cancel_status" value="<?php echo esc_attr($zignites_chat_cod_on_cancel); ?>" class="regular-text" />
             <?php endif; ?>
-            <p class="description"><?php esc_html_e('Order status applied when the customer confirms or cancels. Reply matching + status transitions ship in the next update.', 'zignites-chat'); ?></p>
+            <p class="description"><?php esc_html_e('Order status applied automatically when the customer replies CONFIRM or CANCEL on WhatsApp.', 'zignites-chat'); ?></p>
         </td>
     </tr>
 </table>

--- a/includes/cod-confirmation.php
+++ b/includes/cod-confirmation.php
@@ -158,6 +158,141 @@ function zignites_chat_cod_classify_reply($text, $confirm_keywords, $cancel_keyw
     return '';
 }
 
+/**
+ * Whether two phone numbers refer to the same person.
+ *
+ * Compares normalized (digits-only) numbers, with a suffix fallback so a
+ * locally-stored billing number ("03001234567") still matches the full
+ * international number WhatsApp delivers ("923001234567"). Pure.
+ *
+ * @param string $a          First phone.
+ * @param string $b          Second phone.
+ * @param int    $min_suffix Digits that must match on the suffix path. Default 9.
+ * @return bool
+ */
+function zignites_chat_cod_phone_matches($a, $b, $min_suffix = 9) {
+    $a = zignites_chat_normalize_phone($a);
+    $b = zignites_chat_normalize_phone($b);
+    if ($a === '' || $b === '') {
+        return false;
+    }
+    if ($a === $b) {
+        return true;
+    }
+    $min_suffix = max(1, (int) $min_suffix);
+    if (strlen($a) < $min_suffix || strlen($b) < $min_suffix) {
+        return false;
+    }
+    return substr($a, -$min_suffix) === substr($b, -$min_suffix);
+}
+
+/* -------------------------------------------------------------------------
+ * Inbound reply → order-status transition (C2)
+ * ----------------------------------------------------------------------- */
+
+add_action('zignites_chat_inbound_message', 'zignites_chat_cod_handle_inbound_reply');
+
+/**
+ * Find the sender's most-recent order awaiting COD confirmation.
+ *
+ * Pulls recent pending-COD orders and matches by phone in PHP (tolerant of
+ * formatting / country-code differences via zignites_chat_cod_phone_matches).
+ *
+ * @param string $phone Inbound sender phone.
+ * @return \WC_Order|null
+ */
+function zignites_chat_cod_find_pending_order_by_phone($phone) {
+    if (!function_exists('wc_get_orders') || zignites_chat_normalize_phone($phone) === '') {
+        return null;
+    }
+    $orders = wc_get_orders([
+        'limit'      => (int) apply_filters('zignites_chat_cod_pending_lookup_limit', 50),
+        'orderby'    => 'date',
+        'order'      => 'DESC',
+        'meta_key'   => '_zignites_chat_cod_status', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+        'meta_value' => 'pending',                   // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+        'return'     => 'objects',
+    ]);
+    if (empty($orders) || !is_array($orders)) {
+        return null;
+    }
+    foreach ($orders as $order) {
+        if (is_object($order) && zignites_chat_cod_phone_matches($phone, $order->get_billing_phone())) {
+            return $order;
+        }
+    }
+    return null;
+}
+
+/**
+ * Process a customer's inbound reply to a COD confirmation.
+ *
+ * Hooked to zignites_chat_inbound_message. Matches the sender to a pending COD
+ * order, classifies the reply as confirm/cancel, transitions the order to the
+ * configured status, records a note, and (optionally) acknowledges. A reply
+ * that matches no keyword leaves the order pending.
+ *
+ * @param array $msg Normalized inbound message (phone, body, …).
+ * @return void
+ */
+function zignites_chat_cod_handle_inbound_reply($msg) {
+    if (!zignites_chat_cod_is_enabled() || !is_array($msg)) {
+        return;
+    }
+    $phone = isset($msg['phone']) ? (string) $msg['phone'] : '';
+    $body  = isset($msg['body']) ? (string) $msg['body'] : '';
+    if ($phone === '' || $body === '') {
+        return;
+    }
+
+    $decision = zignites_chat_cod_classify_reply(
+        $body,
+        get_option('zignites_chat_cod_confirm_keywords', 'confirm,yes,1'),
+        get_option('zignites_chat_cod_cancel_keywords', 'cancel,no,2')
+    );
+    if ($decision === '') {
+        return;
+    }
+
+    $order = zignites_chat_cod_find_pending_order_by_phone($phone);
+    if (!$order) {
+        return;
+    }
+
+    if ($decision === 'confirm') {
+        $status   = sanitize_text_field(get_option('zignites_chat_cod_on_confirm_status', 'processing'));
+        $note     = __('Customer confirmed the COD order via WhatsApp.', 'zignites-chat');
+        $cod_meta = 'confirmed';
+    } else {
+        $status   = sanitize_text_field(get_option('zignites_chat_cod_on_cancel_status', 'cancelled'));
+        $note     = __('Customer cancelled the COD order via WhatsApp.', 'zignites-chat');
+        $cod_meta = 'cancelled';
+    }
+
+    $order->update_meta_data('_zignites_chat_cod_status', $cod_meta);
+    $order->update_meta_data('_zignites_chat_cod_replied_at', current_time('mysql'));
+    // update_status saves the order (including the meta set above).
+    if ($status !== '') {
+        $order->update_status($status, $note);
+    } else {
+        $order->add_order_note($note);
+        $order->save();
+    }
+
+    // Acknowledge in the now-open 24h window (the customer just messaged us, so
+    // a free-form reply is allowed). Filterable text; empty disables the ack.
+    $ack_default = ($decision === 'confirm')
+        ? __('Thanks! Your order is confirmed. 🎉', 'zignites-chat')
+        : __('Your order has been cancelled. Let us know if that was a mistake.', 'zignites-chat');
+    $ack = (string) apply_filters('zignites_chat_cod_ack_message', $ack_default, $decision, $order);
+    if ($ack !== '') {
+        zignites_chat_send_whatsapp_message($order->get_billing_phone(), $ack, false, [
+            'type'     => 'cod',
+            'order_id' => $order->get_id(),
+        ]);
+    }
+}
+
 /* -------------------------------------------------------------------------
  * Send on new COD order
  * ----------------------------------------------------------------------- */

--- a/includes/inbox-capture.php
+++ b/includes/inbox-capture.php
@@ -225,6 +225,15 @@ function zignites_chat_inbox_capture_request($request) {
         $result = zignites_chat_inbox_record_message($msg);
         if (!is_wp_error($result)) {
             $recorded++;
+            /**
+             * Fires once per newly-recorded inbound message (deduped on the
+             * provider message id). Consumers like COD confirmation subscribe
+             * to act on a customer's reply.
+             *
+             * @param array $msg            Normalized inbound message.
+             * @param array $result         ['conversation_id'=>int, 'message_id'=>int].
+             */
+            do_action('zignites_chat_inbound_message', $msg, $result);
         }
     }
     return $recorded;

--- a/tests/Unit/CodConfirmationTest.php
+++ b/tests/Unit/CodConfirmationTest.php
@@ -48,6 +48,28 @@ final class CodConfirmationTest extends TestCase
         $this->assertSame('', \zignites_chat_cod_classify_reply('yesterday', 'yes', 'no'));
     }
 
+    /* ---- phone matching ---- */
+
+    public function test_phone_matches_exact_and_formatted(): void
+    {
+        $this->assertTrue(\zignites_chat_cod_phone_matches('+1 (415) 555-0100', '14155550100'));
+        $this->assertTrue(\zignites_chat_cod_phone_matches('14155550100', '14155550100'));
+    }
+
+    public function test_phone_matches_tolerates_country_code_via_suffix(): void
+    {
+        // Local vs full international form, same subscriber number.
+        $this->assertTrue(\zignites_chat_cod_phone_matches('03001234567', '923001234567'));
+    }
+
+    public function test_phone_matches_rejects_different_numbers(): void
+    {
+        $this->assertFalse(\zignites_chat_cod_phone_matches('14155550100', '14155559999'));
+        $this->assertFalse(\zignites_chat_cod_phone_matches('', '14155550100'));
+        // Too short to risk a suffix false-positive.
+        $this->assertFalse(\zignites_chat_cod_phone_matches('123', '999123'));
+    }
+
     /* ---- gateways sanitizer ---- */
 
     public function test_sanitize_gateways_dedupes_and_cleans(): void


### PR DESCRIPTION
Wires the customer's WhatsApp reply back to the order.

- inbox-capture.php now fires a decoupled zignites_chat_inbound_message action for each newly-recorded inbound (deduped on provider message id), so features can react to replies without coupling to the inbox.
- cod-confirmation.php subscribes: matches the sender to a pending COD order (find_pending_order_by_phone), classifies the reply (confirm/cancel), transitions the order to the configured status with an order note, sets _zignites_chat_cod_status = confirmed|cancelled, and sends a filterable acknowledgement (free-form, valid in the now-open 24h window since the customer just messaged).
- Pure, tested zignites_chat_cod_phone_matches() tolerates country-code / formatting differences via a digit-suffix fallback so a locally-stored billing number still matches the international number WhatsApp delivers.

3 new unit tests; full suite 185 pass, PHPCS + lint clean.