### PR TITLE
Inbox internal notes (T2.4)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -502,7 +502,14 @@ Build on the merged two-way inbox (P1):
       then verified with the suffix matcher; aggregated by the pure, tested
       `aggregate_customer_context` (count/sum/recent-limit). 3 unit tests; 209
       pass, PHPCS + JS clean.
-- [ ] T2.4 — Internal notes on a conversation.
+- [x] T2.4 — Internal notes — done on `feat/pro-inbox-internal-notes`. Notes
+      are stored as message rows with `direction='note'` + a new `author_id`
+      column (migration v7: widen `direction` to VARCHAR(8) + add the column),
+      so they interleave inline and polling picks them up, but never touch the
+      thread's customer-facing aggregates or get sent. `add_note` storage; AJAX
+      `zignites_chat_inbox_note`; composer "Internal note" toggle (works even
+      when the 24h window is closed) with distinct note styling + author label.
+      2 unit tests (note direction + author_id); 211 pass, PHPCS + JS clean.
 - [ ] T2.5 — New-message notifications (email / desktop) for agents.
 
 ### Tier 3 — platform / automation
@@ -526,11 +533,11 @@ Build on the merged two-way inbox (P1):
 are all built — T1.1/T1.2 merged into `pro`; T1.3 on `feat/pro-optin-capture`
 awaiting PR. Live smoke tests pending on each (user action).
 
-Tier 2 in progress: **T2.1 (assignment) + T2.2 (canned replies) + T2.3
-(customer context) DONE**. Next: **T2.4 — internal notes** on a conversation
-(agent-only notes stored per thread, shown inline but never sent to the
-customer), then T2.5 agent notifications. Then Tier 3 (automation) and the
-quick wins — see PHASE 9.
+Tier 2 in progress: **T2.1–T2.4 DONE** (assignment, canned replies, customer
+context, internal notes). Next, the last Tier 2 item: **T2.5 — agent
+notifications** (email a relevant agent when a new inbound message arrives —
+the assigned agent, or all managers when unassigned; throttled to avoid spam).
+Then Tier 3 (automation) and the quick wins — see PHASE 9.
 
 The original Pro backlog is otherwise cleared into `pro`; the only blocked item
 is retiring `license-manager.php` (needs the Freemius credentials migration —

--- a/admin/views/tab-inbox.php
+++ b/admin/views/tab-inbox.php
@@ -85,6 +85,10 @@ $zignites_chat_canned  = zignites_chat_inbox_get_canned_replies();
                 <button type="button" class="button button-primary" id="zignites-chat-inbox-send">
                     <?php esc_html_e('Send', 'zignites-chat'); ?>
                 </button>
+                <label class="zignites-chat-inbox-note-toggle">
+                    <input type="checkbox" id="zignites-chat-inbox-note-mode" />
+                    <?php esc_html_e('Internal note (not sent to customer)', 'zignites-chat'); ?>
+                </label>
                 <p class="zignites-chat-inbox-composer-note" id="zignites-chat-inbox-composer-note"></p>
             </div>
         </div>

--- a/assets/css/inbox.css
+++ b/assets/css/inbox.css
@@ -245,6 +245,22 @@
     margin-left: auto;
 }
 
+.zignites-chat-inbox-message.is-note {
+    background: #fcf8e3;
+    border: 1px solid #f5e6a8;
+    margin: 0 auto 10px;
+    max-width: 85%;
+}
+
+.zignites-chat-inbox-note-toggle {
+    grid-column: 1 / -1;
+    font-size: 12px;
+    color: #50575e;
+    display: flex;
+    gap: 6px;
+    align-items: center;
+}
+
 .zignites-chat-inbox-message-body {
     white-space: pre-wrap;
 }

--- a/assets/js/inbox.js
+++ b/assets/js/inbox.js
@@ -25,6 +25,7 @@
         var composerNote = document.getElementById('zignites-chat-inbox-composer-note');
         var filterEl = document.getElementById('zignites-chat-inbox-filter');
         var cannedEl = document.getElementById('zignites-chat-inbox-canned');
+        var noteModeEl = document.getElementById('zignites-chat-inbox-note-mode');
         var assigneeEl = document.getElementById('zignites-chat-inbox-assignee');
         var claimEl = document.getElementById('zignites-chat-inbox-claim');
         var assignSelect = document.getElementById('zignites-chat-inbox-assign-select');
@@ -209,8 +210,9 @@
         // --- Thread view -----------------------------------------------------
 
         function messageEl(m) {
+            var isNote = m.direction === 'note';
             var wrap = document.createElement('div');
-            wrap.className = 'zignites-chat-inbox-message is-' + (m.direction === 'in' ? 'in' : 'out');
+            wrap.className = 'zignites-chat-inbox-message is-' + (isNote ? 'note' : (m.direction === 'in' ? 'in' : 'out'));
 
             var body = document.createElement('div');
             body.className = 'zignites-chat-inbox-message-body';
@@ -219,7 +221,12 @@
 
             var meta = document.createElement('div');
             meta.className = 'zignites-chat-inbox-message-meta';
-            var who = (m.direction === 'in') ? (i18n.customer || '') : (i18n.you || '');
+            var who;
+            if (isNote) {
+                who = (i18n.noteLabel || '') + (m.authorName ? ' · ' + m.authorName : '');
+            } else {
+                who = (m.direction === 'in') ? (i18n.customer || '') : (i18n.you || '');
+            }
             meta.textContent = who + ' · ' + (m.created_at || '');
             wrap.appendChild(meta);
             return wrap;
@@ -233,23 +240,64 @@
             messagesEl.scrollTop = messagesEl.scrollHeight;
         }
 
+        function noteModeOn() {
+            return !!(noteModeEl && noteModeEl.checked);
+        }
+
+        // Composer is usable when the 24h window is open OR the agent is writing
+        // an internal note (notes are never sent to the customer).
+        function updateComposerState() {
+            var enabled = windowOpen || noteModeOn();
+            if (replyEl) replyEl.disabled = !enabled;
+            if (sendEl) {
+                sendEl.disabled = !enabled;
+                sendEl.textContent = noteModeOn() ? (i18n.addNote || '') : (i18n.send || '');
+            }
+            if (composerNote) {
+                composerNote.textContent = enabled ? '' : (i18n.windowClosedNote || '');
+            }
+        }
+
         function renderWindow(open) {
             windowOpen = !!open;
             windowEl.className = 'zignites-chat-inbox-window ' + (open ? 'is-open' : 'is-closed');
             windowEl.textContent = open ? (i18n.windowOpen || '') : (i18n.windowClosed || '');
-            // Disable the composer when the 24h window has closed.
-            if (replyEl) replyEl.disabled = !open;
-            if (sendEl) sendEl.disabled = !open;
-            if (composerNote) composerNote.textContent = open ? '' : (i18n.windowClosedNote || '');
+            updateComposerState();
+        }
+
+        function addNote(text) {
+            sendEl.disabled = true;
+            ajaxPost('zignites_chat_inbox_note', { conversation_id: activeId, body: text }).then(function (res) {
+                updateComposerState();
+                if (!res || !res.success) {
+                    if (composerNote) composerNote.textContent = (res && res.data && res.data.message) || (i18n.noteError || '');
+                    return;
+                }
+                replyEl.value = '';
+                if (res.data.message && res.data.message.id) {
+                    var ph = messagesEl.querySelector('.zignites-chat-inbox-empty');
+                    if (ph) ph.remove();
+                    appendMessages([res.data.message]);
+                }
+            }).catch(function () {
+                updateComposerState();
+                if (composerNote) composerNote.textContent = i18n.noteError || '';
+            });
         }
 
         function sendReply() {
-            if (!activeId || !windowOpen) return;
+            if (!activeId) return;
             var text = replyEl ? replyEl.value.trim() : '';
             if (!text) {
-                if (composerNote) composerNote.textContent = i18n.replyEmpty || '';
+                if (composerNote) composerNote.textContent = noteModeOn() ? (i18n.noteEmpty || '') : (i18n.replyEmpty || '');
                 return;
             }
+            if (noteModeOn()) {
+                if (composerNote) composerNote.textContent = '';
+                addNote(text);
+                return;
+            }
+            if (!windowOpen) return;
             sendEl.disabled = true;
             sendEl.textContent = i18n.sending || '';
             if (composerNote) composerNote.textContent = '';
@@ -339,6 +387,9 @@
         }
         if (filterEl) {
             filterEl.addEventListener('change', loadThreads);
+        }
+        if (noteModeEl) {
+            noteModeEl.addEventListener('change', updateComposerState);
         }
         if (cannedEl && replyEl) {
             cannedEl.addEventListener('change', function () {

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -117,6 +117,7 @@ function zignites_chat_get_migrations() {
         4 => 'zignites_chat_migration_v4_campaign_scheduled_at',
         5 => 'zignites_chat_migration_v5_campaign_media',
         6 => 'zignites_chat_migration_v6_inbox_tables',
+        7 => 'zignites_chat_migration_v7_inbox_notes',
     ];
 }
 
@@ -203,6 +204,17 @@ function zignites_chat_migration_v5_campaign_media() {
  * boot_modules() runs, and the activation hook re-creates the tables too.
  */
 function zignites_chat_migration_v6_inbox_tables() {
+    if (function_exists('zignites_chat_create_inbox_tables')) {
+        zignites_chat_create_inbox_tables();
+    }
+}
+
+/**
+ * v7: widen messages.direction (for the 'note' value) and add
+ * messages.author_id for internal agent notes. Idempotent dbDelta re-run,
+ * same guard shape as v6.
+ */
+function zignites_chat_migration_v7_inbox_notes() {
     if (function_exists('zignites_chat_create_inbox_tables')) {
         zignites_chat_create_inbox_tables();
     }

--- a/includes/inbox-admin.php
+++ b/includes/inbox-admin.php
@@ -355,6 +355,11 @@ function zignites_chat_inbox_enqueue_assets($hook) {
             'ctxNoOrders'   => __('No matching orders found.', 'zignites-chat'),
             'ctxRecent'     => __('Recent orders', 'zignites-chat'),
             'ctxView'       => __('View', 'zignites-chat'),
+            'noteToggle'    => __('Internal note', 'zignites-chat'),
+            'noteLabel'     => __('Note', 'zignites-chat'),
+            'addNote'       => __('Add note', 'zignites-chat'),
+            'noteEmpty'     => __('Type a note before saving.', 'zignites-chat'),
+            'noteError'     => __('Could not save the note.', 'zignites-chat'),
             'assignedTo'    => __('Assigned to', 'zignites-chat'),
             'unassigned'    => __('Unassigned', 'zignites-chat'),
             'claim'         => __('Claim', 'zignites-chat'),
@@ -448,7 +453,7 @@ function zignites_chat_ajax_inbox_thread() {
     $rows = zignites_chat_inbox_get_messages($conversation_id, ['after_id' => $after_id]);
     $messages = [];
     foreach ($rows as $row) {
-        $messages[] = zignites_chat_inbox_present_message($row);
+        $messages[] = zignites_chat_inbox_present_message_decorated($row);
     }
 
     // Opening (or polling) a thread clears its unread badge. Only do so on the
@@ -502,6 +507,77 @@ function zignites_chat_ajax_inbox_assign() {
     wp_send_json_success([
         'agent_id'  => $agent_id,
         'agentName' => zignites_chat_inbox_agent_name($agent_id, zignites_chat_inbox_assignable_agents()),
+    ]);
+}
+
+/**
+ * Resolve a note author's display name.
+ *
+ * @param int $author_id
+ * @return string
+ */
+function zignites_chat_inbox_author_name($author_id) {
+    $author_id = (int) $author_id;
+    if ($author_id <= 0) {
+        return '';
+    }
+    $user = get_userdata($author_id);
+    if ($user) {
+        return (string) $user->display_name;
+    }
+    /* translators: %d: WordPress user id. */
+    return sprintf(__('User #%d', 'zignites-chat'), $author_id);
+}
+
+/**
+ * Present a message row, attaching the author name for internal notes.
+ *
+ * @param array $row
+ * @return array
+ */
+function zignites_chat_inbox_present_message_decorated($row) {
+    $message = zignites_chat_inbox_present_message($row);
+    if (isset($message['direction']) && $message['direction'] === 'note') {
+        $message['authorName'] = zignites_chat_inbox_author_name($message['author_id'] ?? 0);
+    }
+    return $message;
+}
+
+/* ---------------------------------------------------------------------------
+ * AJAX — add an internal note
+ * ------------------------------------------------------------------------ */
+
+add_action('wp_ajax_zignites_chat_inbox_note', 'zignites_chat_ajax_inbox_note');
+function zignites_chat_ajax_inbox_note() {
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error(['message' => __('Unauthorized', 'zignites-chat')], 403);
+    }
+    if (!check_ajax_referer('zignites_chat_inbox', 'nonce', false)) {
+        wp_send_json_error(['message' => __('Bad nonce', 'zignites-chat')], 400);
+    }
+    if (!zignites_chat_is_pro_active()) {
+        wp_send_json_error(['message' => __('Pro required', 'zignites-chat')], 403);
+    }
+
+    $conversation_id = isset($_POST['conversation_id']) ? (int) $_POST['conversation_id'] : 0;
+    $body            = isset($_POST['body']) ? sanitize_textarea_field(wp_unslash($_POST['body'])) : '';
+    if ($body === '') {
+        wp_send_json_error(['message' => __('Type a note before saving.', 'zignites-chat')], 422);
+    }
+
+    $note_id = zignites_chat_inbox_add_note($conversation_id, $body, get_current_user_id());
+    if ($note_id <= 0) {
+        wp_send_json_error(['message' => __('Could not save the note.', 'zignites-chat')], 500);
+    }
+
+    wp_send_json_success([
+        'message' => zignites_chat_inbox_present_message_decorated([
+            'id'         => $note_id,
+            'direction'  => 'note',
+            'body'       => $body,
+            'author_id'  => get_current_user_id(),
+            'created_at' => current_time('mysql'),
+        ]),
     ]);
 }
 

--- a/includes/inbox.php
+++ b/includes/inbox.php
@@ -79,11 +79,12 @@ function zignites_chat_create_inbox_tables() {
         id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
         conversation_id BIGINT UNSIGNED NOT NULL,
         phone VARCHAR(40) NOT NULL,
-        direction VARCHAR(3) NOT NULL,
+        direction VARCHAR(8) NOT NULL,
         body TEXT NULL,
         provider VARCHAR(20) NOT NULL DEFAULT '',
         message_id VARCHAR(190) NOT NULL DEFAULT '',
         status VARCHAR(20) NOT NULL DEFAULT '',
+        author_id BIGINT UNSIGNED NOT NULL DEFAULT 0,
         created_at DATETIME NOT NULL,
         PRIMARY KEY  (id),
         KEY conversation_created (conversation_id, created_at),
@@ -102,17 +103,23 @@ function zignites_chat_create_inbox_tables() {
 /**
  * Normalize a free-form direction string to the stored 'in'/'out' enum.
  *
- * Inbound (customer → store) maps to 'in'; everything else (the store's
- * outbound sends) maps to 'out'. Callers pass known values; the catch-all
+ * Inbound (customer → store) maps to 'in'; internal agent notes map to 'note';
+ * everything else (the store's outbound sends) maps to 'out'. The catch-all
  * 'out' default keeps a typo from being recorded as a customer message and
  * inflating the unread badge.
  *
- * @param string $direction Raw direction (in/inbound/incoming or out/...).
- * @return string 'in' or 'out'.
+ * @param string $direction Raw direction (in/inbound/incoming, note, or out/...).
+ * @return string 'in' | 'out' | 'note'.
  */
 function zignites_chat_inbox_normalize_direction($direction) {
     $direction = strtolower(trim((string) $direction));
-    return in_array($direction, ['in', 'inbound', 'incoming', 'received'], true) ? 'in' : 'out';
+    if (in_array($direction, ['in', 'inbound', 'incoming', 'received'], true)) {
+        return 'in';
+    }
+    if ($direction === 'note') {
+        return 'note';
+    }
+    return 'out';
 }
 
 /**
@@ -439,6 +446,46 @@ function zignites_chat_inbox_mark_read($conversation_id) {
 }
 
 /**
+ * Add an internal agent note to a thread.
+ *
+ * Stored as a message row with direction 'note' and the author's user id. Notes
+ * interleave with messages chronologically but never touch the conversation's
+ * customer-facing aggregates (last_excerpt / unread / last_message_at) and are
+ * never sent to the customer.
+ *
+ * @param int    $conversation_id Thread id.
+ * @param string $body            Note text.
+ * @param int    $author_id       WP user id of the author.
+ * @return int Inserted row id, or 0 on failure.
+ */
+function zignites_chat_inbox_add_note($conversation_id, $body, $author_id) {
+    global $wpdb;
+    $conversation_id = (int) $conversation_id;
+    $body = zignites_chat_sanitize_textarea($body);
+    if ($conversation_id <= 0 || $body === '') {
+        return 0;
+    }
+    $thread = zignites_chat_inbox_get_thread($conversation_id);
+    if ($thread === null) {
+        return 0;
+    }
+    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+    $wpdb->insert(
+        zignites_chat_messages_table_name(),
+        [
+            'conversation_id' => $conversation_id,
+            'phone'           => (string) $thread['phone'],
+            'direction'       => 'note',
+            'body'            => $body,
+            'author_id'       => max(0, (int) $author_id),
+            'created_at'      => current_time('mysql'),
+        ],
+        ['%d', '%s', '%s', '%s', '%d', '%s']
+    );
+    return (int) $wpdb->insert_id;
+}
+
+/**
  * Shape a conversation DB row into the array the admin/AJAX layer returns.
  *
  * Pure (no DB) so it can be unit-tested. Casts types and only exposes the
@@ -482,6 +529,7 @@ function zignites_chat_inbox_present_message($row) {
         'body'       => isset($row['body']) ? (string) $row['body'] : '',
         'status'     => isset($row['status']) ? (string) $row['status'] : '',
         'created_at' => isset($row['created_at']) ? (string) $row['created_at'] : '',
+        'author_id'  => isset($row['author_id']) ? (int) $row['author_id'] : 0,
     ];
 }
 

--- a/tests/Unit/InboxTest.php
+++ b/tests/Unit/InboxTest.php
@@ -158,4 +158,24 @@ final class InboxTest extends TestCase
         $this->assertSame('out', \zignites_chat_inbox_present_message(['direction' => 'garbage'])['direction']);
         $this->assertSame([], \zignites_chat_inbox_present_message(null));
     }
+
+    public function test_normalize_direction_recognizes_note(): void
+    {
+        $this->assertSame('note', \zignites_chat_inbox_normalize_direction('note'));
+        $this->assertSame('note', \zignites_chat_inbox_normalize_direction(' NOTE '));
+    }
+
+    public function test_present_message_carries_note_and_author(): void
+    {
+        $present = \zignites_chat_inbox_present_message([
+            'id'        => 5,
+            'direction' => 'note',
+            'body'      => 'Called the carrier',
+            'author_id' => '12',
+        ]);
+        $this->assertSame('note', $present['direction']);
+        $this->assertSame(12, $present['author_id']);
+        // Default author_id is 0 when absent.
+        $this->assertSame(0, \zignites_chat_inbox_present_message(['id' => 1])['author_id']);
+    }
 }


### PR DESCRIPTION
Lets agents leave private notes on a conversation — visible in the thread, never sent to the customer.

- Notes are stored as message rows with direction='note' and a new author_id column, so they interleave with messages chronologically and the existing poll picks them up. They never touch the thread's customer-facing aggregates (excerpt / unread / last_message_at).
- Schema: migration v7 widens messages.direction to VARCHAR(8) (to hold 'note') and adds author_id; idempotent dbDelta re-run.
- inbox.php: zignites_chat_inbox_add_note(); normalize_direction now recognizes 'note'; present_message carries author_id.
- inbox-admin.php: AJAX zignites_chat_inbox_note + author-name resolution for note rows.
- UI: an "Internal note" composer toggle (usable even when the 24h window is closed) with distinct note styling and the author label.

2 unit tests; full suite 211 pass, PHPCS + JS check clean.