### PR TITLE
WhatsApp opt-in capture & consent log (T1.3)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -452,9 +452,29 @@ injected tracking link/number (pull from common shipment plugins).
 - [ ] Live smoke test: move an order to a tracked status, confirm the WhatsApp
       lands with the tracking link (user action).
 
-#### T1.3 — WhatsApp opt-in capture — ⬜
-Proactive consent: checkout checkbox / widget + a consent log, complementing
-the existing opt-out pipeline. Compliance + list growth.
+#### T1.3 — WhatsApp opt-in capture — ✅ Done on `feat/pro-optin-capture` (live smoke test pending)
+Proactive consent: checkout checkbox + a consent log, complementing the
+existing opt-out pipeline. Compliance + list growth.
+- [x] `includes/optin.php`: consent log option (`zignites_chat_optin_log`,
+      phone → {time, source}); `record_optin` / `has_consent` / `get_optin_log`.
+      An explicit opt-in clears a prior opt-out (filterable) and fires the
+      `customer.opted_in` webhook.
+- [x] Classic-checkout checkbox (`woocommerce_review_order_before_submit`)
+      with a customizable label + pre-checked option; captured on
+      `woocommerce_checkout_order_processed` (order meta `_zignites_chat_optin`
+      + consent log).
+- [x] Marketing gate: `zignites_chat_marketing_blocked()` (opted-out OR
+      consent-required-and-missing) wired into the three bulk senders
+      (cart-recovery queue, campaign chunk, follow-up handler); transactional
+      sends (order/COD/status) untouched.
+- [x] Pure, tested helpers: `optin_log_add`, `optin_decide_blocked`.
+- [x] Pro "Opt-in" tab: enable, label, pre-checked, require-consent, plus an
+      opted-in count; settings + log cleaned on uninstall.
+- [x] 5 unit tests; 197 pass, PHPCS + lint green.
+- Note: block-checkout checkbox UI deferred (classic checkout + the
+      programmatic `record_optin()` API ship now).
+- [ ] Live smoke test: opt in at checkout, confirm the log + that a campaign
+      skips a non-consented number when "require consent" is on (user action).
 
 ### Tier 2 — turn the inbox into a real helpdesk
 Build on the merged two-way inbox (P1):
@@ -481,13 +501,15 @@ Build on the merged two-way inbox (P1):
 ---
 
 ## Next Action
-**T1.2 — Order-status + tracking notifications — DONE on
-`feat/pro-status-tracking-notifications`** (live smoke test pending). T1.1 (COD)
-is also complete and merged.
+**Tier 1 COMPLETE.** T1.1 (COD), T1.2 (status/tracking), T1.3 (opt-in capture)
+are all built — T1.1/T1.2 merged into `pro`; T1.3 on `feat/pro-optin-capture`
+awaiting PR. Live smoke tests pending on each (user action).
 
-Next feature: **T1.3 — WhatsApp opt-in capture** (checkout checkbox / widget +
-a consent log, complementing the existing opt-out pipeline). Then Tier 2
-(inbox→helpdesk), Tier 3 (automation), and the quick wins — see PHASE 9.
+Next: **Tier 2 — turn the inbox into a real helpdesk.** Start with **T2.1 —
+agent assignment + per-agent views** (make the inbox `agent_id` actionable:
+claim/assign a thread, filter "my conversations"), then T2.2 canned replies,
+T2.3 customer-context panel, T2.4 internal notes, T2.5 agent notifications.
+Then Tier 3 (automation) and the quick wins — see PHASE 9.
 
 The original Pro backlog is otherwise cleared into `pro`; the only blocked item
 is retiring `license-manager.php` (needs the Freemius credentials migration —

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -49,6 +49,12 @@ function zignites_chat_register_settings() {
     register_setting('zignites_chat_status_group', 'zignites_chat_status_notify_enabled', ['sanitize_callback' => 'zignites_chat_sanitize_yes_no']);
     register_setting('zignites_chat_status_group', 'zignites_chat_status_notifications', ['sanitize_callback' => 'zignites_chat_status_sanitize_notifications', 'default' => []]);
 
+    // WhatsApp opt-in capture.
+    register_setting('zignites_chat_optin_group', 'zignites_chat_optin_enabled', ['sanitize_callback' => 'zignites_chat_sanitize_yes_no']);
+    register_setting('zignites_chat_optin_group', 'zignites_chat_optin_label', ['sanitize_callback' => 'zignites_chat_sanitize_text']);
+    register_setting('zignites_chat_optin_group', 'zignites_chat_optin_default_checked', ['sanitize_callback' => 'zignites_chat_sanitize_yes_no']);
+    register_setting('zignites_chat_optin_group', 'zignites_chat_optin_required', ['sanitize_callback' => 'zignites_chat_sanitize_yes_no']);
+
     // Chatbot.
     register_setting('zignites_chat_chatbot_group', 'zignites_chat_chatbot_enabled', ['sanitize_callback' => 'zignites_chat_sanitize_yes_no']);
     register_setting('zignites_chat_chatbot_group', 'zignites_chat_chatbot_gpt_enabled', ['sanitize_callback' => 'zignites_chat_sanitize_yes_no']);
@@ -115,6 +121,7 @@ function zignites_chat_register_admin_menus() {
         ['zignites-chat-wa-templates',  __('WhatsApp Templates', 'zignites-chat'), 'zignites_chat_render_wa_templates_page', true],
         ['zignites-chat-chatbot',       __('Chatbot', 'zignites-chat'),          'zignites_chat_render_chatbot_page'],
         ['zignites-chat-cart-recovery', __('Cart Recovery', 'zignites-chat'),    'zignites_chat_render_cart_recovery_page', true],
+        ['zignites-chat-optin',         __('Opt-in', 'zignites-chat'),           'zignites_chat_render_optin_page',         true],
         ['zignites-chat-cod',           __('COD Confirmation', 'zignites-chat'), 'zignites_chat_render_cod_page',           true],
         ['zignites-chat-scheduler',     __('Scheduler', 'zignites-chat'),        'zignites_chat_render_scheduler_page',     true],
         ['zignites-chat-status',        __('Status Notifications', 'zignites-chat'), 'zignites_chat_render_status_page',     true],
@@ -373,6 +380,24 @@ function zignites_chat_render_campaigns_page() {
     zignites_chat_admin_page_close();
 }
 
+function zignites_chat_render_optin_page() {
+    if (!current_user_can('manage_options')) {
+        wp_die(esc_html__('Unauthorized', 'zignites-chat'));
+    }
+    zignites_chat_admin_page_open(__('WhatsApp Opt-in', 'zignites-chat'));
+    if (!zignites_chat_is_pro_active()) {
+        zignites_chat_render_pro_upgrade_notice('optin');
+        zignites_chat_admin_page_close();
+        return;
+    }
+    echo '<form method="post" action="options.php">';
+    settings_fields('zignites_chat_optin_group');
+    require ZIGNITES_CHAT_PATH . 'admin/views/tab-optin.php';
+    submit_button();
+    echo '</form>';
+    zignites_chat_admin_page_close();
+}
+
 function zignites_chat_render_status_page() {
     if (!current_user_can('manage_options')) {
         wp_die(esc_html__('Unauthorized', 'zignites-chat'));
@@ -508,6 +533,16 @@ function zignites_chat_render_pro_upgrade_notice($feature = '') {
                 __('Per message-type template + language mapping', 'zignites-chat'),
                 __('Map order/cart/follow-up data to template variables', 'zignites-chat'),
                 __('Protects your sender number from quality downgrades', 'zignites-chat'),
+            ],
+        ],
+        'optin' => [
+            'title'       => __('WhatsApp Opt-in & Consent', 'zignites-chat'),
+            'description' => __('Grow a compliant marketing list. Capture explicit WhatsApp consent at checkout, keep a consent log, and optionally restrict marketing sends to customers who opted in.', 'zignites-chat'),
+            'benefits'    => [
+                __('Checkout opt-in checkbox with a customizable label', 'zignites-chat'),
+                __('Timestamped consent log per phone number', 'zignites-chat'),
+                __('Require consent before cart recovery / campaigns / follow-ups', 'zignites-chat'),
+                __('Explicit opt-in clears a prior opt-out', 'zignites-chat'),
             ],
         ],
         'status' => [

--- a/admin/views/tab-optin.php
+++ b/admin/views/tab-optin.php
@@ -1,0 +1,60 @@
+<?php
+if (!defined('ABSPATH')) exit;
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals -- View partial: variables are scoped to the render function that includes this file.
+
+$zignites_chat_optin_enabled = get_option('zignites_chat_optin_enabled', 'no');
+$zignites_chat_optin_label   = get_option('zignites_chat_optin_label', __('Yes, send me order updates and offers on WhatsApp.', 'zignites-chat'));
+$zignites_chat_optin_checked = get_option('zignites_chat_optin_default_checked', 'no');
+$zignites_chat_optin_req     = get_option('zignites_chat_optin_required', 'no');
+
+$zignites_chat_optin_log     = zignites_chat_get_optin_log();
+$zignites_chat_optin_count   = count($zignites_chat_optin_log);
+?>
+<h2><?php esc_html_e('WhatsApp Opt-in & Consent', 'zignites-chat'); ?></h2>
+<p class="description">
+    <?php esc_html_e('Capture explicit consent to message customers on WhatsApp, and optionally restrict marketing sends to those who opted in. Transactional messages (order confirmation, COD, status updates) are never affected.', 'zignites-chat'); ?>
+</p>
+
+<div class="zignites-chat-optin-stat" style="background:#edfaef; padding:12px 18px; border-radius:6px; display:inline-block; margin:12px 0;">
+    <strong style="font-size:20px; display:block;"><?php echo esc_html(number_format_i18n($zignites_chat_optin_count)); ?></strong>
+    <span class="description"><?php esc_html_e('Customers opted in', 'zignites-chat'); ?></span>
+</div>
+
+<table class="form-table">
+    <tr>
+        <th scope="row"><label for="zignites_chat_optin_enabled"><?php esc_html_e('Show opt-in at checkout', 'zignites-chat'); ?></label></th>
+        <td>
+            <select name="zignites_chat_optin_enabled" id="zignites_chat_optin_enabled">
+                <option value="no" <?php selected($zignites_chat_optin_enabled, 'no'); ?>><?php esc_html_e('No', 'zignites-chat'); ?></option>
+                <option value="yes" <?php selected($zignites_chat_optin_enabled, 'yes'); ?>><?php esc_html_e('Yes', 'zignites-chat'); ?></option>
+            </select>
+            <p class="description"><?php esc_html_e('Adds a checkbox to the classic checkout. (Block checkout support coming soon.)', 'zignites-chat'); ?></p>
+        </td>
+    </tr>
+    <tr>
+        <th scope="row"><label for="zignites_chat_optin_label"><?php esc_html_e('Checkbox label', 'zignites-chat'); ?></label></th>
+        <td>
+            <input type="text" name="zignites_chat_optin_label" id="zignites_chat_optin_label" value="<?php echo esc_attr($zignites_chat_optin_label); ?>" class="large-text" />
+        </td>
+    </tr>
+    <tr>
+        <th scope="row"><label for="zignites_chat_optin_default_checked"><?php esc_html_e('Pre-checked', 'zignites-chat'); ?></label></th>
+        <td>
+            <select name="zignites_chat_optin_default_checked" id="zignites_chat_optin_default_checked">
+                <option value="no" <?php selected($zignites_chat_optin_checked, 'no'); ?>><?php esc_html_e('No (recommended)', 'zignites-chat'); ?></option>
+                <option value="yes" <?php selected($zignites_chat_optin_checked, 'yes'); ?>><?php esc_html_e('Yes', 'zignites-chat'); ?></option>
+            </select>
+            <p class="description"><?php esc_html_e('Many privacy regimes require opt-in to be unchecked by default.', 'zignites-chat'); ?></p>
+        </td>
+    </tr>
+    <tr>
+        <th scope="row"><label for="zignites_chat_optin_required"><?php esc_html_e('Require consent for marketing', 'zignites-chat'); ?></label></th>
+        <td>
+            <select name="zignites_chat_optin_required" id="zignites_chat_optin_required">
+                <option value="no" <?php selected($zignites_chat_optin_req, 'no'); ?>><?php esc_html_e('No', 'zignites-chat'); ?></option>
+                <option value="yes" <?php selected($zignites_chat_optin_req, 'yes'); ?>><?php esc_html_e('Yes', 'zignites-chat'); ?></option>
+            </select>
+            <p class="description"><?php esc_html_e('When on, cart recovery, campaigns and follow-ups only message customers who opted in. Order, COD and status messages are unaffected.', 'zignites-chat'); ?></p>
+        </td>
+    </tr>
+</table>

--- a/includes/campaigns.php
+++ b/includes/campaigns.php
@@ -684,7 +684,10 @@ function zignites_chat_campaign_process_chunk($campaign_id) {
     foreach ($rows as $row) {
         $phone = $row['phone'];
 
-        if (zignites_chat_is_opted_out($phone)) {
+        $zignites_chat_blocked = function_exists('zignites_chat_marketing_blocked')
+            ? zignites_chat_marketing_blocked($phone)
+            : zignites_chat_is_opted_out($phone);
+        if ($zignites_chat_blocked) {
             $wpdb->update($rt, [
                 'status'  => 'skipped',
                 'sent_at' => current_time('mysql'),

--- a/includes/cart-recovery.php
+++ b/includes/cart-recovery.php
@@ -333,7 +333,12 @@ function zignites_chat_process_cart_recovery_queue() {
             continue;
         }
 
-        if (zignites_chat_is_opted_out($phone)) {
+        // Suppress opt-outs and, when consent is required, non-consented
+        // numbers (cart recovery is marketing).
+        $zignites_chat_blocked = function_exists('zignites_chat_marketing_blocked')
+            ? zignites_chat_marketing_blocked($phone)
+            : zignites_chat_is_opted_out($phone);
+        if ($zignites_chat_blocked) {
             $wpdb->update($table, ['status' => 'opted_out', 'updated_at' => $now], ['id' => $row->id], ['%s','%s'], ['%d']);
             continue;
         }

--- a/includes/class-zignites-chat-plugin.php
+++ b/includes/class-zignites-chat-plugin.php
@@ -88,6 +88,7 @@ final class Plugin {
         require_once ZIGNITES_CHAT_PATH . 'includes/optout.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/delivery-receipts.php';
 
+        require_once ZIGNITES_CHAT_PATH . 'includes/optin.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/order-hooks.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/cod-confirmation.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/status-notifications.php';

--- a/includes/optin.php
+++ b/includes/optin.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * WhatsApp opt-in capture & consent log (Pro) — roadmap T1.3.
+ *
+ * Complements the opt-out suppression list with proactive, explicit consent:
+ * a checkout checkbox records who agreed to receive WhatsApp messages, when,
+ * and from where. An optional "require consent for marketing" mode then gates
+ * the bulk channels (cart recovery, campaigns, follow-ups) to consented
+ * numbers only — transactional sends (order/COD/status) are never gated.
+ *
+ * The log-mutation and gating decisions are pure and unit-tested; the rest is
+ * thin option/WooCommerce glue.
+ *
+ * @package Zignites_Chat
+ */
+
+if (!defined('ABSPATH')) exit;
+
+/* -------------------------------------------------------------------------
+ * Pure helpers (no DB) — unit-tested
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Add/refresh a consent entry in the log. Pure.
+ *
+ * @param array  $log    Existing log keyed by normalized phone.
+ * @param string $phone  Normalized phone (digits only).
+ * @param string $time   MySQL datetime of consent.
+ * @param string $source Where consent was captured (e.g. 'checkout').
+ * @return array Updated log.
+ */
+function zignites_chat_optin_log_add($log, $phone, $time, $source) {
+    if (!is_array($log)) {
+        $log = [];
+    }
+    $phone = (string) $phone;
+    if ($phone === '') {
+        return $log;
+    }
+    $log[$phone] = [
+        'time'   => (string) $time,
+        'source' => (string) $source,
+    ];
+    return $log;
+}
+
+/**
+ * Decide whether a marketing send to a phone is blocked. Pure.
+ *
+ * Blocked when the number opted out, or when consent is required and the
+ * number has not opted in. Transactional callers do not use this.
+ *
+ * @param bool $opted_out   Number is on the suppression list.
+ * @param bool $required    "Require consent for marketing" is on.
+ * @param bool $has_consent Number is in the opt-in log.
+ * @return bool
+ */
+function zignites_chat_optin_decide_blocked($opted_out, $required, $has_consent) {
+    if ($opted_out) {
+        return true;
+    }
+    return $required && !$has_consent;
+}
+
+/* -------------------------------------------------------------------------
+ * Consent store
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Read the consent log: [ normalized_phone => ['time'=>…, 'source'=>…] ].
+ *
+ * @return array<string, array{time:string, source:string}>
+ */
+function zignites_chat_get_optin_log() {
+    $log = get_option('zignites_chat_optin_log', []);
+    return is_array($log) ? $log : [];
+}
+
+/**
+ * Whether a phone has given WhatsApp consent.
+ *
+ * @param string $phone Phone in any format.
+ * @return bool
+ */
+function zignites_chat_has_consent($phone) {
+    $phone = zignites_chat_normalize_phone($phone);
+    if ($phone === '') {
+        return false;
+    }
+    $log = zignites_chat_get_optin_log();
+    return isset($log[$phone]);
+}
+
+/**
+ * Record explicit WhatsApp consent for a phone.
+ *
+ * Removes the number from the opt-out suppression list (an explicit opt-in
+ * supersedes a prior opt-out; filterable) and fires the customer.opted_in
+ * webhook.
+ *
+ * @param string $phone  Phone in any format.
+ * @param string $source Capture source (e.g. 'checkout').
+ * @return bool False when the phone is empty, true otherwise.
+ */
+function zignites_chat_record_optin($phone, $source = 'checkout') {
+    $phone = zignites_chat_normalize_phone($phone);
+    if ($phone === '') {
+        return false;
+    }
+
+    $log = zignites_chat_optin_log_add(zignites_chat_get_optin_log(), $phone, current_time('mysql'), sanitize_text_field($source));
+    update_option('zignites_chat_optin_log', $log, false);
+
+    /** @var bool $clear Whether an explicit opt-in clears a prior opt-out. */
+    if (apply_filters('zignites_chat_optin_clears_optout', true, $phone)) {
+        $optout = zignites_chat_get_optout_list();
+        $idx = array_search($phone, $optout, true);
+        if ($idx !== false) {
+            unset($optout[$idx]);
+            update_option('zignites_chat_optout_list', array_values($optout), false);
+        }
+    }
+
+    if (function_exists('zignites_chat_dispatch_webhook')) {
+        zignites_chat_dispatch_webhook('customer.opted_in', ['phone' => $phone, 'source' => $source]);
+    }
+    return true;
+}
+
+/**
+ * Whether a marketing send to a phone is blocked (opted out, or consent
+ * required and missing). Transactional sends must not call this.
+ *
+ * @param string $phone Phone in any format.
+ * @return bool
+ */
+function zignites_chat_marketing_blocked($phone) {
+    return zignites_chat_optin_decide_blocked(
+        zignites_chat_is_opted_out($phone),
+        get_option('zignites_chat_optin_required', 'no') === 'yes',
+        zignites_chat_has_consent($phone)
+    );
+}
+
+/* -------------------------------------------------------------------------
+ * Checkout capture (classic checkout)
+ * ----------------------------------------------------------------------- */
+
+add_action('woocommerce_review_order_before_submit', 'zignites_chat_optin_checkout_field');
+add_action('woocommerce_checkout_order_processed', 'zignites_chat_optin_capture_checkout', 20, 1);
+
+/**
+ * Render the opt-in checkbox on the classic checkout.
+ */
+function zignites_chat_optin_checkout_field() {
+    if (get_option('zignites_chat_optin_enabled', 'no') !== 'yes') {
+        return;
+    }
+    if (function_exists('zignites_chat_is_pro_active') && !zignites_chat_is_pro_active()) {
+        return;
+    }
+    $label   = get_option('zignites_chat_optin_label', __('Yes, send me order updates and offers on WhatsApp.', 'zignites-chat'));
+    $checked = get_option('zignites_chat_optin_default_checked', 'no') === 'yes';
+    echo '<p class="form-row zignites-chat-optin-row">';
+    echo '<label style="display:flex; gap:8px; align-items:flex-start;">';
+    echo '<input type="checkbox" name="zignites_chat_optin" value="yes" ' . checked($checked, true, false) . ' />';
+    echo '<span>' . esc_html($label) . '</span>';
+    echo '</label>';
+    echo '</p>';
+}
+
+/**
+ * Persist the opt-in choice when a classic-checkout order is placed.
+ *
+ * @param int $order_id
+ * @return void
+ */
+function zignites_chat_optin_capture_checkout($order_id) {
+    if (get_option('zignites_chat_optin_enabled', 'no') !== 'yes') {
+        return;
+    }
+    // WooCommerce verifies the checkout nonce before this hook runs.
+    // phpcs:ignore WordPress.Security.NonceVerification.Missing
+    $opted_in = isset($_POST['zignites_chat_optin']) && sanitize_text_field(wp_unslash($_POST['zignites_chat_optin'])) === 'yes';
+    if (!$opted_in) {
+        return;
+    }
+    $order = function_exists('wc_get_order') ? wc_get_order($order_id) : null;
+    if (!$order) {
+        return;
+    }
+    $order->update_meta_data('_zignites_chat_optin', 'yes');
+    $order->save();
+    zignites_chat_record_optin($order->get_billing_phone(), 'checkout');
+}

--- a/includes/scheduler.php
+++ b/includes/scheduler.php
@@ -40,9 +40,15 @@ function zignites_chat_send_followup_message_handler($order_id) {
     $to = sanitize_text_field($order->get_billing_phone());
     if (!$to) return;
 
-    // Permanent skip: opt-outs never reach the provider, so retrying just
-    // burns attempts on the same `false` return.
-    if (zignites_chat_is_opted_out($to)) return;
+    // Permanent skip: opt-outs (and, when consent is required, non-consented
+    // numbers) never reach the provider, so retrying just burns attempts on
+    // the same `false` return. Follow-ups are marketing, so the consent gate
+    // applies.
+    if (function_exists('zignites_chat_marketing_blocked')) {
+        if (zignites_chat_marketing_blocked($to)) return;
+    } elseif (zignites_chat_is_opted_out($to)) {
+        return;
+    }
 
     // Central outbound budget: if the shared per-minute cap is hit, defer this
     // follow-up by re-scheduling shortly. This is a deferral, not a failure —

--- a/tests/Unit/OptinTest.php
+++ b/tests/Unit/OptinTest.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace ZignitesChat\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class OptinTest extends TestCase
+{
+    public function test_log_add_inserts_and_updates(): void
+    {
+        $log = \zignites_chat_optin_log_add([], '14155550100', '2026-06-03 10:00:00', 'checkout');
+        $this->assertSame(['time' => '2026-06-03 10:00:00', 'source' => 'checkout'], $log['14155550100']);
+
+        // Re-adding the same phone refreshes the entry, not a duplicate key.
+        $log = \zignites_chat_optin_log_add($log, '14155550100', '2026-06-03 11:00:00', 'account');
+        $this->assertCount(1, $log);
+        $this->assertSame('2026-06-03 11:00:00', $log['14155550100']['time']);
+        $this->assertSame('account', $log['14155550100']['source']);
+    }
+
+    public function test_log_add_ignores_empty_phone_and_bad_log(): void
+    {
+        $this->assertSame([], \zignites_chat_optin_log_add([], '', 't', 's'));
+        $this->assertSame(
+            ['14155550100' => ['time' => 't', 'source' => 's']],
+            \zignites_chat_optin_log_add('not-an-array', '14155550100', 't', 's')
+        );
+    }
+
+    public function test_decide_blocked_opted_out_always_blocks(): void
+    {
+        // Opted out → blocked regardless of consent / requirement.
+        $this->assertTrue(\zignites_chat_optin_decide_blocked(true, false, true));
+        $this->assertTrue(\zignites_chat_optin_decide_blocked(true, true, true));
+    }
+
+    public function test_decide_blocked_consent_required(): void
+    {
+        // Required + no consent → blocked.
+        $this->assertTrue(\zignites_chat_optin_decide_blocked(false, true, false));
+        // Required + has consent → allowed.
+        $this->assertFalse(\zignites_chat_optin_decide_blocked(false, true, true));
+    }
+
+    public function test_decide_blocked_not_required_allows_without_consent(): void
+    {
+        $this->assertFalse(\zignites_chat_optin_decide_blocked(false, false, false));
+        $this->assertFalse(\zignites_chat_optin_decide_blocked(false, false, true));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -150,6 +150,7 @@ require_once __DIR__ . '/../includes/catalog-context.php';
 require_once __DIR__ . '/../includes/rate-limiter.php';
 require_once __DIR__ . '/../includes/cod-confirmation.php';
 require_once __DIR__ . '/../includes/status-notifications.php';
+require_once __DIR__ . '/../includes/optin.php';
 require_once __DIR__ . '/../includes/blocks.php';
 require_once __DIR__ . '/../includes/analytics.php';
 require_once __DIR__ . '/../includes/delivery-receipts.php';

--- a/uninstall.php
+++ b/uninstall.php
@@ -87,6 +87,11 @@ $zignites_chat_option_keys = [
     'zignites_chat_cod_on_cancel_status',
     'zignites_chat_status_notify_enabled',
     'zignites_chat_status_notifications',
+    'zignites_chat_optin_enabled',
+    'zignites_chat_optin_label',
+    'zignites_chat_optin_default_checked',
+    'zignites_chat_optin_required',
+    'zignites_chat_optin_log',
 ];
 
 foreach ($zignites_chat_option_keys as $zignites_chat_key) {


### PR DESCRIPTION
Adds proactive consent to complement the opt-out suppression list, and an optional gate that restricts marketing to consented numbers.

- includes/optin.php: a consent log (phone -> {time, source}) with record_optin / has_consent / get_optin_log. An explicit opt-in clears a prior opt-out (filterable) and fires the customer.opted_in webhook.
- Classic-checkout opt-in checkbox (customizable label, optional pre-check), captured on order placement into the log + order meta.
- Marketing gate: zignites_chat_marketing_blocked() (opted-out OR consent-required-and-missing) wired into the three bulk senders (cart-recovery queue, campaign chunk, follow-up). Transactional sends (order/COD/status) are never gated.
- Pure, unit-tested helpers: optin_log_add, optin_decide_blocked.
- Pro "Opt-in" tab: enable, label, pre-checked, require-consent, plus an opted-in count. Settings + log cleaned on uninstall.

Completes Tier 1 of the roadmap. Block-checkout checkbox UI deferred; classic checkout + the record_optin() API ship now. 5 unit tests; full suite 197 pass, PHPCS + lint clean.