### PR TITLE
COD confirmation C3: orders-screen badge + status counts

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -392,7 +392,7 @@ the two-way inbox.
 
 ### Tier 1 — highest leverage
 
-#### T1.1 — COD order confirmation / verification — 🟡 IN PROGRESS on `feat/pro-cod-confirmation`
+#### T1.1 — COD order confirmation / verification — ✅ Complete (C1–C3); live smoke test pending
 The #1 lever in WhatsApp-heavy, cash-on-delivery markets (India, MENA, SEA,
 LATAM): cut fake/abandoned COD orders and return-to-origin (RTO) cost by asking
 the customer to confirm via WhatsApp. Sends an approved template with quick-reply
@@ -420,9 +420,12 @@ Planned increments:
       `_zignites_chat_cod_status = confirmed|cancelled`, and sends a filterable
       ack in the now-open 24h window. 3 new unit tests (phone matching);
       185 pass, PHPCS green.
-- [ ] C3 — Admin surface: COD-confirmation column/badge on the orders screen +
-      a settings tab; analytics counters (sent / confirmed / cancelled / RTO-
-      saved). Uninstall cleanup.
+- [x] C3 — Admin surface: COD badge column on the WooCommerce orders screen
+      (HPOS + legacy hooks; awaiting/confirmed/cancelled/send-failed with
+      coloured pills) + a status-counts stats block on the settings tab
+      (`zignites_chat_cod_status_counts`, cheap paginated COUNT queries, cached
+      5 min, flushed on each status change). Pure `cod_status_label` helper.
+      1 new unit test; 186 pass, PHPCS green.
 - Open question resolved at build: business-initiated confirmation must use an
   approved HSM template with quick-reply buttons (free-form interactive only
   works inside the 24h window), so the buttons live in the Meta-approved
@@ -462,12 +465,15 @@ Build on the merged two-way inbox (P1):
 ---
 
 ## Next Action
-**COD order confirmation (T1.1) — C1 + C2 done on `feat/pro-cod-confirmation-c2`.**
-Next: **C3 (admin surface)** — a COD-confirmation column/badge on the
-WooCommerce orders screen (pending / confirmed / cancelled / send-failed), and
-simple counters (sent / confirmed / cancelled, i.e. RTO saved). Then T1.2
-(status/tracking notifications), T1.3 (opt-in capture), then Tiers 2–3 and the
-quick wins — see PHASE 9 above.
+**COD order confirmation (T1.1) — COMPLETE (C1–C3) on
+`feat/pro-cod-confirmation-c3`.** Only a live smoke test remains (place a COD
+order against a real WABA with an approved buttoned template; reply
+Confirm/Cancel; confirm the order status flips and the badge updates).
+
+Next feature: **T1.2 — Order-status + shipping/tracking notifications** (notify
+on shipped / out-for-delivery / on-hold / refunded / cancelled with per-status
+templates + an injected tracking link). Then T1.3 (opt-in capture), Tier 2
+(inbox→helpdesk), Tier 3 (automation), and the quick wins — see PHASE 9.
 
 The original Pro backlog is otherwise cleared into `pro`; the only blocked item
 is retiring `license-manager.php` (needs the Freemius credentials migration —

--- a/admin/views/tab-cod.php
+++ b/admin/views/tab-cod.php
@@ -28,6 +28,26 @@ $zignites_chat_cod_statuses = function_exists('wc_get_order_statuses') ? wc_get_
     <?php esc_html_e('Automatically ask customers to confirm a new cash-on-delivery order over WhatsApp. The confirmation goes out as your approved WhatsApp template (map it under WhatsApp Templates → COD order confirmation, ideally with Confirm / Cancel quick-reply buttons). The customer’s reply updates the order status.', 'zignites-chat'); ?>
 </p>
 
+<?php $zignites_chat_cod_counts = zignites_chat_cod_status_counts(); ?>
+<div class="zignites-chat-cod-stats" style="display:flex; gap:16px; margin:16px 0;">
+    <div style="background:#fcf9e8; padding:12px 18px; border-radius:6px; min-width:120px;">
+        <strong style="font-size:20px; display:block;"><?php echo esc_html(number_format_i18n($zignites_chat_cod_counts['pending'])); ?></strong>
+        <span class="description"><?php esc_html_e('Awaiting reply', 'zignites-chat'); ?></span>
+    </div>
+    <div style="background:#edfaef; padding:12px 18px; border-radius:6px; min-width:120px;">
+        <strong style="font-size:20px; display:block;"><?php echo esc_html(number_format_i18n($zignites_chat_cod_counts['confirmed'])); ?></strong>
+        <span class="description"><?php esc_html_e('Confirmed', 'zignites-chat'); ?></span>
+    </div>
+    <div style="background:#fcf0f1; padding:12px 18px; border-radius:6px; min-width:120px;">
+        <strong style="font-size:20px; display:block;"><?php echo esc_html(number_format_i18n($zignites_chat_cod_counts['cancelled'])); ?></strong>
+        <span class="description"><?php esc_html_e('Cancelled (RTO saved)', 'zignites-chat'); ?></span>
+    </div>
+    <div style="background:#f0f0f1; padding:12px 18px; border-radius:6px; min-width:120px;">
+        <strong style="font-size:20px; display:block;"><?php echo esc_html(number_format_i18n($zignites_chat_cod_counts['send_failed'])); ?></strong>
+        <span class="description"><?php esc_html_e('Send failed', 'zignites-chat'); ?></span>
+    </div>
+</div>
+
 <table class="form-table">
     <tr>
         <th scope="row"><label for="zignites_chat_cod_enabled"><?php esc_html_e('Enable COD confirmation', 'zignites-chat'); ?></label></th>

--- a/includes/cod-confirmation.php
+++ b/includes/cod-confirmation.php
@@ -187,6 +187,144 @@ function zignites_chat_cod_phone_matches($a, $b, $min_suffix = 9) {
 }
 
 /* -------------------------------------------------------------------------
+ * Admin surface (C3): orders-screen column + status counts
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Human label for a stored COD status. Pure.
+ *
+ * @param string $status One of pending|confirmed|cancelled|send_failed.
+ * @return string Translated label, or '' for an unknown/empty status.
+ */
+function zignites_chat_cod_status_label($status) {
+    switch ((string) $status) {
+        case 'pending':
+            return __('Awaiting reply', 'zignites-chat');
+        case 'confirmed':
+            return __('Confirmed', 'zignites-chat');
+        case 'cancelled':
+            return __('Cancelled', 'zignites-chat');
+        case 'send_failed':
+            return __('Send failed', 'zignites-chat');
+        default:
+            return '';
+    }
+}
+
+/**
+ * Count COD orders by confirmation status (cached 5 min).
+ *
+ * Uses paginated wc_get_orders so each value is a cheap COUNT query, HPOS-safe.
+ *
+ * @return array{pending:int, confirmed:int, cancelled:int, send_failed:int}
+ */
+function zignites_chat_cod_status_counts() {
+    $cached = get_transient('zignites_chat_cod_counts');
+    if (is_array($cached)) {
+        return $cached;
+    }
+    $counts = ['pending' => 0, 'confirmed' => 0, 'cancelled' => 0, 'send_failed' => 0];
+    if (function_exists('wc_get_orders')) {
+        foreach (array_keys($counts) as $status) {
+            $res = wc_get_orders([
+                'limit'      => 1,
+                'paginate'   => true,
+                'return'     => 'ids',
+                'meta_key'   => '_zignites_chat_cod_status', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+                'meta_value' => $status,                     // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+            ]);
+            $counts[$status] = is_object($res) ? (int) $res->total : 0;
+        }
+    }
+    set_transient('zignites_chat_cod_counts', $counts, 5 * MINUTE_IN_SECONDS);
+    return $counts;
+}
+
+/**
+ * Drop the cached counts after a COD status change.
+ */
+function zignites_chat_cod_flush_counts_cache() {
+    delete_transient('zignites_chat_cod_counts');
+}
+
+// Orders-list column — registered for both HPOS and legacy post-based screens.
+add_filter('manage_woocommerce_page_wc-orders_columns', 'zignites_chat_cod_add_order_column');
+add_filter('manage_edit-shop_order_columns', 'zignites_chat_cod_add_order_column');
+add_action('manage_woocommerce_page_wc-orders_custom_column', 'zignites_chat_cod_render_order_column', 10, 2);
+add_action('manage_shop_order_posts_custom_column', 'zignites_chat_cod_render_order_column', 10, 2);
+add_action('admin_head', 'zignites_chat_cod_admin_column_styles');
+
+/**
+ * Insert the COD column after the order-status column.
+ *
+ * @param array $columns
+ * @return array
+ */
+function zignites_chat_cod_add_order_column($columns) {
+    if (!is_array($columns)) {
+        return $columns;
+    }
+    $out = [];
+    foreach ($columns as $key => $label) {
+        $out[$key] = $label;
+        if ($key === 'order_status') {
+            $out['zignites_chat_cod'] = __('COD', 'zignites-chat');
+        }
+    }
+    if (!isset($out['zignites_chat_cod'])) {
+        $out['zignites_chat_cod'] = __('COD', 'zignites-chat');
+    }
+    return $out;
+}
+
+/**
+ * Render the COD badge cell. Works for both HPOS (passes a WC_Order) and
+ * legacy (passes a post id) custom-column hooks.
+ *
+ * @param string         $column
+ * @param int|\WC_Order  $order_or_id
+ * @return void
+ */
+function zignites_chat_cod_render_order_column($column, $order_or_id) {
+    if ($column !== 'zignites_chat_cod') {
+        return;
+    }
+    $order = is_object($order_or_id) ? $order_or_id : (function_exists('wc_get_order') ? wc_get_order($order_or_id) : null);
+    if (!$order) {
+        echo '&mdash;';
+        return;
+    }
+    $status = (string) $order->get_meta('_zignites_chat_cod_status');
+    $label  = zignites_chat_cod_status_label($status);
+    if ($label === '') {
+        echo '&mdash;';
+        return;
+    }
+    printf(
+        '<span class="zignites-chat-cod-badge zignites-chat-cod-%1$s">%2$s</span>',
+        esc_attr($status),
+        esc_html($label)
+    );
+}
+
+/**
+ * Tiny badge styling, printed only on the orders screens.
+ */
+function zignites_chat_cod_admin_column_styles() {
+    $screen = function_exists('get_current_screen') ? get_current_screen() : null;
+    if (!$screen || !in_array($screen->id, ['woocommerce_page_wc-orders', 'edit-shop_order'], true)) {
+        return;
+    }
+    echo '<style>
+        .zignites-chat-cod-badge{display:inline-block;padding:2px 8px;border-radius:10px;font-size:11px;line-height:1.6;white-space:nowrap}
+        .zignites-chat-cod-pending{background:#fcf9e8;color:#8a6d3b}
+        .zignites-chat-cod-confirmed{background:#edfaef;color:#00650c}
+        .zignites-chat-cod-cancelled{background:#fcf0f1;color:#8a1f24}
+        .zignites-chat-cod-send_failed{background:#f0f0f1;color:#646970}
+    </style>';
+}
+
+/* -------------------------------------------------------------------------
  * Inbound reply → order-status transition (C2)
  * ----------------------------------------------------------------------- */
 
@@ -278,6 +416,7 @@ function zignites_chat_cod_handle_inbound_reply($msg) {
         $order->add_order_note($note);
         $order->save();
     }
+    zignites_chat_cod_flush_counts_cache();
 
     // Acknowledge in the now-open 24h window (the customer just messaged us, so
     // a free-form reply is allowed). Filterable text; empty disables the ack.
@@ -375,4 +514,5 @@ function zignites_chat_cod_maybe_send($order_id) {
     $order->update_meta_data('_zignites_chat_cod_status', $sent === true ? 'pending' : 'send_failed');
     $order->update_meta_data('_zignites_chat_cod_sent_at', current_time('mysql'));
     $order->save();
+    zignites_chat_cod_flush_counts_cache();
 }

--- a/tests/Unit/CodConfirmationTest.php
+++ b/tests/Unit/CodConfirmationTest.php
@@ -70,6 +70,18 @@ final class CodConfirmationTest extends TestCase
         $this->assertFalse(\zignites_chat_cod_phone_matches('123', '999123'));
     }
 
+    /* ---- status label ---- */
+
+    public function test_status_label(): void
+    {
+        $this->assertSame('Awaiting reply', \zignites_chat_cod_status_label('pending'));
+        $this->assertSame('Confirmed', \zignites_chat_cod_status_label('confirmed'));
+        $this->assertSame('Cancelled', \zignites_chat_cod_status_label('cancelled'));
+        $this->assertSame('Send failed', \zignites_chat_cod_status_label('send_failed'));
+        $this->assertSame('', \zignites_chat_cod_status_label('whatever'));
+        $this->assertSame('', \zignites_chat_cod_status_label(''));
+    }
+
     /* ---- gateways sanitizer ---- */
 
     public function test_sanitize_gateways_dedupes_and_cleans(): void


### PR DESCRIPTION
Completes the COD order confirmation feature (T1.1) with its admin surface.

- A "COD" column on the WooCommerce orders screen (registered for both HPOS and legacy post-based hooks) showing a coloured badge: awaiting reply / confirmed / cancelled / send failed. Pure zignites_chat_cod_status_label() drives the labels.
- zignites_chat_cod_status_counts(): cheap paginated COUNT queries per status, cached 5 min and flushed whenever a COD status changes.
- A stats block on the COD settings tab (awaiting / confirmed / cancelled = RTO saved / send failed).

1 new unit test; full suite 186 pass, PHPCS + lint clean.