### PR TITLE
Inbox agent assignment + per-agent views (T2.1)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -478,7 +478,15 @@ existing opt-out pipeline. Compliance + list growth.
 
 ### Tier 2 — turn the inbox into a real helpdesk
 Build on the merged two-way inbox (P1):
-- [ ] T2.1 — Agent assignment + per-agent views (make `agent_id` actionable).
+- [x] T2.1 — Agent assignment + per-agent views — done on
+      `feat/pro-inbox-agent-assignment`. `agent_id` is now actionable:
+      `assign_thread` storage + an `agent_id` filter on `get_threads`; AJAX
+      `zignites_chat_inbox_assign` (claim/assign/unassign, validates the agent
+      is an admin/shop-manager); the thread list shows the assignee, the panel
+      header has a Claim button + assign dropdown, and a list filter (All /
+      Assigned to me / Unassigned). Pure helpers `scope_to_agent_filter`,
+      `agent_name`; presenter exposes `agent_id`. 3 unit tests; 200 pass,
+      PHPCS + lint green.
 - [ ] T2.2 — Canned / quick replies in the inbox composer.
 - [ ] T2.3 — Customer context panel (order history, LTV) beside the thread.
 - [ ] T2.4 — Internal notes on a conversation.
@@ -505,11 +513,11 @@ Build on the merged two-way inbox (P1):
 are all built — T1.1/T1.2 merged into `pro`; T1.3 on `feat/pro-optin-capture`
 awaiting PR. Live smoke tests pending on each (user action).
 
-Next: **Tier 2 — turn the inbox into a real helpdesk.** Start with **T2.1 —
-agent assignment + per-agent views** (make the inbox `agent_id` actionable:
-claim/assign a thread, filter "my conversations"), then T2.2 canned replies,
-T2.3 customer-context panel, T2.4 internal notes, T2.5 agent notifications.
-Then Tier 3 (automation) and the quick wins — see PHASE 9.
+Tier 2 in progress: **T2.1 (agent assignment) DONE** on
+`feat/pro-inbox-agent-assignment`. Next: **T2.2 — canned / quick replies** in
+the inbox composer (a small library of saved snippets the agent can insert),
+then T2.3 customer-context panel, T2.4 internal notes, T2.5 agent
+notifications. Then Tier 3 (automation) and the quick wins — see PHASE 9.
 
 The original Pro backlog is otherwise cleared into `pro`; the only blocked item
 is retiring `license-manager.php` (needs the Freemius credentials migration —

--- a/admin/views/tab-inbox.php
+++ b/admin/views/tab-inbox.php
@@ -13,6 +13,11 @@ $zignites_chat_threads = zignites_chat_inbox_get_threads(['limit' => 100]);
         <div class="zignites-chat-inbox-search">
             <input type="search" id="zignites-chat-inbox-search" class="regular-text"
                    placeholder="<?php esc_attr_e('Search name or number…', 'zignites-chat'); ?>" />
+            <select id="zignites-chat-inbox-filter" style="margin-top:8px; width:100%;">
+                <option value="all"><?php esc_html_e('All conversations', 'zignites-chat'); ?></option>
+                <option value="mine"><?php esc_html_e('Assigned to me', 'zignites-chat'); ?></option>
+                <option value="unassigned"><?php esc_html_e('Unassigned', 'zignites-chat'); ?></option>
+            </select>
         </div>
         <ul class="zignites-chat-inbox-threads" id="zignites-chat-inbox-threads">
             <?php if (empty($zignites_chat_threads)) : ?>
@@ -46,6 +51,11 @@ $zignites_chat_threads = zignites_chat_inbox_get_threads(['limit' => 100]);
             <div class="zignites-chat-inbox-thread-header">
                 <span class="zignites-chat-inbox-thread-title" id="zignites-chat-inbox-thread-title"></span>
                 <span class="zignites-chat-inbox-thread-phone" id="zignites-chat-inbox-thread-phone"></span>
+                <span class="zignites-chat-inbox-assign" id="zignites-chat-inbox-assign">
+                    <span class="zignites-chat-inbox-assignee" id="zignites-chat-inbox-assignee"></span>
+                    <button type="button" class="button button-small" id="zignites-chat-inbox-claim"></button>
+                    <select id="zignites-chat-inbox-assign-select"></select>
+                </span>
             </div>
             <div class="zignites-chat-inbox-window" id="zignites-chat-inbox-window"></div>
             <div class="zignites-chat-inbox-messages" id="zignites-chat-inbox-messages"></div>

--- a/assets/css/inbox.css
+++ b/assets/css/inbox.css
@@ -89,6 +89,33 @@
     white-space: nowrap;
 }
 
+.zignites-chat-inbox-thread-agent {
+    grid-column: 1 / -1;
+    color: #2271b1;
+    font-size: 11px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.zignites-chat-inbox-assign {
+    display: inline-flex;
+    gap: 8px;
+    align-items: center;
+    margin-left: auto;
+    font-size: 12px;
+}
+
+.zignites-chat-inbox-assignee {
+    color: #50575e;
+}
+
+.zignites-chat-inbox-thread-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
 .zignites-chat-inbox-badge {
     grid-area: badge;
     justify-self: end;

--- a/assets/js/inbox.js
+++ b/assets/js/inbox.js
@@ -22,8 +22,16 @@
         var replyEl = document.getElementById('zignites-chat-inbox-reply');
         var sendEl = document.getElementById('zignites-chat-inbox-send');
         var composerNote = document.getElementById('zignites-chat-inbox-composer-note');
+        var filterEl = document.getElementById('zignites-chat-inbox-filter');
+        var assigneeEl = document.getElementById('zignites-chat-inbox-assignee');
+        var claimEl = document.getElementById('zignites-chat-inbox-claim');
+        var assignSelect = document.getElementById('zignites-chat-inbox-assign-select');
+
+        var agents = config.agents || [];
+        var currentUser = parseInt(config.currentUser, 10) || 0;
 
         var activeId = 0;
+        var activeAgentId = 0;
         var lastMessageId = 0;
         var windowOpen = false;
         var searchTimer = null;
@@ -87,6 +95,13 @@
                 time.textContent = t.last_message_at || '';
                 li.appendChild(time);
 
+                if (t.agentName) {
+                    var who = document.createElement('span');
+                    who.className = 'zignites-chat-inbox-thread-agent';
+                    who.textContent = '@ ' + t.agentName;
+                    li.appendChild(who);
+                }
+
                 li.addEventListener('click', function () { openThread(t.id); });
                 listEl.appendChild(li);
             });
@@ -95,11 +110,52 @@
         function loadThreads() {
             var params = {};
             if (searchEl && searchEl.value) params.search = searchEl.value;
+            if (filterEl && filterEl.value) params.scope = filterEl.value;
             return ajaxGet('zignites_chat_inbox_threads', params).then(function (res) {
                 if (res && res.success) {
                     renderThreads(res.data.threads);
                 }
             }).catch(function () { /* transient network error — next poll retries */ });
+        }
+
+        // --- Assignment ------------------------------------------------------
+
+        function renderAssignment(agentId, agentName) {
+            activeAgentId = parseInt(agentId, 10) || 0;
+            if (assigneeEl) {
+                assigneeEl.textContent = (i18n.assignedTo || '') + ': ' + (agentName || (i18n.unassigned || ''));
+            }
+            if (claimEl) {
+                // Hide Claim when the current user already owns the thread.
+                claimEl.textContent = i18n.claim || '';
+                claimEl.style.display = (currentUser && activeAgentId === currentUser) ? 'none' : '';
+            }
+            if (assignSelect) assignSelect.value = String(activeAgentId);
+        }
+
+        function buildAssignSelect() {
+            if (!assignSelect) return;
+            assignSelect.innerHTML = '';
+            var unassigned = document.createElement('option');
+            unassigned.value = '0';
+            unassigned.textContent = i18n.unassigned || '';
+            assignSelect.appendChild(unassigned);
+            agents.forEach(function (a) {
+                var opt = document.createElement('option');
+                opt.value = String(a.id);
+                opt.textContent = a.name;
+                assignSelect.appendChild(opt);
+            });
+        }
+
+        function assign(agentId) {
+            if (!activeId) return;
+            ajaxPost('zignites_chat_inbox_assign', { conversation_id: activeId, agent_id: agentId }).then(function (res) {
+                if (res && res.success) {
+                    renderAssignment(res.data.agent_id, res.data.agentName);
+                    loadThreads();
+                }
+            }).catch(function () { /* ignore */ });
         }
 
         // --- Thread view -----------------------------------------------------
@@ -195,6 +251,7 @@
                 var t = res.data.thread;
                 titleEl.textContent = t.name || t.phone || (i18n.unknown || '');
                 phoneEl.textContent = t.phone || '';
+                renderAssignment(t.agent_id, t.agentName);
                 renderWindow(!!t.windowOpen);
 
                 messagesEl.innerHTML = '';
@@ -231,6 +288,17 @@
                 searchTimer = setTimeout(loadThreads, 300);
             });
         }
+        if (filterEl) {
+            filterEl.addEventListener('change', loadThreads);
+        }
+
+        buildAssignSelect();
+        if (claimEl) {
+            claimEl.addEventListener('click', function () { assign(currentUser); });
+        }
+        if (assignSelect) {
+            assignSelect.addEventListener('change', function () { assign(parseInt(assignSelect.value, 10) || 0); });
+        }
 
         if (sendEl) {
             sendEl.addEventListener('click', sendReply);
@@ -249,6 +317,9 @@
         Array.prototype.forEach.call(listEl.querySelectorAll('.zignites-chat-inbox-thread'), function (li) {
             li.addEventListener('click', function () { openThread(parseInt(li.getAttribute('data-id'), 10)); });
         });
+
+        // Refresh once on load so JS-rendered rows include assignee names.
+        loadThreads();
 
         window.setInterval(function () {
             loadThreads();

--- a/includes/inbox-admin.php
+++ b/includes/inbox-admin.php
@@ -35,6 +35,69 @@ function zignites_chat_render_inbox_page() {
 }
 
 /* ---------------------------------------------------------------------------
+ * Agents (assignment)
+ * ------------------------------------------------------------------------ */
+
+/**
+ * Users who can be assigned inbox conversations: those who can manage the
+ * store (administrators + shop managers). Returns [user_id => display_name].
+ *
+ * @return array<int, string>
+ */
+function zignites_chat_inbox_assignable_agents() {
+    $agents = [];
+    $users  = get_users([
+        'role__in' => ['administrator', 'shop_manager'],
+        'orderby'  => 'display_name',
+        'fields'   => ['ID', 'display_name'],
+    ]);
+    foreach ($users as $user) {
+        $agents[(int) $user->ID] = (string) $user->display_name;
+    }
+    return apply_filters('zignites_chat_inbox_assignable_agents', $agents);
+}
+
+/**
+ * Resolve an agent id to a display name from the agents map.
+ *
+ * @param int   $agent_id
+ * @param array $agents   [id => name] map.
+ * @return string '' when unassigned, the name when known, else "User #id".
+ */
+function zignites_chat_inbox_agent_name($agent_id, $agents) {
+    $agent_id = (int) $agent_id;
+    if ($agent_id <= 0) {
+        return '';
+    }
+    if (isset($agents[$agent_id])) {
+        return (string) $agents[$agent_id];
+    }
+    /* translators: %d: WordPress user id. */
+    return sprintf(__('User #%d', 'zignites-chat'), $agent_id);
+}
+
+/**
+ * Translate a list-scope param into a get_threads() agent_id filter.
+ *
+ * @param string $scope   'all' | 'mine' | 'unassigned' | numeric agent id.
+ * @param int    $user_id Current user id (for 'mine').
+ * @return int|null null = no filter, 0 = unassigned, >0 = that agent.
+ */
+function zignites_chat_inbox_scope_to_agent_filter($scope, $user_id) {
+    $scope = (string) $scope;
+    if ($scope === 'mine') {
+        return (int) $user_id;
+    }
+    if ($scope === 'unassigned') {
+        return 0;
+    }
+    if ($scope !== '' && ctype_digit($scope)) {
+        return (int) $scope;
+    }
+    return null; // 'all' / empty
+}
+
+/* ---------------------------------------------------------------------------
  * Assets
  * ------------------------------------------------------------------------ */
 
@@ -45,11 +108,25 @@ function zignites_chat_inbox_enqueue_assets($hook) {
     }
     wp_enqueue_style('zignites-chat-inbox-css', ZIGNITES_CHAT_URL . 'assets/css/inbox.css', [], ZIGNITES_CHAT_VERSION);
     wp_enqueue_script('zignites-chat-inbox-js', ZIGNITES_CHAT_URL . 'assets/js/inbox.js', [], ZIGNITES_CHAT_VERSION, true);
+    $agents = zignites_chat_inbox_assignable_agents();
+    $agent_options = [];
+    foreach ($agents as $id => $name) {
+        $agent_options[] = ['id' => (int) $id, 'name' => (string) $name];
+    }
     wp_localize_script('zignites-chat-inbox-js', 'zignitesChatInbox', [
         'ajaxUrl'      => admin_url('admin-ajax.php'),
         'nonce'        => wp_create_nonce('zignites_chat_inbox'),
         'pollInterval' => (int) apply_filters('zignites_chat_inbox_poll_interval', 15000),
+        'currentUser'  => get_current_user_id(),
+        'agents'       => $agent_options,
         'i18n'         => [
+            'assignedTo'    => __('Assigned to', 'zignites-chat'),
+            'unassigned'    => __('Unassigned', 'zignites-chat'),
+            'claim'         => __('Claim', 'zignites-chat'),
+            'assign'        => __('Assign…', 'zignites-chat'),
+            'filterAll'     => __('All conversations', 'zignites-chat'),
+            'filterMine'    => __('Assigned to me', 'zignites-chat'),
+            'filterUnassigned' => __('Unassigned', 'zignites-chat'),
             'loading'       => __('Loading…', 'zignites-chat'),
             'noThreads'     => __('No conversations yet. Inbound WhatsApp messages will appear here.', 'zignites-chat'),
             'noMessages'    => __('No messages in this conversation.', 'zignites-chat'),
@@ -86,11 +163,21 @@ function zignites_chat_ajax_inbox_threads() {
     }
 
     $search = isset($_GET['search']) ? sanitize_text_field(wp_unslash($_GET['search'])) : '';
-    $rows   = zignites_chat_inbox_get_threads(['limit' => 100, 'search' => $search]);
+    $scope  = isset($_GET['scope']) ? sanitize_key(wp_unslash($_GET['scope'])) : '';
+    $agent_filter = zignites_chat_inbox_scope_to_agent_filter($scope, get_current_user_id());
 
+    $rows = zignites_chat_inbox_get_threads([
+        'limit'    => 100,
+        'search'   => $search,
+        'agent_id' => $agent_filter,
+    ]);
+
+    $agents  = zignites_chat_inbox_assignable_agents();
     $threads = [];
     foreach ($rows as $row) {
-        $threads[] = zignites_chat_inbox_present_thread($row);
+        $thread = zignites_chat_inbox_present_thread($row);
+        $thread['agentName'] = zignites_chat_inbox_agent_name($thread['agent_id'], $agents);
+        $threads[] = $thread;
     }
 
     wp_send_json_success([
@@ -138,10 +225,48 @@ function zignites_chat_ajax_inbox_thread() {
 
     $present = zignites_chat_inbox_present_thread($thread);
     $present['windowOpen'] = zignites_chat_inbox_window_is_open($thread['last_inbound_at'] ?? '');
+    $present['agentName']  = zignites_chat_inbox_agent_name($present['agent_id'], zignites_chat_inbox_assignable_agents());
 
     wp_send_json_success([
         'thread'   => $present,
         'messages' => $messages,
+    ]);
+}
+
+/* ---------------------------------------------------------------------------
+ * AJAX — assign / claim / unassign a conversation
+ * ------------------------------------------------------------------------ */
+
+add_action('wp_ajax_zignites_chat_inbox_assign', 'zignites_chat_ajax_inbox_assign');
+function zignites_chat_ajax_inbox_assign() {
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error(['message' => __('Unauthorized', 'zignites-chat')], 403);
+    }
+    if (!check_ajax_referer('zignites_chat_inbox', 'nonce', false)) {
+        wp_send_json_error(['message' => __('Bad nonce', 'zignites-chat')], 400);
+    }
+    if (!zignites_chat_is_pro_active()) {
+        wp_send_json_error(['message' => __('Pro required', 'zignites-chat')], 403);
+    }
+
+    $conversation_id = isset($_POST['conversation_id']) ? (int) $_POST['conversation_id'] : 0;
+    $agent_id        = isset($_POST['agent_id']) ? (int) $_POST['agent_id'] : 0;
+
+    if (zignites_chat_inbox_get_thread($conversation_id) === null) {
+        wp_send_json_error(['message' => __('Not found', 'zignites-chat')], 404);
+    }
+    // A non-zero assignee must be a real, eligible agent.
+    if ($agent_id > 0 && !isset(zignites_chat_inbox_assignable_agents()[$agent_id])) {
+        wp_send_json_error(['message' => __('Unknown agent', 'zignites-chat')], 422);
+    }
+
+    if (!zignites_chat_inbox_assign_thread($conversation_id, $agent_id)) {
+        wp_send_json_error(['message' => __('Could not update assignment.', 'zignites-chat')], 500);
+    }
+
+    wp_send_json_success([
+        'agent_id'  => $agent_id,
+        'agentName' => zignites_chat_inbox_agent_name($agent_id, zignites_chat_inbox_assignable_agents()),
     ]);
 }
 

--- a/includes/inbox.php
+++ b/includes/inbox.php
@@ -288,9 +288,11 @@ function zignites_chat_inbox_get_thread($conversation_id) {
  * List conversation threads, unread first then most-recently active.
  *
  * @param array $args {
- *   @type int    $limit  Max rows (1–200). Default 50.
- *   @type int    $offset Pagination offset. Default 0.
- *   @type string $search Optional phone/name LIKE filter.
+ *   @type int      $limit    Max rows (1–200). Default 50.
+ *   @type int      $offset   Pagination offset. Default 0.
+ *   @type string   $search   Optional phone/name LIKE filter.
+ *   @type int|null $agent_id Optional assignee filter: null = no filter,
+ *                           0 = unassigned only, >0 = that agent only.
  * }
  * @return array<int, array> Thread rows (ARRAY_A).
  */
@@ -299,23 +301,54 @@ function zignites_chat_inbox_get_threads($args = []) {
     $limit  = isset($args['limit']) ? max(1, min(200, (int) $args['limit'])) : 50;
     $offset = isset($args['offset']) ? max(0, (int) $args['offset']) : 0;
     $search = isset($args['search']) ? trim((string) $args['search']) : '';
+    $agent  = array_key_exists('agent_id', $args) && $args['agent_id'] !== null ? (int) $args['agent_id'] : null;
     $table  = zignites_chat_conversations_table_name();
 
+    $where  = [];
+    $params = [];
     if ($search !== '') {
         $like = '%' . $wpdb->esc_like($search) . '%';
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-        $rows = $wpdb->get_results($wpdb->prepare(
-            "SELECT * FROM {$table} WHERE phone LIKE %s OR customer_name LIKE %s ORDER BY unread_count DESC, last_message_at DESC LIMIT %d OFFSET %d",
-            $like, $like, $limit, $offset
-        ), ARRAY_A);
-    } else {
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-        $rows = $wpdb->get_results($wpdb->prepare(
-            "SELECT * FROM {$table} ORDER BY unread_count DESC, last_message_at DESC LIMIT %d OFFSET %d",
-            $limit, $offset
-        ), ARRAY_A);
+        $where[] = '(phone LIKE %s OR customer_name LIKE %s)';
+        $params[] = $like;
+        $params[] = $like;
     }
+    if ($agent !== null) {
+        $where[] = 'agent_id = %d';
+        $params[] = max(0, $agent);
+    }
+
+    $where_sql = $where ? ' WHERE ' . implode(' AND ', $where) : '';
+    $params[]  = $limit;
+    $params[]  = $offset;
+
+    $sql = "SELECT * FROM {$table}{$where_sql} ORDER BY unread_count DESC, last_message_at DESC LIMIT %d OFFSET %d";
+    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
+    $rows = $wpdb->get_results($wpdb->prepare($sql, $params), ARRAY_A);
     return is_array($rows) ? $rows : [];
+}
+
+/**
+ * Assign (or clear) a thread's agent.
+ *
+ * @param int $conversation_id Thread id.
+ * @param int $agent_id        WP user id, or 0 to unassign.
+ * @return bool
+ */
+function zignites_chat_inbox_assign_thread($conversation_id, $agent_id) {
+    global $wpdb;
+    $conversation_id = (int) $conversation_id;
+    if ($conversation_id <= 0) {
+        return false;
+    }
+    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+    $updated = $wpdb->update(
+        zignites_chat_conversations_table_name(),
+        ['agent_id' => max(0, (int) $agent_id)],
+        ['id' => $conversation_id],
+        ['%d'],
+        ['%d']
+    );
+    return $updated !== false;
 }
 
 /**
@@ -427,6 +460,7 @@ function zignites_chat_inbox_present_thread($row) {
         'unread'          => isset($row['unread_count']) ? (int) $row['unread_count'] : 0,
         'last_message_at' => isset($row['last_message_at']) ? (string) $row['last_message_at'] : '',
         'last_inbound_at' => isset($row['last_inbound_at']) ? (string) $row['last_inbound_at'] : '',
+        'agent_id'        => isset($row['agent_id']) ? (int) $row['agent_id'] : 0,
     ];
 }
 

--- a/tests/Unit/InboxAgentTest.php
+++ b/tests/Unit/InboxAgentTest.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace ZignitesChat\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class InboxAgentTest extends TestCase
+{
+    public function test_scope_to_agent_filter(): void
+    {
+        // 'all' / empty → no filter (null).
+        $this->assertNull(\zignites_chat_inbox_scope_to_agent_filter('all', 7));
+        $this->assertNull(\zignites_chat_inbox_scope_to_agent_filter('', 7));
+        // 'mine' → current user.
+        $this->assertSame(7, \zignites_chat_inbox_scope_to_agent_filter('mine', 7));
+        // 'unassigned' → 0.
+        $this->assertSame(0, \zignites_chat_inbox_scope_to_agent_filter('unassigned', 7));
+        // Numeric → that agent.
+        $this->assertSame(42, \zignites_chat_inbox_scope_to_agent_filter('42', 7));
+        // Garbage → no filter.
+        $this->assertNull(\zignites_chat_inbox_scope_to_agent_filter('bogus', 7));
+    }
+
+    public function test_agent_name(): void
+    {
+        $agents = [3 => 'Alice', 9 => 'Bob'];
+        $this->assertSame('', \zignites_chat_inbox_agent_name(0, $agents));      // unassigned
+        $this->assertSame('Alice', \zignites_chat_inbox_agent_name(3, $agents));
+        // Unknown id → fallback label (stubbed __ returns the format string).
+        $this->assertSame('User #5', \zignites_chat_inbox_agent_name(5, $agents));
+    }
+
+    public function test_present_thread_includes_agent_id(): void
+    {
+        $present = \zignites_chat_inbox_present_thread(['id' => 1, 'agent_id' => '4']);
+        $this->assertSame(4, $present['agent_id']);
+        // Absent agent_id defaults to 0 (unassigned).
+        $this->assertSame(0, \zignites_chat_inbox_present_thread(['id' => 1])['agent_id']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -146,6 +146,7 @@ require_once __DIR__ . '/../includes/cart-recovery.php';
 require_once __DIR__ . '/../includes/campaigns.php';
 require_once __DIR__ . '/../includes/inbox.php';
 require_once __DIR__ . '/../includes/inbox-capture.php';
+require_once __DIR__ . '/../includes/inbox-admin.php';
 require_once __DIR__ . '/../includes/catalog-context.php';
 require_once __DIR__ . '/../includes/rate-limiter.php';
 require_once __DIR__ . '/../includes/cod-confirmation.php';


### PR DESCRIPTION
Makes the inbox conversations' agent_id actionable — the first step of turning the two-way inbox into a team helpdesk.

- inbox.php: zignites_chat_inbox_assign_thread() storage + an agent_id filter on get_threads (null = all, 0 = unassigned, >0 = that agent); present_thread now exposes agent_id.
- inbox-admin.php: assignable-agents list (admins + shop managers), the zignites_chat_inbox_assign AJAX (claim / assign / unassign, validates the target is an eligible agent), and assignee names attached to thread
  + list responses. Pure helpers scope_to_agent_filter + agent_name.
- UI: a list filter (All / Assigned to me / Unassigned), the assignee shown on each thread row, and a Claim button + assign dropdown in the thread panel header.

3 unit tests; full suite 200 pass, PHPCS + lint + JS check clean.