### PR TITLE
Inbox agent email notifications (T2.5)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -510,7 +510,14 @@ Build on the merged two-way inbox (P1):
       `zignites_chat_inbox_note`; composer "Internal note" toggle (works even
       when the 24h window is closed) with distinct note styling + author label.
       2 unit tests (note direction + author_id); 211 pass, PHPCS + JS clean.
-- [ ] T2.5 — New-message notifications (email / desktop) for agents.
+- [x] T2.5 — Agent email notifications — done on
+      `feat/pro-inbox-agent-notifications`. On a new inbound (via the
+      `zignites_chat_inbound_message` hook) emails the assigned agent, or all
+      managers when unassigned, or a configured override address. Throttled to
+      one email per conversation per 15 min (transient + pure
+      `notify_should_send`). Pure tested `notify_recipient_ids`. Settings live
+      in their own group (`zignites_chat_inbox_notify_group`) so saving them
+      doesn't wipe canned replies. 3 unit tests; 214 pass, PHPCS + lint green.
 
 ### Tier 3 — platform / automation
 - [ ] T3.1 — Drip & automation sequences (welcome, win-back, browse-abandon)
@@ -533,11 +540,12 @@ Build on the merged two-way inbox (P1):
 are all built — T1.1/T1.2 merged into `pro`; T1.3 on `feat/pro-optin-capture`
 awaiting PR. Live smoke tests pending on each (user action).
 
-Tier 2 in progress: **T2.1–T2.4 DONE** (assignment, canned replies, customer
-context, internal notes). Next, the last Tier 2 item: **T2.5 — agent
-notifications** (email a relevant agent when a new inbound message arrives —
-the assigned agent, or all managers when unassigned; throttled to avoid spam).
-Then Tier 3 (automation) and the quick wins — see PHASE 9.
+**Tier 2 COMPLETE** (T2.1–T2.5: assignment, canned replies, customer context,
+internal notes, agent notifications) — the two-way inbox is now a full team
+helpdesk. Next: **Tier 3 — T3.1 drip & automation sequences** (the big one:
+multi-step, rule-based flows like welcome / win-back / browse-abandon), or
+pick off the **quick wins** (Q1 restock alerts, Q2 review/NPS, Q3 quiet hours,
+Q4 Meta template sync, Q5 sender-health) first — see PHASE 9.
 
 The original Pro backlog is otherwise cleared into `pro`; the only blocked item
 is retiring `license-manager.php` (needs the Freemius credentials migration —

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -71,6 +71,11 @@ function zignites_chat_register_settings() {
     // Inbox — canned/quick replies.
     register_setting('zignites_chat_inbox_group', 'zignites_chat_inbox_canned_replies', ['sanitize_callback' => 'zignites_chat_inbox_parse_canned_replies', 'default' => []]);
 
+    // Inbox — agent email notifications (separate group so saving it doesn't
+    // wipe the canned-replies option via options.php).
+    register_setting('zignites_chat_inbox_notify_group', 'zignites_chat_inbox_notify_enabled', ['sanitize_callback' => 'zignites_chat_sanitize_yes_no']);
+    register_setting('zignites_chat_inbox_notify_group', 'zignites_chat_inbox_notify_email', ['sanitize_callback' => 'sanitize_email']);
+
     // Cart Recovery.
     register_setting('zignites_chat_cart_recovery_group', 'zignites_chat_cart_recovery_enabled', ['sanitize_callback' => 'zignites_chat_sanitize_yes_no']);
     register_setting('zignites_chat_cart_recovery_group', 'zignites_chat_cart_recovery_delay', ['sanitize_callback' => 'zignites_chat_sanitize_int']);

--- a/admin/views/tab-inbox.php
+++ b/admin/views/tab-inbox.php
@@ -19,6 +19,37 @@ $zignites_chat_canned  = zignites_chat_inbox_get_canned_replies();
     </form>
 </details>
 
+<details class="zignites-chat-inbox-notify-manage" style="margin:8px 0 16px;">
+    <summary style="cursor:pointer; font-weight:600;"><?php esc_html_e('Email notifications', 'zignites-chat'); ?></summary>
+    <form method="post" action="options.php" style="margin-top:10px;">
+        <?php settings_fields('zignites_chat_inbox_notify_group'); ?>
+        <?php
+        $zignites_chat_notify_on    = get_option('zignites_chat_inbox_notify_enabled', 'no');
+        $zignites_chat_notify_email = get_option('zignites_chat_inbox_notify_email', '');
+        ?>
+        <table class="form-table">
+            <tr>
+                <th scope="row"><label for="zignites_chat_inbox_notify_enabled"><?php esc_html_e('Notify on new message', 'zignites-chat'); ?></label></th>
+                <td>
+                    <select name="zignites_chat_inbox_notify_enabled" id="zignites_chat_inbox_notify_enabled">
+                        <option value="no" <?php selected($zignites_chat_notify_on, 'no'); ?>><?php esc_html_e('No', 'zignites-chat'); ?></option>
+                        <option value="yes" <?php selected($zignites_chat_notify_on, 'yes'); ?>><?php esc_html_e('Yes', 'zignites-chat'); ?></option>
+                    </select>
+                    <p class="description"><?php esc_html_e('Emails the assigned agent (or all managers when unassigned) when a customer replies. Throttled to one email per conversation every 15 minutes.', 'zignites-chat'); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="zignites_chat_inbox_notify_email"><?php esc_html_e('Override address', 'zignites-chat'); ?></label></th>
+                <td>
+                    <input type="email" name="zignites_chat_inbox_notify_email" id="zignites_chat_inbox_notify_email" value="<?php echo esc_attr($zignites_chat_notify_email); ?>" class="regular-text" placeholder="<?php esc_attr_e('team@example.com', 'zignites-chat'); ?>" />
+                    <p class="description"><?php esc_html_e('Optional. When set, all notifications go here instead of to individual agents.', 'zignites-chat'); ?></p>
+                </td>
+            </tr>
+        </table>
+        <?php submit_button(__('Save notification settings', 'zignites-chat'), 'secondary', 'submit', true); ?>
+    </form>
+</details>
+
 <div class="zignites-chat-inbox" id="zignites-chat-inbox">
     <div class="zignites-chat-inbox-list" id="zignites-chat-inbox-list">
         <div class="zignites-chat-inbox-search">

--- a/includes/inbox-admin.php
+++ b/includes/inbox-admin.php
@@ -35,6 +35,130 @@ function zignites_chat_render_inbox_page() {
 }
 
 /* ---------------------------------------------------------------------------
+ * Agent notifications (email on new inbound)
+ * ------------------------------------------------------------------------ */
+
+/**
+ * Decide which user ids to notify for a thread. Pure.
+ *
+ * An assigned thread notifies just its agent; an unassigned thread notifies
+ * every manager.
+ *
+ * @param int   $agent_id    Thread assignee (0 = unassigned).
+ * @param array $manager_ids All eligible manager user ids.
+ * @return array<int, int>
+ */
+function zignites_chat_inbox_notify_recipient_ids($agent_id, $manager_ids) {
+    $agent_id = (int) $agent_id;
+    if ($agent_id > 0) {
+        return [$agent_id];
+    }
+    if (!is_array($manager_ids)) {
+        return [];
+    }
+    return array_values(array_unique(array_map('intval', $manager_ids)));
+}
+
+/**
+ * Whether enough time has passed since the last notification for a thread. Pure.
+ *
+ * @param int $last_ts Unix timestamp of the last notification (0 = never).
+ * @param int $now     Current unix timestamp.
+ * @param int $window  Throttle window in seconds.
+ * @return bool True when a notification should be sent.
+ */
+function zignites_chat_inbox_notify_should_send($last_ts, $now, $window) {
+    $last = (int) $last_ts;
+    if ($last <= 0) {
+        return true;
+    }
+    return ((int) $now - $last) >= max(1, (int) $window);
+}
+
+add_action('zignites_chat_inbound_message', 'zignites_chat_inbox_notify_on_inbound', 10, 2);
+
+/**
+ * Email the relevant agent(s) when a new inbound message lands.
+ *
+ * Throttled per conversation so a burst of messages produces at most one email
+ * per window. Recipients: a configured override address, else the assigned
+ * agent, else all managers.
+ *
+ * @param array $msg    Normalized inbound message.
+ * @param array $result ['conversation_id'=>int, 'message_id'=>int].
+ * @return void
+ */
+function zignites_chat_inbox_notify_on_inbound($msg, $result = []) {
+    if (get_option('zignites_chat_inbox_notify_enabled', 'no') !== 'yes') {
+        return;
+    }
+    if (function_exists('zignites_chat_is_pro_active') && !zignites_chat_is_pro_active()) {
+        return;
+    }
+    if (!is_array($msg)) {
+        return;
+    }
+    $conversation_id = (is_array($result) && isset($result['conversation_id'])) ? (int) $result['conversation_id'] : 0;
+    if ($conversation_id <= 0) {
+        return;
+    }
+
+    // Per-conversation throttle.
+    $window = (int) apply_filters('zignites_chat_inbox_notify_throttle', 15 * MINUTE_IN_SECONDS);
+    $key    = 'zignites_chat_inbox_notify_' . $conversation_id;
+    $last   = (int) get_transient($key);
+    if (!zignites_chat_inbox_notify_should_send($last, time(), $window)) {
+        return;
+    }
+    set_transient($key, time(), $window);
+
+    $thread = zignites_chat_inbox_get_thread($conversation_id);
+    if ($thread === null) {
+        return;
+    }
+
+    // Resolve recipient emails.
+    $emails   = [];
+    $override = sanitize_email(get_option('zignites_chat_inbox_notify_email', ''));
+    if ($override !== '' && is_email($override)) {
+        $emails[] = $override;
+    } else {
+        $ids = zignites_chat_inbox_notify_recipient_ids(
+            (int) $thread['agent_id'],
+            array_keys(zignites_chat_inbox_assignable_agents())
+        );
+        foreach ($ids as $id) {
+            $user = get_userdata($id);
+            if ($user && is_email($user->user_email)) {
+                $emails[] = $user->user_email;
+            }
+        }
+    }
+    $emails = array_values(array_unique(array_filter($emails)));
+    if (empty($emails)) {
+        return;
+    }
+
+    $name    = ($thread['customer_name'] !== '') ? $thread['customer_name'] : $thread['phone'];
+    $snippet = zignites_chat_inbox_make_excerpt(isset($msg['body']) ? $msg['body'] : '', 200);
+    $link    = admin_url('admin.php?page=zignites-chat-inbox');
+
+    /* translators: %s: customer name or phone. */
+    $subject = sprintf(__('New WhatsApp message from %s', 'zignites-chat'), $name);
+    $body    = implode("\n", [
+        /* translators: %s: customer name or phone. */
+        sprintf(__('You have a new WhatsApp message from %s.', 'zignites-chat'), $name),
+        '',
+        $snippet,
+        '',
+        /* translators: %s: inbox URL. */
+        sprintf(__('Open the inbox: %s', 'zignites-chat'), $link),
+    ]);
+
+    wp_mail($emails, $subject, $body);
+}
+
+/* ---------------------------------------------------------------------------
  * Customer context (order history beside the thread)
  * ------------------------------------------------------------------------ */
 

--- a/tests/Unit/InboxNotifyTest.php
+++ b/tests/Unit/InboxNotifyTest.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace ZignitesChat\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class InboxNotifyTest extends TestCase
+{
+    public function test_recipient_ids_assigned_thread_notifies_agent_only(): void
+    {
+        $this->assertSame([5], \zignites_chat_inbox_notify_recipient_ids(5, [1, 2, 3]));
+    }
+
+    public function test_recipient_ids_unassigned_notifies_all_managers(): void
+    {
+        $this->assertSame([1, 2, 3], \zignites_chat_inbox_notify_recipient_ids(0, [1, 2, 3]));
+        // Deduped + cast to int.
+        $this->assertSame([1, 2], \zignites_chat_inbox_notify_recipient_ids(0, ['1', 2, '2', 1]));
+        $this->assertSame([], \zignites_chat_inbox_notify_recipient_ids(0, 'nope'));
+    }
+
+    public function test_should_send_throttle(): void
+    {
+        $window = 900; // 15 min
+        // Never notified → send.
+        $this->assertTrue(\zignites_chat_inbox_notify_should_send(0, 1000, $window));
+        // Within the window → throttled.
+        $this->assertFalse(\zignites_chat_inbox_notify_should_send(1000, 1000 + 600, $window));
+        // Exactly at the window boundary → send.
+        $this->assertTrue(\zignites_chat_inbox_notify_should_send(1000, 1000 + 900, $window));
+        // Past the window → send.
+        $this->assertTrue(\zignites_chat_inbox_notify_should_send(1000, 1000 + 1200, $window));
+    }
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -93,6 +93,8 @@ $zignites_chat_option_keys = [
     'zignites_chat_optin_required',
     'zignites_chat_optin_log',
     'zignites_chat_inbox_canned_replies',
+    'zignites_chat_inbox_notify_enabled',
+    'zignites_chat_inbox_notify_email',
 ];
 
 foreach ($zignites_chat_option_keys as $zignites_chat_key) {


### PR DESCRIPTION
Emails the right agent when a customer replies, so messages aren't missed.

- includes/inbox-admin.php: on the zignites_chat_inbound_message hook, emails the assigned agent, or all managers when the thread is unassigned, or a configured override address. Throttled to one email per conversation per 15 minutes via a transient.
- Pure, unit-tested helpers: notify_recipient_ids (assigned → agent; unassigned → all managers) and notify_should_send (throttle window).
- Settings (enable + override address) live in their own zignites_chat_inbox_notify_group so saving them doesn't wipe the canned-replies option through options.php; rendered as an "Email notifications" section on the Inbox page. Cleaned on uninstall.

Completes Tier 2 — the two-way inbox is now a full team helpdesk. 3 unit tests; full suite 214 pass, PHPCS + lint clean.