### PR TITLE
Inbox canned / quick replies (T2.2)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -487,7 +487,14 @@ Build on the merged two-way inbox (P1):
       Assigned to me / Unassigned). Pure helpers `scope_to_agent_filter`,
       `agent_name`; presenter exposes `agent_id`. 3 unit tests; 200 pass,
       PHPCS + lint green.
-- [ ] T2.2 — Canned / quick replies in the inbox composer.
+- [x] T2.2 — Canned / quick replies — done on `feat/pro-inbox-canned-replies`.
+      Saved snippets (`zignites_chat_inbox_canned_replies`, [{title, body}])
+      managed via a "Manage quick replies" form on the Inbox page (one
+      "Title | Message" per line); a "Quick reply…" dropdown in the composer
+      inserts the chosen snippet into the reply box. Pure tested helpers
+      `parse_canned_replies` (string/array → normalized list, first-pipe split,
+      derives title, caps 50) + `canned_replies_to_text`. 6 unit tests; 206
+      pass, PHPCS + JS clean; settings cleaned on uninstall.
 - [ ] T2.3 — Customer context panel (order history, LTV) beside the thread.
 - [ ] T2.4 — Internal notes on a conversation.
 - [ ] T2.5 — New-message notifications (email / desktop) for agents.
@@ -513,11 +520,11 @@ Build on the merged two-way inbox (P1):
 are all built — T1.1/T1.2 merged into `pro`; T1.3 on `feat/pro-optin-capture`
 awaiting PR. Live smoke tests pending on each (user action).
 
-Tier 2 in progress: **T2.1 (agent assignment) DONE** on
-`feat/pro-inbox-agent-assignment`. Next: **T2.2 — canned / quick replies** in
-the inbox composer (a small library of saved snippets the agent can insert),
-then T2.3 customer-context panel, T2.4 internal notes, T2.5 agent
-notifications. Then Tier 3 (automation) and the quick wins — see PHASE 9.
+Tier 2 in progress: **T2.1 (agent assignment) + T2.2 (canned replies) DONE**.
+Next: **T2.3 — customer-context panel** (show the customer's order history /
+lifetime value beside the open thread, matched by phone), then T2.4 internal
+notes, T2.5 agent notifications. Then Tier 3 (automation) and the quick wins —
+see PHASE 9.
 
 The original Pro backlog is otherwise cleared into `pro`; the only blocked item
 is retiring `license-manager.php` (needs the Freemius credentials migration —

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -68,6 +68,9 @@ function zignites_chat_register_settings() {
     register_setting('zignites_chat_chatbot_group', 'zignites_chat_chatbot_icon', ['sanitize_callback' => 'zignites_chat_sanitize_text']);
     register_setting('zignites_chat_chatbot_group', 'zignites_chat_chatbot_welcome', ['sanitize_callback' => 'zignites_chat_sanitize_text']);
 
+    // Inbox — canned/quick replies.
+    register_setting('zignites_chat_inbox_group', 'zignites_chat_inbox_canned_replies', ['sanitize_callback' => 'zignites_chat_inbox_parse_canned_replies', 'default' => []]);
+
     // Cart Recovery.
     register_setting('zignites_chat_cart_recovery_group', 'zignites_chat_cart_recovery_enabled', ['sanitize_callback' => 'zignites_chat_sanitize_yes_no']);
     register_setting('zignites_chat_cart_recovery_group', 'zignites_chat_cart_recovery_delay', ['sanitize_callback' => 'zignites_chat_sanitize_int']);

--- a/admin/views/tab-inbox.php
+++ b/admin/views/tab-inbox.php
@@ -3,10 +3,21 @@ if (!defined('ABSPATH')) exit;
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals -- View partial: these variables are scoped to the render function that includes this file, not the global namespace.
 
 $zignites_chat_threads = zignites_chat_inbox_get_threads(['limit' => 100]);
+$zignites_chat_canned  = zignites_chat_inbox_get_canned_replies();
 ?>
 <p class="description">
     <?php esc_html_e('Read and reply to WhatsApp conversations with your customers. Inbound messages are captured automatically from your connected provider.', 'zignites-chat'); ?>
 </p>
+
+<details class="zignites-chat-inbox-canned-manage" style="margin:8px 0 16px;">
+    <summary style="cursor:pointer; font-weight:600;"><?php esc_html_e('Manage quick replies', 'zignites-chat'); ?></summary>
+    <form method="post" action="options.php" style="margin-top:10px;">
+        <?php settings_fields('zignites_chat_inbox_group'); ?>
+        <p class="description"><?php esc_html_e('One reply per line as "Title | Message". The title is what agents pick from the composer; the message is inserted. Lines without a "|" use the message as both.', 'zignites-chat'); ?></p>
+        <textarea name="zignites_chat_inbox_canned_replies" rows="5" class="large-text" placeholder="<?php esc_attr_e('Shipping delay | Sorry for the delay — your order ships within 24 hours.', 'zignites-chat'); ?>"><?php echo esc_textarea(zignites_chat_inbox_canned_replies_to_text($zignites_chat_canned)); ?></textarea>
+        <?php submit_button(__('Save quick replies', 'zignites-chat'), 'secondary', 'submit', true); ?>
+    </form>
+</details>
 
 <div class="zignites-chat-inbox" id="zignites-chat-inbox">
     <div class="zignites-chat-inbox-list" id="zignites-chat-inbox-list">
@@ -60,6 +71,14 @@ $zignites_chat_threads = zignites_chat_inbox_get_threads(['limit' => 100]);
             <div class="zignites-chat-inbox-window" id="zignites-chat-inbox-window"></div>
             <div class="zignites-chat-inbox-messages" id="zignites-chat-inbox-messages"></div>
             <div class="zignites-chat-inbox-composer" id="zignites-chat-inbox-composer">
+                <?php if (!empty($zignites_chat_canned)) : ?>
+                    <select id="zignites-chat-inbox-canned" class="zignites-chat-inbox-canned-select">
+                        <option value=""><?php esc_html_e('Quick reply…', 'zignites-chat'); ?></option>
+                        <?php foreach ($zignites_chat_canned as $zignites_chat_cr) : ?>
+                            <option value="<?php echo esc_attr($zignites_chat_cr['body']); ?>"><?php echo esc_html($zignites_chat_cr['title']); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                <?php endif; ?>
                 <textarea id="zignites-chat-inbox-reply" rows="2"
                           placeholder="<?php esc_attr_e('Type a reply…', 'zignites-chat'); ?>"></textarea>
                 <button type="button" class="button button-primary" id="zignites-chat-inbox-send">

--- a/assets/css/inbox.css
+++ b/assets/css/inbox.css
@@ -244,6 +244,12 @@
     min-height: 38px;
 }
 
+.zignites-chat-inbox-canned-select {
+    grid-column: 1 / -1;
+    justify-self: start;
+    max-width: 260px;
+}
+
 .zignites-chat-inbox-composer textarea:disabled {
     background: #f0f0f1;
     color: #8c8f94;

--- a/assets/js/inbox.js
+++ b/assets/js/inbox.js
@@ -23,6 +23,7 @@
         var sendEl = document.getElementById('zignites-chat-inbox-send');
         var composerNote = document.getElementById('zignites-chat-inbox-composer-note');
         var filterEl = document.getElementById('zignites-chat-inbox-filter');
+        var cannedEl = document.getElementById('zignites-chat-inbox-canned');
         var assigneeEl = document.getElementById('zignites-chat-inbox-assignee');
         var claimEl = document.getElementById('zignites-chat-inbox-claim');
         var assignSelect = document.getElementById('zignites-chat-inbox-assign-select');
@@ -290,6 +291,16 @@
         }
         if (filterEl) {
             filterEl.addEventListener('change', loadThreads);
+        }
+        if (cannedEl && replyEl) {
+            cannedEl.addEventListener('change', function () {
+                var snippet = cannedEl.value;
+                if (snippet) {
+                    replyEl.value = replyEl.value ? (replyEl.value.replace(/\s*$/, '') + ' ' + snippet) : snippet;
+                    replyEl.focus();
+                }
+                cannedEl.value = '';
+            });
         }
 
         buildAssignSelect();

--- a/includes/inbox-admin.php
+++ b/includes/inbox-admin.php
@@ -35,6 +35,96 @@ function zignites_chat_render_inbox_page() {
 }
 
 /* ---------------------------------------------------------------------------
+ * Canned / quick replies
+ * ------------------------------------------------------------------------ */
+
+/**
+ * Parse the canned-replies textarea (one "Title | Body" per line) into a
+ * normalized list of [{title, body}]. Pure.
+ *
+ * A line without a "|" is treated as body-only, with the title derived from
+ * the start of the body. Empty lines are skipped; the list is capped.
+ *
+ * @param string|array $value Raw textarea string (or an already-structured array).
+ * @return array<int, array{title:string, body:string}>
+ */
+function zignites_chat_inbox_parse_canned_replies($value) {
+    $rows = [];
+    if (is_array($value)) {
+        foreach ($value as $entry) {
+            if (is_array($entry)) {
+                $rows[] = [
+                    'title' => isset($entry['title']) ? (string) $entry['title'] : '',
+                    'body'  => isset($entry['body']) ? (string) $entry['body'] : '',
+                ];
+            }
+        }
+    } else {
+        foreach (preg_split('/\r\n|\r|\n/', (string) $value) as $line) {
+            $line = trim($line);
+            if ($line === '') {
+                continue;
+            }
+            if (strpos($line, '|') !== false) {
+                list($title, $body) = explode('|', $line, 2);
+            } else {
+                $title = '';
+                $body  = $line;
+            }
+            $rows[] = ['title' => trim($title), 'body' => trim($body)];
+        }
+    }
+
+    $out = [];
+    foreach ($rows as $row) {
+        $body = function_exists('sanitize_textarea_field') ? sanitize_textarea_field($row['body']) : trim($row['body']);
+        if ($body === '') {
+            continue;
+        }
+        $title = function_exists('sanitize_text_field') ? sanitize_text_field($row['title']) : trim($row['title']);
+        if ($title === '') {
+            // Derive a short label from the body.
+            $title = function_exists('mb_substr') ? mb_substr($body, 0, 40) : substr($body, 0, 40);
+        }
+        $out[] = ['title' => $title, 'body' => $body];
+        if (count($out) >= 50) {
+            break;
+        }
+    }
+    return $out;
+}
+
+/**
+ * Render a canned-replies list back into the "Title | Body" textarea form. Pure.
+ *
+ * @param array $entries [{title, body}].
+ * @return string
+ */
+function zignites_chat_inbox_canned_replies_to_text($entries) {
+    if (!is_array($entries)) {
+        return '';
+    }
+    $lines = [];
+    foreach ($entries as $entry) {
+        if (!is_array($entry) || empty($entry['body'])) {
+            continue;
+        }
+        $title = isset($entry['title']) ? (string) $entry['title'] : '';
+        $lines[] = ($title !== '' ? $title . ' | ' : '') . (string) $entry['body'];
+    }
+    return implode("\n", $lines);
+}
+
+/**
+ * Read the saved canned replies.
+ *
+ * @return array<int, array{title:string, body:string}>
+ */
+function zignites_chat_inbox_get_canned_replies() {
+    return zignites_chat_inbox_parse_canned_replies(get_option('zignites_chat_inbox_canned_replies', []));
+}
+
+/* ---------------------------------------------------------------------------
  * Agents (assignment)
  * ------------------------------------------------------------------------ */
 
@@ -119,7 +209,9 @@ function zignites_chat_inbox_enqueue_assets($hook) {
         'pollInterval' => (int) apply_filters('zignites_chat_inbox_poll_interval', 15000),
         'currentUser'  => get_current_user_id(),
         'agents'       => $agent_options,
+        'cannedReplies' => array_values(zignites_chat_inbox_get_canned_replies()),
         'i18n'         => [
+            'cannedInsert'  => __('Quick reply…', 'zignites-chat'),
             'assignedTo'    => __('Assigned to', 'zignites-chat'),
             'unassigned'    => __('Unassigned', 'zignites-chat'),
             'claim'         => __('Claim', 'zignites-chat'),

--- a/tests/Unit/InboxCannedRepliesTest.php
+++ b/tests/Unit/InboxCannedRepliesTest.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace ZignitesChat\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class InboxCannedRepliesTest extends TestCase
+{
+    public function test_parse_title_and_body(): void
+    {
+        $rows = \zignites_chat_inbox_parse_canned_replies("Shipping | Ships in 24h\nThanks | Thank you for your order!");
+        $this->assertCount(2, $rows);
+        $this->assertSame('Shipping', $rows[0]['title']);
+        $this->assertSame('Ships in 24h', $rows[0]['body']);
+        $this->assertSame('Thanks', $rows[1]['title']);
+    }
+
+    public function test_parse_body_only_derives_title(): void
+    {
+        $rows = \zignites_chat_inbox_parse_canned_replies('Hello there, how can we help?');
+        $this->assertCount(1, $rows);
+        $this->assertSame('Hello there, how can we help?', $rows[0]['body']);
+        $this->assertSame('Hello there, how can we help?', $rows[0]['title']);
+    }
+
+    public function test_parse_skips_blank_lines_and_empty_bodies(): void
+    {
+        $rows = \zignites_chat_inbox_parse_canned_replies("\n  \nReal | Has body\nNoBody |   ");
+        $this->assertCount(1, $rows);
+        $this->assertSame('Real', $rows[0]['title']);
+    }
+
+    public function test_parse_only_first_pipe_splits(): void
+    {
+        $rows = \zignites_chat_inbox_parse_canned_replies('Title | body with | pipes');
+        $this->assertSame('Title', $rows[0]['title']);
+        $this->assertSame('body with | pipes', $rows[0]['body']);
+    }
+
+    public function test_parse_accepts_structured_array(): void
+    {
+        $rows = \zignites_chat_inbox_parse_canned_replies([
+            ['title' => 'A', 'body' => 'Body A'],
+            ['title' => '', 'body' => ''], // dropped (empty body)
+        ]);
+        $this->assertCount(1, $rows);
+        $this->assertSame('A', $rows[0]['title']);
+    }
+
+    public function test_to_text_round_trips(): void
+    {
+        $entries = [
+            ['title' => 'Shipping', 'body' => 'Ships in 24h'],
+            ['title' => '', 'body' => 'Plain body'],
+        ];
+        $text = \zignites_chat_inbox_canned_replies_to_text($entries);
+        $this->assertSame("Shipping | Ships in 24h\nPlain body", $text);
+    }
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -92,6 +92,7 @@ $zignites_chat_option_keys = [
     'zignites_chat_optin_default_checked',
     'zignites_chat_optin_required',
     'zignites_chat_optin_log',
+    'zignites_chat_inbox_canned_replies',
 ];
 
 foreach ($zignites_chat_option_keys as $zignites_chat_key) {


### PR DESCRIPTION
Lets agents insert saved snippets into the reply composer.

- includes/inbox-admin.php: zignites_chat_inbox_canned_replies option ([{title, body}]) with pure, tested helpers parse_canned_replies (string "Title | Message" lines or a structured array → normalized list; first-pipe split, derives a title, caps 50) and canned_replies_to_text for the editor round-trip.
- A "Manage quick replies" form on the Inbox page (options.php) and a "Quick reply…" dropdown in the composer that inserts the chosen snippet into the reply box.
- Setting registered + cleaned on uninstall.

6 unit tests; full suite 206 pass, PHPCS + JS check clean.