### PR TITLE
Back-in-stock WhatsApp alerts (Q1)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -525,7 +525,16 @@ Build on the merged two-way inbox (P1):
       build; the strategic differentiator.
 
 ### Quick wins (reuse existing plumbing)
-- [ ] Q1 — Back-in-stock / restock alerts via WhatsApp.
+- [x] Q1 — Back-in-stock alerts — done on `feat/pro-back-in-stock`.
+      `includes/back-in-stock.php`: a `{prefix}zignites_chat_stock_subs` table
+      (migration v8); a "notify me on WhatsApp" form on out-of-stock product
+      pages (nopriv AJAX subscribe, re-arms on re-subscribe); on
+      `woocommerce_product_set_stock_status` → 'instock' a chunked cron
+      processor sends alerts (opt-out-aware, defers on quiet hours, consumes
+      the shared rate-limit budget). Pure tested helpers `stock_is_instock`,
+      `stock_render_message`. Pro "Back in Stock" tab (enable, heading, message
+      template). Table + options + cron cleaned on uninstall; table created on
+      activation. 3 unit tests; 223 pass, PHPCS + lint + JS clean.
 - [ ] Q2 — Review / NPS request post-delivery.
 - [x] Q3 — Quiet hours — done on `feat/pro-quiet-hours`.
       `includes/quiet-hours.php`: a configurable nightly window (store timezone)
@@ -548,12 +557,11 @@ Build on the merged two-way inbox (P1):
 are all built — T1.1/T1.2 merged into `pro`; T1.3 on `feat/pro-optin-capture`
 awaiting PR. Live smoke tests pending on each (user action).
 
-**Tier 2 COMPLETE.** Quick win **Q3 (quiet hours) DONE** on
-`feat/pro-quiet-hours`. Remaining quick wins: **Q1 restock alerts**, **Q2
-review/NPS**, **Q4 Meta template sync**, **Q5 sender-health**. Plus the big
-**Tier 3 — T3.1 drip & automation sequences**. Suggested next: another quick
-win (Q1 back-in-stock alerts pairs well with the existing send plumbing) or
-start T3.1 — see PHASE 9.
+**Tier 2 COMPLETE.** Quick wins **Q3 (quiet hours) + Q1 (back-in-stock) DONE**
+(Q1 on `feat/pro-back-in-stock`). Remaining quick wins: **Q2 review/NPS**, **Q4
+Meta template sync**, **Q5 sender-health**. Plus the big **Tier 3 — T3.1 drip &
+automation sequences**. Suggested next: Q2 (review/NPS request — reuses the
+follow-up scheduler) or start T3.1 — see PHASE 9.
 
 The original Pro backlog is otherwise cleared into `pro`; the only blocked item
 is retiring `license-manager.php` (needs the Freemius credentials migration —

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -68,6 +68,11 @@ function zignites_chat_register_settings() {
     register_setting('zignites_chat_chatbot_group', 'zignites_chat_chatbot_icon', ['sanitize_callback' => 'zignites_chat_sanitize_text']);
     register_setting('zignites_chat_chatbot_group', 'zignites_chat_chatbot_welcome', ['sanitize_callback' => 'zignites_chat_sanitize_text']);
 
+    // Back-in-stock alerts.
+    register_setting('zignites_chat_stock_group', 'zignites_chat_stock_alerts_enabled', ['sanitize_callback' => 'zignites_chat_sanitize_yes_no']);
+    register_setting('zignites_chat_stock_group', 'zignites_chat_stock_alert_message', ['sanitize_callback' => 'zignites_chat_sanitize_textarea']);
+    register_setting('zignites_chat_stock_group', 'zignites_chat_stock_form_heading', ['sanitize_callback' => 'zignites_chat_sanitize_text']);
+
     // Quiet hours.
     register_setting('zignites_chat_quiet_group', 'zignites_chat_quiet_hours_enabled', ['sanitize_callback' => 'zignites_chat_sanitize_yes_no']);
     register_setting('zignites_chat_quiet_group', 'zignites_chat_quiet_start', ['sanitize_callback' => 'zignites_chat_quiet_sanitize_time']);
@@ -139,6 +144,7 @@ function zignites_chat_register_admin_menus() {
         ['zignites-chat-scheduler',     __('Scheduler', 'zignites-chat'),        'zignites_chat_render_scheduler_page',     true],
         ['zignites-chat-status',        __('Status Notifications', 'zignites-chat'), 'zignites_chat_render_status_page',     true],
         ['zignites-chat-quiet',         __('Quiet Hours', 'zignites-chat'),      'zignites_chat_render_quiet_page',         true],
+        ['zignites-chat-stock',         __('Back in Stock', 'zignites-chat'),    'zignites_chat_render_stock_page',         true],
         ['zignites-chat-campaigns',     __('Campaigns', 'zignites-chat'),        'zignites_chat_render_campaigns_page',     true],
         ['zignites-chat-inbox',         __('Inbox', 'zignites-chat'),            'zignites_chat_render_inbox_page',         true],
         ['zignites-chat-analytics',     __('Analytics', 'zignites-chat'),        'zignites_chat_render_analytics_page',     true],
@@ -412,6 +418,24 @@ function zignites_chat_render_optin_page() {
     zignites_chat_admin_page_close();
 }
 
+function zignites_chat_render_stock_page() {
+    if (!current_user_can('manage_options')) {
+        wp_die(esc_html__('Unauthorized', 'zignites-chat'));
+    }
+    zignites_chat_admin_page_open(__('Back-in-Stock Alerts', 'zignites-chat'));
+    if (!zignites_chat_is_pro_active()) {
+        zignites_chat_render_pro_upgrade_notice('stock');
+        zignites_chat_admin_page_close();
+        return;
+    }
+    echo '<form method="post" action="options.php">';
+    settings_fields('zignites_chat_stock_group');
+    require ZIGNITES_CHAT_PATH . 'admin/views/tab-stock.php';
+    submit_button();
+    echo '</form>';
+    zignites_chat_admin_page_close();
+}
+
 function zignites_chat_render_quiet_page() {
     if (!current_user_can('manage_options')) {
         wp_die(esc_html__('Unauthorized', 'zignites-chat'));
@@ -575,6 +599,16 @@ function zignites_chat_render_pro_upgrade_notice($feature = '') {
                 __('Timestamped consent log per phone number', 'zignites-chat'),
                 __('Require consent before cart recovery / campaigns / follow-ups', 'zignites-chat'),
                 __('Explicit opt-in clears a prior opt-out', 'zignites-chat'),
+            ],
+        ],
+        'stock' => [
+            'title'       => __('Back-in-Stock Alerts', 'zignites-chat'),
+            'description' => __('Recover lost sales on sold-out products. Shoppers leave their WhatsApp number on an out-of-stock product and get pinged the moment it’s restocked.', 'zignites-chat'),
+            'benefits'    => [
+                __('“Notify me on WhatsApp” form on out-of-stock products', 'zignites-chat'),
+                __('Automatic alert the moment a product is restocked', 'zignites-chat'),
+                __('Throttled, opt-out-aware, respects quiet hours', 'zignites-chat'),
+                __('Turn dead stock-outs into recovered revenue', 'zignites-chat'),
             ],
         ],
         'quiet' => [

--- a/admin/views/tab-stock.php
+++ b/admin/views/tab-stock.php
@@ -1,0 +1,35 @@
+<?php
+if (!defined('ABSPATH')) exit;
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals -- View partial: variables are scoped to the render function that includes this file.
+
+$zignites_chat_stock_on      = get_option('zignites_chat_stock_alerts_enabled', 'no');
+$zignites_chat_stock_msg     = get_option('zignites_chat_stock_alert_message', __('Good news! {product} is back in stock. Grab it here: {product_url}', 'zignites-chat'));
+$zignites_chat_stock_heading = get_option('zignites_chat_stock_form_heading', __('Notify me on WhatsApp when it’s back', 'zignites-chat'));
+?>
+<h2><?php esc_html_e('Back-in-Stock Alerts', 'zignites-chat'); ?></h2>
+<p class="description">
+    <?php esc_html_e('Shows a “notify me on WhatsApp” form on out-of-stock product pages. When the product is restocked, subscribers get a WhatsApp message automatically (throttled, opt-out-aware, and respecting quiet hours).', 'zignites-chat'); ?>
+</p>
+
+<table class="form-table">
+    <tr>
+        <th scope="row"><label for="zignites_chat_stock_alerts_enabled"><?php esc_html_e('Enable back-in-stock alerts', 'zignites-chat'); ?></label></th>
+        <td>
+            <select name="zignites_chat_stock_alerts_enabled" id="zignites_chat_stock_alerts_enabled">
+                <option value="no" <?php selected($zignites_chat_stock_on, 'no'); ?>><?php esc_html_e('No', 'zignites-chat'); ?></option>
+                <option value="yes" <?php selected($zignites_chat_stock_on, 'yes'); ?>><?php esc_html_e('Yes', 'zignites-chat'); ?></option>
+            </select>
+        </td>
+    </tr>
+    <tr>
+        <th scope="row"><label for="zignites_chat_stock_form_heading"><?php esc_html_e('Form heading', 'zignites-chat'); ?></label></th>
+        <td><input type="text" name="zignites_chat_stock_form_heading" id="zignites_chat_stock_form_heading" value="<?php echo esc_attr($zignites_chat_stock_heading); ?>" class="large-text" /></td>
+    </tr>
+    <tr>
+        <th scope="row"><label for="zignites_chat_stock_alert_message"><?php esc_html_e('Alert message', 'zignites-chat'); ?></label></th>
+        <td>
+            <textarea name="zignites_chat_stock_alert_message" id="zignites_chat_stock_alert_message" rows="3" class="large-text"><?php echo esc_textarea($zignites_chat_stock_msg); ?></textarea>
+            <p class="description"><?php esc_html_e('Placeholders: {product}, {product_url}, {site}.', 'zignites-chat'); ?></p>
+        </td>
+    </tr>
+</table>

--- a/assets/js/back-in-stock.js
+++ b/assets/js/back-in-stock.js
@@ -1,0 +1,59 @@
+// Zignites Chat – Back-in-stock WhatsApp subscribe form.
+
+(function () {
+    document.addEventListener('DOMContentLoaded', function () {
+        var root = document.querySelector('.zignites-chat-stock-form');
+        if (!root) return;
+
+        var cfg = (typeof zignitesChatStock !== 'undefined') ? zignitesChatStock : {};
+        var i18n = cfg.i18n || {};
+        var phoneEl = root.querySelector('.zignites-chat-stock-phone');
+        var btn = root.querySelector('.zignites-chat-stock-submit');
+        var msg = root.querySelector('.zignites-chat-stock-msg');
+        var productId = root.getAttribute('data-product');
+
+        function submit() {
+            var phone = phoneEl ? phoneEl.value.trim() : '';
+            if (!phone) {
+                msg.textContent = i18n.empty || '';
+                return;
+            }
+            btn.disabled = true;
+            var original = btn.textContent;
+            btn.textContent = i18n.sending || '';
+            msg.textContent = '';
+
+            var body = 'action=zignites_chat_stock_subscribe'
+                + '&nonce=' + encodeURIComponent(cfg.nonce || '')
+                + '&product_id=' + encodeURIComponent(productId)
+                + '&phone=' + encodeURIComponent(phone);
+
+            fetch(cfg.ajaxUrl, {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: body
+            }).then(function (r) { return r.json(); }).then(function (res) {
+                btn.disabled = false;
+                btn.textContent = original;
+                if (res && res.success) {
+                    msg.textContent = res.data.message || '';
+                    if (phoneEl) phoneEl.value = '';
+                } else {
+                    msg.textContent = (res && res.data && res.data.message) || (i18n.error || '');
+                }
+            }).catch(function () {
+                btn.disabled = false;
+                btn.textContent = original;
+                msg.textContent = i18n.error || '';
+            });
+        }
+
+        if (btn) btn.addEventListener('click', submit);
+        if (phoneEl) {
+            phoneEl.addEventListener('keydown', function (e) {
+                if (e.key === 'Enter') { e.preventDefault(); submit(); }
+            });
+        }
+    });
+})();

--- a/includes/back-in-stock.php
+++ b/includes/back-in-stock.php
@@ -1,0 +1,330 @@
+<?php
+/**
+ * Back-in-stock alerts (Pro) — roadmap Q1.
+ *
+ * Lets shoppers subscribe on an out-of-stock product to be notified over
+ * WhatsApp when it is restocked. Subscriptions are stored in a custom table;
+ * when a product flips to "instock" a background processor sends the alerts
+ * (chunked, opt-out-aware, deferred by quiet hours / the rate limiter).
+ *
+ * The message renderer and status helper are pure and unit-tested; the rest is
+ * WooCommerce + storage glue.
+ *
+ * @package Zignites_Chat
+ */
+
+if (!defined('ABSPATH')) exit;
+
+/* -------------------------------------------------------------------------
+ * Schema
+ * ----------------------------------------------------------------------- */
+
+function zignites_chat_stock_subs_table_name() {
+    global $wpdb;
+    return $wpdb->prefix . 'zignites_chat_stock_subs';
+}
+
+/**
+ * dbDelta-based, idempotent. Called from migration v8 and the activation hook.
+ */
+function zignites_chat_create_stock_subs_table() {
+    global $wpdb;
+    $charset_collate = $wpdb->get_charset_collate();
+    $table = zignites_chat_stock_subs_table_name();
+
+    $sql = "CREATE TABLE {$table} (
+        id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+        product_id BIGINT UNSIGNED NOT NULL,
+        phone VARCHAR(40) NOT NULL,
+        status VARCHAR(20) NOT NULL DEFAULT 'pending',
+        created_at DATETIME NOT NULL,
+        notified_at DATETIME NULL,
+        PRIMARY KEY  (id),
+        UNIQUE KEY product_phone (product_id, phone),
+        KEY product_status (product_id, status)
+    ) {$charset_collate};";
+
+    require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+    dbDelta($sql);
+}
+
+/* -------------------------------------------------------------------------
+ * Pure helpers (no DB) — unit-tested
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Whether a WooCommerce stock-status value means "available". Pure.
+ *
+ * @param string $status
+ * @return bool
+ */
+function zignites_chat_stock_is_instock($status) {
+    return (string) $status === 'instock';
+}
+
+/**
+ * Render the alert template by substituting placeholders. Pure.
+ *
+ * @param string $template
+ * @param array  $values Map of '{placeholder}' => replacement.
+ * @return string
+ */
+function zignites_chat_stock_render_message($template, $values) {
+    if (!is_array($values)) {
+        return (string) $template;
+    }
+    return str_replace(array_keys($values), array_values($values), (string) $template);
+}
+
+/* -------------------------------------------------------------------------
+ * Subscription storage
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Record (or re-arm) a back-in-stock subscription.
+ *
+ * @param int    $product_id
+ * @param string $phone Customer phone (any format).
+ * @return bool True when stored.
+ */
+function zignites_chat_stock_subscribe($product_id, $phone) {
+    global $wpdb;
+    $product_id = (int) $product_id;
+    $phone = zignites_chat_normalize_phone($phone);
+    if ($product_id <= 0 || $phone === '') {
+        return false;
+    }
+    $table = zignites_chat_stock_subs_table_name();
+    $now = current_time('mysql');
+
+    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+    $existing = $wpdb->get_var($wpdb->prepare(
+        "SELECT id FROM {$table} WHERE product_id = %d AND phone = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+        $product_id,
+        $phone
+    ));
+
+    if ($existing) {
+        // Re-arm a previously-notified (or still-pending) subscription.
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+        $wpdb->update(
+            $table,
+            ['status' => 'pending', 'created_at' => $now, 'notified_at' => null],
+            ['id' => (int) $existing],
+            ['%s', '%s', '%s'],
+            ['%d']
+        );
+        return true;
+    }
+
+    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+    $wpdb->insert(
+        $table,
+        ['product_id' => $product_id, 'phone' => $phone, 'status' => 'pending', 'created_at' => $now],
+        ['%d', '%s', '%s', '%s']
+    );
+    return (bool) $wpdb->insert_id;
+}
+
+/**
+ * Count pending subscriptions for a product.
+ *
+ * @param int $product_id
+ * @return int
+ */
+function zignites_chat_stock_pending_count($product_id) {
+    global $wpdb;
+    $table = zignites_chat_stock_subs_table_name();
+    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+    return (int) $wpdb->get_var($wpdb->prepare(
+        "SELECT COUNT(*) FROM {$table} WHERE product_id = %d AND status = 'pending'",
+        (int) $product_id
+    ));
+}
+
+/* -------------------------------------------------------------------------
+ * Restock trigger → background processor
+ * ----------------------------------------------------------------------- */
+
+add_action('woocommerce_product_set_stock_status', 'zignites_chat_stock_on_status_change', 20, 2);
+add_action('woocommerce_variation_set_stock_status', 'zignites_chat_stock_on_status_change', 20, 2);
+add_action('zignites_chat_process_stock_alerts', 'zignites_chat_stock_process_alerts');
+
+/**
+ * When a product flips to "instock", queue its alert processor.
+ *
+ * @param int    $product_id
+ * @param string $stock_status
+ * @return void
+ */
+function zignites_chat_stock_on_status_change($product_id, $stock_status) {
+    if (get_option('zignites_chat_stock_alerts_enabled', 'no') !== 'yes') {
+        return;
+    }
+    if (function_exists('zignites_chat_is_pro_active') && !zignites_chat_is_pro_active()) {
+        return;
+    }
+    if (!zignites_chat_stock_is_instock($stock_status)) {
+        return;
+    }
+    $product_id = (int) $product_id;
+    if (zignites_chat_stock_pending_count($product_id) < 1) {
+        return;
+    }
+    if (!wp_next_scheduled('zignites_chat_process_stock_alerts', [$product_id])) {
+        wp_schedule_single_event(time() + 30, 'zignites_chat_process_stock_alerts', [$product_id]);
+    }
+}
+
+/**
+ * Send back-in-stock alerts for a product's pending subscribers.
+ *
+ * Chunked + deferred (quiet hours, rate limiter) so a large list doesn't
+ * stall and respects sending policy. Opt-outs are skipped.
+ *
+ * @param int $product_id
+ * @return void
+ */
+function zignites_chat_stock_process_alerts($product_id) {
+    global $wpdb;
+    $product_id = (int) $product_id;
+    if ($product_id <= 0 || get_option('zignites_chat_stock_alerts_enabled', 'no') !== 'yes') {
+        return;
+    }
+    if (function_exists('zignites_chat_is_pro_active') && !zignites_chat_is_pro_active()) {
+        return;
+    }
+    if (!function_exists('wc_get_product')) {
+        return;
+    }
+
+    // Quiet hours: resume after the window.
+    if (function_exists('zignites_chat_quiet_hours_active') && zignites_chat_quiet_hours_active()) {
+        $resume = function_exists('zignites_chat_quiet_hours_resume_seconds') ? zignites_chat_quiet_hours_resume_seconds() : 0;
+        wp_schedule_single_event(time() + max(60, $resume), 'zignites_chat_process_stock_alerts', [$product_id]);
+        return;
+    }
+
+    $product = wc_get_product($product_id);
+    // If it went out of stock again before we sent, stop — re-armed when restocked.
+    if (!$product || !$product->is_in_stock()) {
+        return;
+    }
+
+    $table = zignites_chat_stock_subs_table_name();
+    $chunk = max(1, min(100, (int) apply_filters('zignites_chat_stock_chunk_size', 20)));
+    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+    $rows = $wpdb->get_results($wpdb->prepare(
+        "SELECT id, phone FROM {$table} WHERE product_id = %d AND status = 'pending' ORDER BY id ASC LIMIT %d",
+        $product_id,
+        $chunk
+    ));
+    if (!$rows) {
+        return;
+    }
+
+    $template = get_option(
+        'zignites_chat_stock_alert_message',
+        __('Good news! {product} is back in stock. Grab it here: {product_url}', 'zignites-chat')
+    );
+    $values_base = [
+        '{product}'     => $product->get_name(),
+        '{product_url}' => get_permalink($product_id),
+        '{site}'        => function_exists('get_bloginfo') ? get_bloginfo('name') : '',
+    ];
+
+    $now = current_time('mysql');
+    foreach ($rows as $row) {
+        if (zignites_chat_is_opted_out($row->phone)) {
+            // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+            $wpdb->update($table, ['status' => 'opted_out', 'notified_at' => $now], ['id' => (int) $row->id], ['%s', '%s'], ['%d']);
+            continue;
+        }
+        // Shared per-minute budget: stop this run when exhausted; remaining
+        // subs stay pending and the reschedule below picks them up.
+        if (function_exists('zignites_chat_outbound_rate_acquire') && !zignites_chat_outbound_rate_acquire()) {
+            break;
+        }
+
+        $message = zignites_chat_stock_render_message($template, $values_base);
+        zignites_chat_send_whatsapp_message($row->phone, $message, false, [
+            'type'       => 'back_in_stock',
+            'product_id' => $product_id,
+        ]);
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+        $wpdb->update($table, ['status' => 'notified', 'notified_at' => $now], ['id' => (int) $row->id], ['%s', '%s'], ['%d']);
+    }
+
+    if (zignites_chat_stock_pending_count($product_id) > 0) {
+        wp_schedule_single_event(time() + max(10, (int) apply_filters('zignites_chat_stock_chunk_interval', MINUTE_IN_SECONDS)), 'zignites_chat_process_stock_alerts', [$product_id]);
+    }
+}
+
+/* -------------------------------------------------------------------------
+ * Frontend opt-in form + subscribe AJAX
+ * ----------------------------------------------------------------------- */
+
+add_action('woocommerce_single_product_summary', 'zignites_chat_stock_render_form', 35);
+
+/**
+ * Render the "notify me on WhatsApp" form on an out-of-stock product page.
+ */
+function zignites_chat_stock_render_form() {
+    if (get_option('zignites_chat_stock_alerts_enabled', 'no') !== 'yes') {
+        return;
+    }
+    if (function_exists('zignites_chat_is_pro_active') && !zignites_chat_is_pro_active()) {
+        return;
+    }
+    global $product;
+    if (!is_object($product) || $product->is_in_stock()) {
+        return;
+    }
+
+    wp_enqueue_script('zignites-chat-back-in-stock', ZIGNITES_CHAT_URL . 'assets/js/back-in-stock.js', [], ZIGNITES_CHAT_VERSION, true);
+    wp_localize_script('zignites-chat-back-in-stock', 'zignitesChatStock', [
+        'ajaxUrl' => admin_url('admin-ajax.php'),
+        'nonce'   => wp_create_nonce('zignites_chat_stock'),
+        'i18n'    => [
+            'sending' => __('Sending…', 'zignites-chat'),
+            'error'   => __('Could not subscribe. Please try again.', 'zignites-chat'),
+            'empty'   => __('Please enter your WhatsApp number.', 'zignites-chat'),
+        ],
+    ]);
+
+    $heading = get_option('zignites_chat_stock_form_heading', __('Notify me on WhatsApp when it’s back', 'zignites-chat'));
+    echo '<div class="zignites-chat-stock-form" data-product="' . esc_attr((string) $product->get_id()) . '">';
+    echo '<p class="zignites-chat-stock-heading">' . esc_html($heading) . '</p>';
+    echo '<input type="tel" class="zignites-chat-stock-phone" placeholder="' . esc_attr__('e.g. +1 415 555 0100', 'zignites-chat') . '" />';
+    echo '<button type="button" class="button zignites-chat-stock-submit">' . esc_html__('Notify me', 'zignites-chat') . '</button>';
+    echo '<span class="zignites-chat-stock-msg" role="status"></span>';
+    echo '</div>';
+}
+
+add_action('wp_ajax_zignites_chat_stock_subscribe', 'zignites_chat_stock_subscribe_ajax');
+add_action('wp_ajax_nopriv_zignites_chat_stock_subscribe', 'zignites_chat_stock_subscribe_ajax');
+
+/**
+ * Handle a back-in-stock subscription request from the storefront.
+ */
+function zignites_chat_stock_subscribe_ajax() {
+    if (!check_ajax_referer('zignites_chat_stock', 'nonce', false)) {
+        wp_send_json_error(['message' => __('Expired — please refresh and try again.', 'zignites-chat')], 400);
+    }
+    if (get_option('zignites_chat_stock_alerts_enabled', 'no') !== 'yes'
+        || (function_exists('zignites_chat_is_pro_active') && !zignites_chat_is_pro_active())) {
+        wp_send_json_error(['message' => __('Unavailable', 'zignites-chat')], 403);
+    }
+
+    $product_id = isset($_POST['product_id']) ? (int) $_POST['product_id'] : 0;
+    $phone      = isset($_POST['phone']) ? zignites_chat_normalize_phone(wp_unslash($_POST['phone'])) : '';
+    if ($product_id <= 0 || strlen($phone) < 7) {
+        wp_send_json_error(['message' => __('Please enter a valid WhatsApp number.', 'zignites-chat')], 422);
+    }
+
+    if (!zignites_chat_stock_subscribe($product_id, $phone)) {
+        wp_send_json_error(['message' => __('Could not subscribe. Please try again.', 'zignites-chat')], 500);
+    }
+
+    wp_send_json_success(['message' => __('Done! We’ll WhatsApp you when it’s back in stock.', 'zignites-chat')]);
+}

--- a/includes/class-zignites-chat-plugin.php
+++ b/includes/class-zignites-chat-plugin.php
@@ -96,6 +96,7 @@ final class Plugin {
         require_once ZIGNITES_CHAT_PATH . 'includes/cart-recovery.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/scheduler.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/campaigns.php';
+        require_once ZIGNITES_CHAT_PATH . 'includes/back-in-stock.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/inbox.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/inbox-capture.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/inbox-admin.php';
@@ -116,6 +117,8 @@ final class Plugin {
         zignites_chat_create_campaign_tables();
         require_once ZIGNITES_CHAT_PATH . 'includes/inbox.php';
         zignites_chat_create_inbox_tables();
+        require_once ZIGNITES_CHAT_PATH . 'includes/back-in-stock.php';
+        zignites_chat_create_stock_subs_table();
         zignites_chat_schedule_cart_recovery_cron();
         zignites_chat_run_migrations();
     }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -118,6 +118,7 @@ function zignites_chat_get_migrations() {
         5 => 'zignites_chat_migration_v5_campaign_media',
         6 => 'zignites_chat_migration_v6_inbox_tables',
         7 => 'zignites_chat_migration_v7_inbox_notes',
+        8 => 'zignites_chat_migration_v8_stock_subs',
     ];
 }
 
@@ -217,6 +218,16 @@ function zignites_chat_migration_v6_inbox_tables() {
 function zignites_chat_migration_v7_inbox_notes() {
     if (function_exists('zignites_chat_create_inbox_tables')) {
         zignites_chat_create_inbox_tables();
+    }
+}
+
+/**
+ * v8: create the back-in-stock subscriptions table. Idempotent dbDelta;
+ * same WC-state guard shape as the other table migrations.
+ */
+function zignites_chat_migration_v8_stock_subs() {
+    if (function_exists('zignites_chat_create_stock_subs_table')) {
+        zignites_chat_create_stock_subs_table();
     }
 }
 

--- a/tests/Unit/BackInStockTest.php
+++ b/tests/Unit/BackInStockTest.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace ZignitesChat\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class BackInStockTest extends TestCase
+{
+    public function test_is_instock(): void
+    {
+        $this->assertTrue(\zignites_chat_stock_is_instock('instock'));
+        $this->assertFalse(\zignites_chat_stock_is_instock('outofstock'));
+        $this->assertFalse(\zignites_chat_stock_is_instock('onbackorder'));
+        $this->assertFalse(\zignites_chat_stock_is_instock(''));
+    }
+
+    public function test_render_message_substitutes(): void
+    {
+        $out = \zignites_chat_stock_render_message(
+            '{product} is back! Buy: {product_url} — {site}',
+            [
+                '{product}'     => 'Blue Mug',
+                '{product_url}' => 'https://shop/mug',
+                '{site}'        => 'My Store',
+            ]
+        );
+        $this->assertSame('Blue Mug is back! Buy: https://shop/mug — My Store', $out);
+    }
+
+    public function test_render_message_with_non_array_values(): void
+    {
+        $this->assertSame('literal', \zignites_chat_stock_render_message('literal', 'nope'));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -144,6 +144,7 @@ require_once __DIR__ . '/../includes/wa-templates.php';
 require_once __DIR__ . '/../includes/media.php';
 require_once __DIR__ . '/../includes/cart-recovery.php';
 require_once __DIR__ . '/../includes/campaigns.php';
+require_once __DIR__ . '/../includes/back-in-stock.php';
 require_once __DIR__ . '/../includes/inbox.php';
 require_once __DIR__ . '/../includes/inbox-capture.php';
 require_once __DIR__ . '/../includes/inbox-admin.php';

--- a/uninstall.php
+++ b/uninstall.php
@@ -81,6 +81,9 @@ $zignites_chat_option_keys = [
     'zignites_chat_quiet_hours_enabled',
     'zignites_chat_quiet_start',
     'zignites_chat_quiet_end',
+    'zignites_chat_stock_alerts_enabled',
+    'zignites_chat_stock_alert_message',
+    'zignites_chat_stock_form_heading',
     'zignites_chat_cod_enabled',
     'zignites_chat_cod_gateways',
     'zignites_chat_cod_message_template',
@@ -116,6 +119,7 @@ $zignites_chat_tables = array(
 	$wpdb->prefix . 'zignites_chat_campaigns',
 	$wpdb->prefix . 'zignites_chat_conversations',
 	$wpdb->prefix . 'zignites_chat_messages',
+	$wpdb->prefix . 'zignites_chat_stock_subs',
 );
 foreach ( $zignites_chat_tables as $zignites_chat_table ) {
 	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange -- One-time uninstall cleanup; table name is built from $wpdb->prefix, no user input.
@@ -131,6 +135,7 @@ $zignites_chat_cron_hooks = array(
 	'zignites_chat_send_order_message',
 	'zignites_chat_send_followup_message',
 	'zignites_chat_webhook_retry',
+	'zignites_chat_process_stock_alerts',
 );
 foreach ($zignites_chat_cron_hooks as $zignites_chat_hook) {
 	wp_clear_scheduled_hook($zignites_chat_hook);


### PR DESCRIPTION
Recovers sales on sold-out products: shoppers leave their WhatsApp number on an out-of-stock product and get pinged when it's restocked.

- includes/back-in-stock.php: a {prefix}zignites_chat_stock_subs table (migration v8, created on activation, dropped on uninstall); a "notify me on WhatsApp" form on out-of-stock product pages with a nopriv AJAX subscribe (re-arms an existing subscription on re-subscribe).
- On woocommerce_product_set_stock_status flipping to 'instock', a chunked background processor sends the alerts — opt-out-aware, deferred by quiet hours, and consuming the shared per-minute rate-limit budget.
- Pure, unit-tested helpers: stock_is_instock, stock_render_message.
- Pro "Back in Stock" tab (enable, form heading, message template with {product}/{product_url}/{site}). Cron cleared on uninstall.

3 unit tests; full suite 223 pass, PHPCS + lint + JS check clean.