### PR TITLE
Order-status + shipping/tracking notifications (T1.2)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -431,10 +431,26 @@ Planned increments:
   works inside the 24h window), so the buttons live in the Meta-approved
   template; the plugin fills variables + reads the button reply.
 
-#### T1.2 — Order-status + shipping/tracking notifications — ⬜
+#### T1.2 — Order-status + shipping/tracking notifications — ✅ Done on `feat/pro-status-tracking-notifications` (live smoke test pending)
 Notify on every status (shipped, out-for-delivery, on-hold, refunded,
 cancelled), not just processing/completed, with per-status templates and an
 injected tracking link/number (pull from common shipment plugins).
+- [x] `includes/status-notifications.php`: hooks `woocommerce_order_status_changed`,
+      sends a WhatsApp message when an order enters an opted-in status. Master
+      toggle + per-status `{enabled, template}` config; all-off by default so it
+      never overlaps the classic confirmation until enabled.
+- [x] Tracking injection from `_wc_shipment_tracking_items` (WooCommerce
+      Shipment Tracking + Advanced Shipment Tracking), exposed as
+      `{tracking_number}`/`{tracking_url}`/`{carrier}`; filterable via
+      `zignites_chat_order_tracking`.
+- [x] Pure, tested helpers: `status_normalize`, `should_notify`,
+      `extract_tracking`, `status_render`, `sanitize_notifications`.
+- [x] Pro "Status Notifications" submenu/tab: master toggle + a per-status
+      table (checkbox + template) over every eligible WC status; upsell card;
+      settings cleaned on uninstall.
+- [x] 6 unit tests; 192 pass, PHPCS + lint green.
+- [ ] Live smoke test: move an order to a tracked status, confirm the WhatsApp
+      lands with the tracking link (user action).
 
 #### T1.3 — WhatsApp opt-in capture — ⬜
 Proactive consent: checkout checkbox / widget + a consent log, complementing
@@ -465,14 +481,12 @@ Build on the merged two-way inbox (P1):
 ---
 
 ## Next Action
-**COD order confirmation (T1.1) — COMPLETE (C1–C3) on
-`feat/pro-cod-confirmation-c3`.** Only a live smoke test remains (place a COD
-order against a real WABA with an approved buttoned template; reply
-Confirm/Cancel; confirm the order status flips and the badge updates).
+**T1.2 — Order-status + tracking notifications — DONE on
+`feat/pro-status-tracking-notifications`** (live smoke test pending). T1.1 (COD)
+is also complete and merged.
 
-Next feature: **T1.2 — Order-status + shipping/tracking notifications** (notify
-on shipped / out-for-delivery / on-hold / refunded / cancelled with per-status
-templates + an injected tracking link). Then T1.3 (opt-in capture), Tier 2
+Next feature: **T1.3 — WhatsApp opt-in capture** (checkout checkbox / widget +
+a consent log, complementing the existing opt-out pipeline). Then Tier 2
 (inbox→helpdesk), Tier 3 (automation), and the quick wins — see PHASE 9.
 
 The original Pro backlog is otherwise cleared into `pro`; the only blocked item

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -45,6 +45,10 @@ function zignites_chat_register_settings() {
     register_setting('zignites_chat_cod_group', 'zignites_chat_cod_on_confirm_status', ['sanitize_callback' => 'zignites_chat_sanitize_text']);
     register_setting('zignites_chat_cod_group', 'zignites_chat_cod_on_cancel_status', ['sanitize_callback' => 'zignites_chat_sanitize_text']);
 
+    // Order-status + tracking notifications.
+    register_setting('zignites_chat_status_group', 'zignites_chat_status_notify_enabled', ['sanitize_callback' => 'zignites_chat_sanitize_yes_no']);
+    register_setting('zignites_chat_status_group', 'zignites_chat_status_notifications', ['sanitize_callback' => 'zignites_chat_status_sanitize_notifications', 'default' => []]);
+
     // Chatbot.
     register_setting('zignites_chat_chatbot_group', 'zignites_chat_chatbot_enabled', ['sanitize_callback' => 'zignites_chat_sanitize_yes_no']);
     register_setting('zignites_chat_chatbot_group', 'zignites_chat_chatbot_gpt_enabled', ['sanitize_callback' => 'zignites_chat_sanitize_yes_no']);
@@ -113,6 +117,7 @@ function zignites_chat_register_admin_menus() {
         ['zignites-chat-cart-recovery', __('Cart Recovery', 'zignites-chat'),    'zignites_chat_render_cart_recovery_page', true],
         ['zignites-chat-cod',           __('COD Confirmation', 'zignites-chat'), 'zignites_chat_render_cod_page',           true],
         ['zignites-chat-scheduler',     __('Scheduler', 'zignites-chat'),        'zignites_chat_render_scheduler_page',     true],
+        ['zignites-chat-status',        __('Status Notifications', 'zignites-chat'), 'zignites_chat_render_status_page',     true],
         ['zignites-chat-campaigns',     __('Campaigns', 'zignites-chat'),        'zignites_chat_render_campaigns_page',     true],
         ['zignites-chat-inbox',         __('Inbox', 'zignites-chat'),            'zignites_chat_render_inbox_page',         true],
         ['zignites-chat-analytics',     __('Analytics', 'zignites-chat'),        'zignites_chat_render_analytics_page',     true],
@@ -368,6 +373,24 @@ function zignites_chat_render_campaigns_page() {
     zignites_chat_admin_page_close();
 }
 
+function zignites_chat_render_status_page() {
+    if (!current_user_can('manage_options')) {
+        wp_die(esc_html__('Unauthorized', 'zignites-chat'));
+    }
+    zignites_chat_admin_page_open(__('Order Status Notifications', 'zignites-chat'));
+    if (!zignites_chat_is_pro_active()) {
+        zignites_chat_render_pro_upgrade_notice('status');
+        zignites_chat_admin_page_close();
+        return;
+    }
+    echo '<form method="post" action="options.php">';
+    settings_fields('zignites_chat_status_group');
+    require ZIGNITES_CHAT_PATH . 'admin/views/tab-status.php';
+    submit_button();
+    echo '</form>';
+    zignites_chat_admin_page_close();
+}
+
 function zignites_chat_render_cod_page() {
     if (!current_user_can('manage_options')) {
         wp_die(esc_html__('Unauthorized', 'zignites-chat'));
@@ -485,6 +508,16 @@ function zignites_chat_render_pro_upgrade_notice($feature = '') {
                 __('Per message-type template + language mapping', 'zignites-chat'),
                 __('Map order/cart/follow-up data to template variables', 'zignites-chat'),
                 __('Protects your sender number from quality downgrades', 'zignites-chat'),
+            ],
+        ],
+        'status' => [
+            'title'       => __('Order Status & Tracking Notifications', 'zignites-chat'),
+            'description' => __('Keep customers updated on WhatsApp at every step — shipped, out for delivery, on hold, refunded — with the tracking link right in the message.', 'zignites-chat'),
+            'benefits'    => [
+                __('Per-status WhatsApp messages with their own templates', 'zignites-chat'),
+                __('Inject tracking number, carrier and link automatically', 'zignites-chat'),
+                __('Works with WooCommerce Shipment Tracking & AST', 'zignites-chat'),
+                __('Fewer "where is my order?" support tickets', 'zignites-chat'),
             ],
         ],
         'cod' => [

--- a/admin/views/tab-status.php
+++ b/admin/views/tab-status.php
@@ -1,0 +1,58 @@
+<?php
+if (!defined('ABSPATH')) exit;
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals -- View partial: variables are scoped to the render function that includes this file.
+
+$zignites_chat_status_enabled  = get_option('zignites_chat_status_notify_enabled', 'no');
+$zignites_chat_status_config   = zignites_chat_status_get_config();
+$zignites_chat_status_list     = zignites_chat_status_eligible_statuses();
+?>
+<h2><?php esc_html_e('Order Status & Tracking Notifications', 'zignites-chat'); ?></h2>
+<p class="description">
+    <?php esc_html_e('Send a WhatsApp message whenever an order moves into a status you enable below. Leave a status disabled to send nothing. Note: Processing and Completed may already be covered by the order confirmation on the Messaging tab — enabling them here too will send a second message.', 'zignites-chat'); ?>
+</p>
+
+<table class="form-table">
+    <tr>
+        <th scope="row"><label for="zignites_chat_status_notify_enabled"><?php esc_html_e('Enable status notifications', 'zignites-chat'); ?></label></th>
+        <td>
+            <select name="zignites_chat_status_notify_enabled" id="zignites_chat_status_notify_enabled">
+                <option value="no" <?php selected($zignites_chat_status_enabled, 'no'); ?>><?php esc_html_e('No', 'zignites-chat'); ?></option>
+                <option value="yes" <?php selected($zignites_chat_status_enabled, 'yes'); ?>><?php esc_html_e('Yes', 'zignites-chat'); ?></option>
+            </select>
+        </td>
+    </tr>
+</table>
+
+<p class="description">
+    <?php esc_html_e('Placeholders: {name}, {order_id}, {total}, {status}, {currency_symbol}, {tracking_number}, {tracking_url}, {carrier}. Tracking values come from WooCommerce Shipment Tracking / Advanced Shipment Tracking when present.', 'zignites-chat'); ?>
+</p>
+
+<table class="widefat striped" style="max-width:900px;">
+    <thead>
+        <tr>
+            <th style="width:60px;"><?php esc_html_e('Send', 'zignites-chat'); ?></th>
+            <th style="width:180px;"><?php esc_html_e('Status', 'zignites-chat'); ?></th>
+            <th><?php esc_html_e('Message template', 'zignites-chat'); ?></th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($zignites_chat_status_list as $zignites_chat_slug => $zignites_chat_label) :
+            $zignites_chat_entry    = isset($zignites_chat_status_config[$zignites_chat_slug]) && is_array($zignites_chat_status_config[$zignites_chat_slug]) ? $zignites_chat_status_config[$zignites_chat_slug] : [];
+            $zignites_chat_on       = isset($zignites_chat_entry['enabled']) && $zignites_chat_entry['enabled'] === 'yes';
+            $zignites_chat_tmpl     = isset($zignites_chat_entry['template']) ? $zignites_chat_entry['template'] : '';
+            ?>
+            <tr>
+                <td style="text-align:center;">
+                    <input type="checkbox" name="zignites_chat_status_notifications[<?php echo esc_attr($zignites_chat_slug); ?>][enabled]" value="yes" <?php checked($zignites_chat_on); ?> />
+                </td>
+                <td>
+                    <strong><?php echo esc_html($zignites_chat_label); ?></strong><br />
+                    <code><?php echo esc_html($zignites_chat_slug); ?></code>
+                </td>
+                <td>
+                    <textarea name="zignites_chat_status_notifications[<?php echo esc_attr($zignites_chat_slug); ?>][template]" rows="2" class="large-text" placeholder="<?php esc_attr_e('e.g. Hi {name}, your order #{order_id} is now {status}. Track it here: {tracking_url}', 'zignites-chat'); ?>"><?php echo esc_textarea($zignites_chat_tmpl); ?></textarea>
+                </td>
+            </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>

--- a/includes/class-zignites-chat-plugin.php
+++ b/includes/class-zignites-chat-plugin.php
@@ -90,6 +90,7 @@ final class Plugin {
 
         require_once ZIGNITES_CHAT_PATH . 'includes/order-hooks.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/cod-confirmation.php';
+        require_once ZIGNITES_CHAT_PATH . 'includes/status-notifications.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/cart-recovery.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/scheduler.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/campaigns.php';

--- a/includes/status-notifications.php
+++ b/includes/status-notifications.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * Order-status + shipping/tracking notifications (Pro) — roadmap T1.2.
+ *
+ * The classic order confirmation only fires on processing/completed. This
+ * module lets the store send a WhatsApp message on *any* order status change
+ * the admin opts into (shipped, out-for-delivery, on-hold, refunded,
+ * cancelled, …), each with its own template, and injects tracking details
+ * pulled from the common shipment-tracking plugins.
+ *
+ * Defaults are all-off so it never overlaps the classic confirmation until the
+ * admin enables a status. The placeholder renderer and tracking extractor are
+ * pure and unit-tested; the rest is thin WooCommerce glue.
+ *
+ * @package Zignites_Chat
+ */
+
+if (!defined('ABSPATH')) exit;
+
+/* -------------------------------------------------------------------------
+ * Settings access
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Master toggle (Pro + enabled).
+ *
+ * @return bool
+ */
+function zignites_chat_status_notify_is_enabled() {
+    if (function_exists('zignites_chat_is_pro_active') && !zignites_chat_is_pro_active()) {
+        return false;
+    }
+    return get_option('zignites_chat_status_notify_enabled', 'no') === 'yes';
+}
+
+/**
+ * Per-status config: ['<slug>' => ['enabled' => 'yes'|'no', 'template' => string]].
+ *
+ * @return array<string, array{enabled:string, template:string}>
+ */
+function zignites_chat_status_get_config() {
+    $stored = get_option('zignites_chat_status_notifications', []);
+    return is_array($stored) ? $stored : [];
+}
+
+/**
+ * Order statuses the UI offers / sends for — every registered WC status minus
+ * internal ones that never warrant a customer message.
+ *
+ * @return array<string, string> slug => label
+ */
+function zignites_chat_status_eligible_statuses() {
+    $statuses = function_exists('wc_get_order_statuses') ? wc_get_order_statuses() : [];
+    $out = [];
+    foreach ($statuses as $key => $label) {
+        $slug = zignites_chat_status_normalize($key);
+        if (in_array($slug, ['checkout-draft', 'trash', 'pending'], true)) {
+            continue;
+        }
+        $out[$slug] = $label;
+    }
+    return $out;
+}
+
+/* -------------------------------------------------------------------------
+ * Pure helpers (no WC, no DB) — unit-tested
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Strip WooCommerce's `wc-` status prefix. Pure.
+ *
+ * @param string $status
+ * @return string
+ */
+function zignites_chat_status_normalize($status) {
+    $status = (string) $status;
+    return strpos($status, 'wc-') === 0 ? substr($status, 3) : $status;
+}
+
+/**
+ * Whether a notification is enabled for a given status. Pure.
+ *
+ * @param string $status Normalized status slug.
+ * @param array  $config Per-status config (see zignites_chat_status_get_config).
+ * @return bool
+ */
+function zignites_chat_status_should_notify($status, $config) {
+    $status = zignites_chat_status_normalize($status);
+    if (!is_array($config) || !isset($config[$status]) || !is_array($config[$status])) {
+        return false;
+    }
+    $entry = $config[$status];
+    return (isset($entry['enabled']) && $entry['enabled'] === 'yes')
+        && isset($entry['template']) && trim((string) $entry['template']) !== '';
+}
+
+/**
+ * Extract tracking details from shipment-tracking order meta items. Pure.
+ *
+ * Reads the `_wc_shipment_tracking_items` shape used by WooCommerce Shipment
+ * Tracking and Advanced Shipment Tracking. Returns the most-recent item as
+ * ['number' => , 'url' => , 'carrier' => ] (empty strings when absent).
+ *
+ * @param mixed $items Decoded meta value (array of items) or anything.
+ * @return array{number:string, url:string, carrier:string}
+ */
+function zignites_chat_extract_tracking($items) {
+    $empty = ['number' => '', 'url' => '', 'carrier' => ''];
+    if (!is_array($items) || empty($items)) {
+        return $empty;
+    }
+    // Most-recent item is typically last; prefer the last array entry.
+    $item = end($items);
+    if (!is_array($item)) {
+        return $empty;
+    }
+    $number  = isset($item['tracking_number']) ? (string) $item['tracking_number'] : '';
+    $carrier = '';
+    foreach (['formatted_tracking_provider', 'tracking_provider', 'custom_tracking_provider'] as $k) {
+        if (!empty($item[$k])) {
+            $carrier = (string) $item[$k];
+            break;
+        }
+    }
+    $url = '';
+    foreach (['formatted_tracking_link', 'custom_tracking_link', 'tracking_link'] as $k) {
+        if (!empty($item[$k])) {
+            $url = (string) $item[$k];
+            break;
+        }
+    }
+    return [
+        'number'  => trim($number),
+        'url'     => trim($url),
+        'carrier' => trim(wp_strip_all_tags($carrier)),
+    ];
+}
+
+/**
+ * Render a status-notification template by substituting placeholders. Pure.
+ *
+ * @param string $template
+ * @param array  $values Map of '{placeholder}' => replacement.
+ * @return string
+ */
+function zignites_chat_status_render($template, $values) {
+    if (!is_array($values)) {
+        return (string) $template;
+    }
+    return str_replace(array_keys($values), array_values($values), (string) $template);
+}
+
+/* -------------------------------------------------------------------------
+ * Send on status change
+ * ----------------------------------------------------------------------- */
+
+add_action('woocommerce_order_status_changed', 'zignites_chat_status_maybe_notify', 20, 4);
+
+/**
+ * Read tracking details off an order via the shipment-tracking meta.
+ *
+ * @param \WC_Order $order
+ * @return array{number:string, url:string, carrier:string}
+ */
+function zignites_chat_status_get_order_tracking($order) {
+    $items = $order->get_meta('_wc_shipment_tracking_items');
+    if (is_string($items) && $items !== '') {
+        $decoded = json_decode($items, true);
+        $items = is_array($decoded) ? $decoded : [];
+    }
+    $tracking = zignites_chat_extract_tracking($items);
+    /**
+     * Filter the tracking details for an order, for stores using a shipment
+     * plugin that stores tracking elsewhere.
+     */
+    return apply_filters('zignites_chat_order_tracking', $tracking, $order);
+}
+
+/**
+ * Send a WhatsApp notification when an order moves into an opted-in status.
+ *
+ * @param int       $order_id
+ * @param string    $from
+ * @param string    $to
+ * @param \WC_Order $order
+ * @return void
+ */
+function zignites_chat_status_maybe_notify($order_id, $from, $to, $order = null) {
+    if (!zignites_chat_status_notify_is_enabled()) {
+        return;
+    }
+    $config = zignites_chat_status_get_config();
+    if (!zignites_chat_status_should_notify($to, $config)) {
+        return;
+    }
+    if (!$order) {
+        $order = function_exists('wc_get_order') ? wc_get_order($order_id) : null;
+    }
+    if (!$order) {
+        return;
+    }
+
+    $phone = sanitize_text_field($order->get_billing_phone());
+    if (!$phone || zignites_chat_is_opted_out($phone)) {
+        return;
+    }
+
+    $to_slug  = zignites_chat_status_normalize($to);
+    $template = (string) $config[$to_slug]['template'];
+    $tracking = zignites_chat_status_get_order_tracking($order);
+
+    $message = zignites_chat_status_render($template, [
+        '{name}'            => $order->get_billing_first_name(),
+        '{order_id}'        => $order->get_id(),
+        '{total}'           => $order->get_total(),
+        '{status}'          => wc_get_order_status_name($to_slug),
+        '{currency_symbol}' => function_exists('zignites_chat_currency_symbol_text') ? zignites_chat_currency_symbol_text() : '',
+        '{tracking_number}' => $tracking['number'],
+        '{tracking_url}'    => $tracking['url'],
+        '{carrier}'         => $tracking['carrier'],
+    ]);
+    if (trim($message) === '') {
+        return;
+    }
+
+    zignites_chat_send_whatsapp_message($phone, $message, false, [
+        'type'     => 'status_' . $to_slug,
+        'order_id' => $order->get_id(),
+    ]);
+}
+
+/* -------------------------------------------------------------------------
+ * Settings sanitizer
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Sanitize the per-status notifications option.
+ *
+ * @param mixed $raw Submitted array keyed by status slug.
+ * @return array<string, array{enabled:string, template:string}>
+ */
+function zignites_chat_status_sanitize_notifications($raw) {
+    if (!is_array($raw)) {
+        return [];
+    }
+    $clean = [];
+    foreach ($raw as $slug => $entry) {
+        $slug = sanitize_key((string) $slug);
+        if ($slug === '' || !is_array($entry)) {
+            continue;
+        }
+        $enabled  = (isset($entry['enabled']) && $entry['enabled'] === 'yes') ? 'yes' : 'no';
+        $template = isset($entry['template']) ? zignites_chat_sanitize_textarea($entry['template']) : '';
+        $clean[$slug] = ['enabled' => $enabled, 'template' => $template];
+    }
+    return $clean;
+}

--- a/tests/Unit/StatusNotificationsTest.php
+++ b/tests/Unit/StatusNotificationsTest.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+namespace ZignitesChat\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class StatusNotificationsTest extends TestCase
+{
+    public function test_normalize_strips_wc_prefix(): void
+    {
+        $this->assertSame('shipped', \zignites_chat_status_normalize('wc-shipped'));
+        $this->assertSame('processing', \zignites_chat_status_normalize('processing'));
+        $this->assertSame('', \zignites_chat_status_normalize(''));
+    }
+
+    public function test_should_notify(): void
+    {
+        $config = [
+            'shipped'   => ['enabled' => 'yes', 'template' => 'Your order shipped!'],
+            'on-hold'   => ['enabled' => 'no',  'template' => 'On hold'],
+            'completed' => ['enabled' => 'yes', 'template' => '   '], // blank → no
+        ];
+        $this->assertTrue(\zignites_chat_status_should_notify('shipped', $config));
+        $this->assertTrue(\zignites_chat_status_should_notify('wc-shipped', $config)); // normalized
+        $this->assertFalse(\zignites_chat_status_should_notify('on-hold', $config));   // disabled
+        $this->assertFalse(\zignites_chat_status_should_notify('completed', $config)); // blank template
+        $this->assertFalse(\zignites_chat_status_should_notify('refunded', $config));  // absent
+        $this->assertFalse(\zignites_chat_status_should_notify('shipped', 'nope'));
+    }
+
+    public function test_extract_tracking_reads_latest_item(): void
+    {
+        $items = [
+            ['tracking_number' => 'OLD123', 'tracking_provider' => 'UPS'],
+            [
+                'tracking_number'            => 'TRK999',
+                'formatted_tracking_provider'=> 'DHL',
+                'formatted_tracking_link'    => 'https://track.dhl/TRK999',
+            ],
+        ];
+        $t = \zignites_chat_extract_tracking($items);
+        $this->assertSame('TRK999', $t['number']);
+        $this->assertSame('DHL', $t['carrier']);
+        $this->assertSame('https://track.dhl/TRK999', $t['url']);
+    }
+
+    public function test_extract_tracking_handles_empty_and_partial(): void
+    {
+        $this->assertSame(['number' => '', 'url' => '', 'carrier' => ''], \zignites_chat_extract_tracking([]));
+        $this->assertSame(['number' => '', 'url' => '', 'carrier' => ''], \zignites_chat_extract_tracking('nope'));
+
+        $partial = \zignites_chat_extract_tracking([['tracking_number' => 'N1']]);
+        $this->assertSame('N1', $partial['number']);
+        $this->assertSame('', $partial['url']);
+        $this->assertSame('', $partial['carrier']);
+    }
+
+    public function test_render_substitutes_placeholders(): void
+    {
+        $out = \zignites_chat_status_render(
+            'Hi {name}, order #{order_id} is {status}. Track: {tracking_url}',
+            [
+                '{name}'         => 'Sam',
+                '{order_id}'     => 42,
+                '{status}'       => 'Shipped',
+                '{tracking_url}' => 'https://t/abc',
+            ]
+        );
+        $this->assertSame('Hi Sam, order #42 is Shipped. Track: https://t/abc', $out);
+    }
+
+    public function test_sanitize_notifications(): void
+    {
+        $raw = [
+            'shipped'   => ['enabled' => 'yes', 'template' => '  Shipped!  '],
+            'on-hold'   => ['enabled' => 'maybe', 'template' => 'Hold'],
+            ''          => ['enabled' => 'yes', 'template' => 'x'], // empty slug dropped
+            'bad'       => 'not-an-array',                          // dropped
+        ];
+        $clean = \zignites_chat_status_sanitize_notifications($raw);
+        $this->assertSame('yes', $clean['shipped']['enabled']);
+        $this->assertSame('Shipped!', $clean['shipped']['template']);
+        $this->assertSame('no', $clean['on-hold']['enabled']); // invalid → no
+        $this->assertArrayNotHasKey('', $clean);
+        $this->assertArrayNotHasKey('bad', $clean);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -149,6 +149,7 @@ require_once __DIR__ . '/../includes/inbox-capture.php';
 require_once __DIR__ . '/../includes/catalog-context.php';
 require_once __DIR__ . '/../includes/rate-limiter.php';
 require_once __DIR__ . '/../includes/cod-confirmation.php';
+require_once __DIR__ . '/../includes/status-notifications.php';
 require_once __DIR__ . '/../includes/blocks.php';
 require_once __DIR__ . '/../includes/analytics.php';
 require_once __DIR__ . '/../includes/delivery-receipts.php';

--- a/uninstall.php
+++ b/uninstall.php
@@ -85,6 +85,8 @@ $zignites_chat_option_keys = [
     'zignites_chat_cod_cancel_keywords',
     'zignites_chat_cod_on_confirm_status',
     'zignites_chat_cod_on_cancel_status',
+    'zignites_chat_status_notify_enabled',
+    'zignites_chat_status_notifications',
 ];
 
 foreach ($zignites_chat_option_keys as $zignites_chat_key) {


### PR DESCRIPTION
Send a WhatsApp message on any order status change the admin opts into — shipped, out-for-delivery, on-hold, refunded, cancelled — each with its own template and the tracking link injected.

- includes/status-notifications.php: hooks woocommerce_order_status_changed and sends when an order enters an enabled status. Master toggle + a per-status {enabled, template} config; all-off by default so it never overlaps the classic order confirmation until enabled.
- Tracking pulled from _wc_shipment_tracking_items (WooCommerce Shipment Tracking + Advanced Shipment Tracking), exposed as {tracking_number}, {tracking_url}, {carrier}; filterable via zignites_chat_order_tracking.
- Pure, unit-tested helpers: status_normalize, should_notify, extract_tracking, status_render, sanitize_notifications.
- Pro "Status Notifications" tab: master toggle + a per-status table (checkbox + template) across every eligible WC status. Upsell card; settings cleaned on uninstall.

6 unit tests; full suite 192 pass, PHPCS + lint clean.