### PR TITLE
Inbox customer context panel (T2.3)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -495,7 +495,13 @@ Build on the merged two-way inbox (P1):
       `parse_canned_replies` (string/array → normalized list, first-pipe split,
       derives title, caps 50) + `canned_replies_to_text`. 6 unit tests; 206
       pass, PHPCS + JS clean; settings cleaned on uninstall.
-- [ ] T2.3 — Customer context panel (order history, LTV) beside the thread.
+- [x] T2.3 — Customer context panel — done on `feat/pro-inbox-customer-context`.
+      Opening a thread loads a context strip (orders count, lifetime spend,
+      recent orders with edit links) via AJAX `zignites_chat_inbox_context`.
+      Orders matched by a last-9-digits `_billing_phone` LIKE query (HPOS-safe)
+      then verified with the suffix matcher; aggregated by the pure, tested
+      `aggregate_customer_context` (count/sum/recent-limit). 3 unit tests; 209
+      pass, PHPCS + JS clean.
 - [ ] T2.4 — Internal notes on a conversation.
 - [ ] T2.5 — New-message notifications (email / desktop) for agents.
 
@@ -520,11 +526,11 @@ Build on the merged two-way inbox (P1):
 are all built — T1.1/T1.2 merged into `pro`; T1.3 on `feat/pro-optin-capture`
 awaiting PR. Live smoke tests pending on each (user action).
 
-Tier 2 in progress: **T2.1 (agent assignment) + T2.2 (canned replies) DONE**.
-Next: **T2.3 — customer-context panel** (show the customer's order history /
-lifetime value beside the open thread, matched by phone), then T2.4 internal
-notes, T2.5 agent notifications. Then Tier 3 (automation) and the quick wins —
-see PHASE 9.
+Tier 2 in progress: **T2.1 (assignment) + T2.2 (canned replies) + T2.3
+(customer context) DONE**. Next: **T2.4 — internal notes** on a conversation
+(agent-only notes stored per thread, shown inline but never sent to the
+customer), then T2.5 agent notifications. Then Tier 3 (automation) and the
+quick wins — see PHASE 9.
 
 The original Pro backlog is otherwise cleared into `pro`; the only blocked item
 is retiring `license-manager.php` (needs the Freemius credentials migration —

--- a/admin/views/tab-inbox.php
+++ b/admin/views/tab-inbox.php
@@ -68,6 +68,7 @@ $zignites_chat_canned  = zignites_chat_inbox_get_canned_replies();
                     <select id="zignites-chat-inbox-assign-select"></select>
                 </span>
             </div>
+            <div class="zignites-chat-inbox-context" id="zignites-chat-inbox-context" style="display:none;"></div>
             <div class="zignites-chat-inbox-window" id="zignites-chat-inbox-window"></div>
             <div class="zignites-chat-inbox-messages" id="zignites-chat-inbox-messages"></div>
             <div class="zignites-chat-inbox-composer" id="zignites-chat-inbox-composer">

--- a/assets/css/inbox.css
+++ b/assets/css/inbox.css
@@ -178,6 +178,32 @@
     font-size: 12px;
 }
 
+.zignites-chat-inbox-context {
+    padding: 8px 16px;
+    border-bottom: 1px solid #f0f0f1;
+    background: #fbfbfc;
+    font-size: 12px;
+    color: #50575e;
+}
+
+.zignites-chat-inbox-context-summary {
+    font-weight: 600;
+    color: #1d2327;
+}
+
+.zignites-chat-inbox-context-orders {
+    margin: 4px 0 0;
+    padding: 0;
+    list-style: none;
+}
+
+.zignites-chat-inbox-context-orders li {
+    margin: 2px 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .zignites-chat-inbox-window {
     padding: 6px 16px;
     font-size: 12px;

--- a/assets/js/inbox.js
+++ b/assets/js/inbox.js
@@ -19,6 +19,7 @@
         var phoneEl = document.getElementById('zignites-chat-inbox-thread-phone');
         var windowEl = document.getElementById('zignites-chat-inbox-window');
         var messagesEl = document.getElementById('zignites-chat-inbox-messages');
+        var contextEl = document.getElementById('zignites-chat-inbox-context');
         var replyEl = document.getElementById('zignites-chat-inbox-reply');
         var sendEl = document.getElementById('zignites-chat-inbox-send');
         var composerNote = document.getElementById('zignites-chat-inbox-composer-note');
@@ -149,6 +150,52 @@
             });
         }
 
+        // --- Customer context ------------------------------------------------
+
+        function renderContext(ctx) {
+            if (!contextEl) return;
+            contextEl.innerHTML = '';
+            contextEl.style.display = '';
+            if (!ctx || !ctx.order_count) {
+                contextEl.textContent = i18n.ctxNoOrders || '';
+                return;
+            }
+
+            var summary = document.createElement('div');
+            summary.className = 'zignites-chat-inbox-context-summary';
+            summary.textContent = (i18n.ctxOrders || '') + ': ' + ctx.order_count + '  ·  ' + (i18n.ctxSpent || '') + ': ' + (ctx.total_spent || '');
+            contextEl.appendChild(summary);
+
+            if (ctx.orders && ctx.orders.length) {
+                var list = document.createElement('ul');
+                list.className = 'zignites-chat-inbox-context-orders';
+                ctx.orders.forEach(function (o) {
+                    var li = document.createElement('li');
+                    var a = document.createElement('a');
+                    a.href = o.edit_url;
+                    a.target = '_blank';
+                    a.rel = 'noopener';
+                    a.textContent = '#' + o.number;
+                    li.appendChild(a);
+                    var meta = document.createElement('span');
+                    meta.textContent = ' · ' + o.total + ' · ' + o.status + ' · ' + o.date;
+                    li.appendChild(meta);
+                    list.appendChild(li);
+                });
+                contextEl.appendChild(list);
+            }
+        }
+
+        function loadContext(id) {
+            if (!contextEl) return;
+            contextEl.style.display = 'none';
+            ajaxGet('zignites_chat_inbox_context', { conversation_id: id }).then(function (res) {
+                if (res && res.success) {
+                    renderContext(res.data.context);
+                }
+            }).catch(function () { /* context is best-effort */ });
+        }
+
         function assign(agentId) {
             if (!activeId) return;
             ajaxPost('zignites_chat_inbox_assign', { conversation_id: activeId, agent_id: agentId }).then(function (res) {
@@ -254,6 +301,7 @@
                 phoneEl.textContent = t.phone || '';
                 renderAssignment(t.agent_id, t.agentName);
                 renderWindow(!!t.windowOpen);
+                loadContext(id);
 
                 messagesEl.innerHTML = '';
                 if (!res.data.messages.length) {

--- a/includes/inbox-admin.php
+++ b/includes/inbox-admin.php
@@ -35,6 +35,144 @@ function zignites_chat_render_inbox_page() {
 }
 
 /* ---------------------------------------------------------------------------
+ * Customer context (order history beside the thread)
+ * ------------------------------------------------------------------------ */
+
+/**
+ * Aggregate plain order rows into a customer-context summary. Pure.
+ *
+ * @param array $rows Each: ['id','number','status','date','total'(float),'edit_url'].
+ * @param int   $recent_limit How many recent orders to include in the list.
+ * @return array{order_count:int, total_spent:float, orders:array<int,array>}
+ */
+function zignites_chat_inbox_aggregate_customer_context($rows, $recent_limit = 5) {
+    if (!is_array($rows)) {
+        $rows = [];
+    }
+    $count = 0;
+    $total = 0.0;
+    foreach ($rows as $row) {
+        if (!is_array($row)) {
+            continue;
+        }
+        $count++;
+        $total += isset($row['total']) ? (float) $row['total'] : 0.0;
+    }
+    $recent_limit = max(0, (int) $recent_limit);
+    return [
+        'order_count' => $count,
+        'total_spent' => $total,
+        'orders'      => array_slice(array_values(array_filter($rows, 'is_array')), 0, $recent_limit),
+    ];
+}
+
+/**
+ * Build a customer-context summary for a phone from recent WooCommerce orders.
+ *
+ * Orders are matched by a last-digits LIKE query (tolerant of formatting /
+ * country code), then verified with the suffix matcher, then aggregated.
+ *
+ * @param string $phone Customer phone (any format).
+ * @return array Presented context (formatted strings) or an empty shell.
+ */
+function zignites_chat_inbox_get_customer_context($phone) {
+    $empty = ['order_count' => 0, 'total_spent' => '', 'orders' => []];
+    $digits = function_exists('zignites_chat_normalize_phone') ? zignites_chat_normalize_phone($phone) : preg_replace('/[^0-9]/', '', (string) $phone);
+    if ($digits === '' || !function_exists('wc_get_orders')) {
+        return $empty;
+    }
+
+    $suffix = substr($digits, -9);
+    $limit  = (int) apply_filters('zignites_chat_inbox_context_order_limit', 50);
+
+    $orders = wc_get_orders([
+        'limit'      => max(1, $limit),
+        'orderby'    => 'date',
+        'order'      => 'DESC',
+        'return'     => 'objects',
+        'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+            [
+                'key'     => '_billing_phone',
+                'value'   => $suffix,
+                'compare' => 'LIKE',
+            ],
+        ],
+    ]);
+    if (empty($orders) || !is_array($orders)) {
+        return $empty;
+    }
+
+    $rows = [];
+    foreach ($orders as $order) {
+        if (!is_object($order)) {
+            continue;
+        }
+        // Verify (drops a coincidental last-digits LIKE collision).
+        if (function_exists('zignites_chat_cod_phone_matches')
+            && !zignites_chat_cod_phone_matches($digits, $order->get_billing_phone())) {
+            continue;
+        }
+        $date = $order->get_date_created();
+        $rows[] = [
+            'id'       => $order->get_id(),
+            'number'   => $order->get_order_number(),
+            'status'   => function_exists('wc_get_order_status_name') ? wc_get_order_status_name($order->get_status()) : $order->get_status(),
+            'date'     => $date ? $date->date_i18n(get_option('date_format')) : '',
+            'total'    => (float) $order->get_total(),
+            'edit_url' => method_exists($order, 'get_edit_order_url') ? $order->get_edit_order_url() : admin_url('post.php?post=' . $order->get_id() . '&action=edit'),
+        ];
+    }
+
+    $agg = zignites_chat_inbox_aggregate_customer_context($rows);
+
+    $format = static function ($amount) {
+        if (function_exists('wc_price')) {
+            return html_entity_decode(wp_strip_all_tags(wc_price($amount)), ENT_QUOTES, 'UTF-8');
+        }
+        return number_format((float) $amount, 2);
+    };
+
+    $orders_out = [];
+    foreach ($agg['orders'] as $row) {
+        $orders_out[] = [
+            'id'       => (int) $row['id'],
+            'number'   => (string) $row['number'],
+            'status'   => (string) $row['status'],
+            'date'     => (string) $row['date'],
+            'total'    => $format($row['total']),
+            'edit_url' => esc_url_raw($row['edit_url']),
+        ];
+    }
+
+    return [
+        'order_count' => (int) $agg['order_count'],
+        'total_spent' => $format($agg['total_spent']),
+        'orders'      => $orders_out,
+    ];
+}
+
+add_action('wp_ajax_zignites_chat_inbox_context', 'zignites_chat_ajax_inbox_context');
+function zignites_chat_ajax_inbox_context() {
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error(['message' => __('Unauthorized', 'zignites-chat')], 403);
+    }
+    if (!check_ajax_referer('zignites_chat_inbox', 'nonce', false)) {
+        wp_send_json_error(['message' => __('Bad nonce', 'zignites-chat')], 400);
+    }
+    if (!zignites_chat_is_pro_active()) {
+        wp_send_json_error(['message' => __('Pro required', 'zignites-chat')], 403);
+    }
+
+    $conversation_id = isset($_GET['conversation_id']) ? (int) $_GET['conversation_id'] : 0;
+    $thread = zignites_chat_inbox_get_thread($conversation_id);
+    if ($thread === null) {
+        wp_send_json_error(['message' => __('Not found', 'zignites-chat')], 404);
+    }
+
+    wp_send_json_success(['context' => zignites_chat_inbox_get_customer_context($thread['phone'])]);
+}
+
+/* ---------------------------------------------------------------------------
  * Canned / quick replies
  * ------------------------------------------------------------------------ */
 
@@ -212,6 +350,11 @@ function zignites_chat_inbox_enqueue_assets($hook) {
         'cannedReplies' => array_values(zignites_chat_inbox_get_canned_replies()),
         'i18n'         => [
             'cannedInsert'  => __('Quick reply…', 'zignites-chat'),
+            'ctxOrders'     => __('Orders', 'zignites-chat'),
+            'ctxSpent'      => __('Lifetime', 'zignites-chat'),
+            'ctxNoOrders'   => __('No matching orders found.', 'zignites-chat'),
+            'ctxRecent'     => __('Recent orders', 'zignites-chat'),
+            'ctxView'       => __('View', 'zignites-chat'),
             'assignedTo'    => __('Assigned to', 'zignites-chat'),
             'unassigned'    => __('Unassigned', 'zignites-chat'),
             'claim'         => __('Claim', 'zignites-chat'),

--- a/tests/Unit/InboxCustomerContextTest.php
+++ b/tests/Unit/InboxCustomerContextTest.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace ZignitesChat\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class InboxCustomerContextTest extends TestCase
+{
+    public function test_aggregate_counts_and_sums(): void
+    {
+        $rows = [
+            ['id' => 3, 'total' => 25.50, 'status' => 'Processing'],
+            ['id' => 2, 'total' => 10.00, 'status' => 'Completed'],
+            ['id' => 1, 'total' => 4.50,  'status' => 'Completed'],
+        ];
+        $agg = \zignites_chat_inbox_aggregate_customer_context($rows);
+        $this->assertSame(3, $agg['order_count']);
+        $this->assertSame(40.0, $agg['total_spent']);
+        $this->assertCount(3, $agg['orders']);
+    }
+
+    public function test_aggregate_respects_recent_limit(): void
+    {
+        $rows = [];
+        for ($i = 0; $i < 8; $i++) {
+            $rows[] = ['id' => $i, 'total' => 1.0];
+        }
+        $agg = \zignites_chat_inbox_aggregate_customer_context($rows, 5);
+        $this->assertSame(8, $agg['order_count']);   // count all
+        $this->assertCount(5, $agg['orders']);       // list only the recent N
+        $this->assertSame(8.0, $agg['total_spent']);
+    }
+
+    public function test_aggregate_handles_empty_and_garbage(): void
+    {
+        $agg = \zignites_chat_inbox_aggregate_customer_context([]);
+        $this->assertSame(0, $agg['order_count']);
+        $this->assertSame(0.0, $agg['total_spent']);
+        $this->assertSame([], $agg['orders']);
+
+        $agg2 = \zignites_chat_inbox_aggregate_customer_context('nope');
+        $this->assertSame(0, $agg2['order_count']);
+
+        // Non-array rows are skipped, missing totals count as 0.
+        $agg3 = \zignites_chat_inbox_aggregate_customer_context([
+            'bad',
+            ['id' => 1], // no total
+        ]);
+        $this->assertSame(1, $agg3['order_count']);
+        $this->assertSame(0.0, $agg3['total_spent']);
+    }
+}


### PR DESCRIPTION
Shows the customer's order history beside the open conversation so agents have context without leaving the inbox.

- includes/inbox-admin.php: zignites_chat_inbox_get_customer_context() matches orders by a last-9-digits _billing_phone LIKE query (HPOS-safe, tolerant of formatting/country code), verifies each with the suffix matcher, and aggregates via the pure, tested aggregate_customer_context() (order count, lifetime spend, recent orders). AJAX zignites_chat_inbox_context (cap + nonce + Pro).
- A context strip under the thread header shows orders / lifetime spend and recent orders with edit links, loaded on thread open.

3 unit tests; full suite 209 pass, PHPCS + JS check clean.