### PR TITLE
Drip sequences: engine foundation (T3.1 S1)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -520,9 +520,33 @@ Build on the merged two-way inbox (P1):
       doesn't wipe canned replies. 3 unit tests; 214 pass, PHPCS + lint green.
 
 ### Tier 3 — platform / automation
-- [ ] T3.1 — Drip & automation sequences (welcome, win-back, browse-abandon)
+- [🟡] T3.1 — Drip & automation sequences (welcome, win-back, browse-abandon)
       as multi-step, rule-based flows rather than discrete features. Biggest
-      build; the strategic differentiator.
+      build; the strategic differentiator. **Built in reviewable increments**
+      (decision 2026-06-08), one PR each off `pro`:
+  - [x] S1 — Engine foundation, on `feat/pro-drip-sequences`.
+        `includes/drip-sequences.php`: the enrollments table
+        (`{prefix}zignites_chat_sequence_enrollments`, migration v9 + activation
+        + uninstall drop); sequence-definition storage (option
+        `zignites_chat_sequences`) with a pure sanitizer + normalizing getters
+        (`get_sequences`/`find`/`active_for_trigger`); a trigger catalogue
+        (order_completed / optin / win_back / browse_abandon, each with its
+        placeholder set); and pure, unit-tested scheduling helpers
+        (`delay_to_seconds`, `step_count`, `get_step`, `next_run_at` with
+        cumulative per-step offsets, `render_message`, `sanitize_step`).
+        No enrollment/cron/UI yet — mirrors inbox I1. 8 unit tests; 244 pass,
+        PHPCS green.
+  - [ ] S2 — Enrollment + trigger wiring (enroll on order_completed / optin;
+        idempotent upsert into the table; respects Pro + per-sequence enable).
+  - [ ] S3 — Cron processor + sender: walk due enrollments, send the step via
+        the dispatcher (opt-out/consent/quiet-hours/rate-limit gates), advance
+        `current_step`/`next_run_at`, complete at the end. Chunked like the
+        other bulk senders.
+  - [ ] S4 — Admin CRUD UI: a Pro "Sequences" submenu to create/edit sequences
+        (trigger + ordered steps with delays + messages) and an enrollment
+        count per sequence.
+  - [ ] S5 — Scan-based triggers: win-back (no order in N days) + browse-abandon
+        (viewed product, no order), each a scheduled scan that enrolls matches.
 
 ### Quick wins (reuse existing plumbing)
 - [x] Q1 — Back-in-stock alerts — done on `feat/pro-back-in-stock`.
@@ -583,10 +607,13 @@ are all built — T1.1/T1.2 merged into `pro`; T1.3 on `feat/pro-optin-capture`
 awaiting PR. Live smoke tests pending on each (user action).
 
 **Tier 2 COMPLETE.** Quick wins **Q3 (quiet hours), Q1 (back-in-stock),
-Q2 (review/NPS request) + Q4 (Meta template sync) DONE** (Q1/Q2 merged into
-`pro`; Q4 on `feat/pro-template-sync` awaiting PR). Remaining quick win:
-**Q5 sender-health**. Plus the big **Tier 3 — T3.1 drip & automation
-sequences**. Suggested next: Q5 or start T3.1 — see PHASE 9.
+Q2 (review/NPS request) + Q4 (Meta template sync) DONE** (all merged into
+`pro`). Remaining quick win: **Q5 sender-health**.
+
+**Tier 3 — T3.1 drip & automation sequences IN PROGRESS** (incremental PRs).
+**S1 engine foundation DONE** on `feat/pro-drip-sequences` (awaiting PR). Next:
+S2 enrollment + trigger wiring → S3 cron sender → S4 admin UI → S5 scan-based
+triggers. See PHASE 9 → Tier 3 for the increment breakdown.
 
 The original Pro backlog is otherwise cleared into `pro`; the only blocked item
 is retiring `license-manager.php` (needs the Freemius credentials migration —

--- a/includes/class-zignites-chat-plugin.php
+++ b/includes/class-zignites-chat-plugin.php
@@ -99,6 +99,7 @@ final class Plugin {
         require_once ZIGNITES_CHAT_PATH . 'includes/campaigns.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/back-in-stock.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/review-request.php';
+        require_once ZIGNITES_CHAT_PATH . 'includes/drip-sequences.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/inbox.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/inbox-capture.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/inbox-admin.php';
@@ -121,6 +122,8 @@ final class Plugin {
         zignites_chat_create_inbox_tables();
         require_once ZIGNITES_CHAT_PATH . 'includes/back-in-stock.php';
         zignites_chat_create_stock_subs_table();
+        require_once ZIGNITES_CHAT_PATH . 'includes/drip-sequences.php';
+        zignites_chat_create_sequence_enrollments_table();
         zignites_chat_schedule_cart_recovery_cron();
         zignites_chat_run_migrations();
     }

--- a/includes/drip-sequences.php
+++ b/includes/drip-sequences.php
@@ -1,0 +1,337 @@
+<?php
+/**
+ * Drip & automation sequences (Pro) — roadmap T3.1, increment 1 (engine
+ * foundation).
+ *
+ * A sequence is a named, rule-based automation: a trigger (the entry event —
+ * order completed, opt-in, win-back, browse-abandon) plus an ordered list of
+ * steps, each a delay + a WhatsApp message. When the trigger fires for a phone
+ * the customer is *enrolled*; a background processor then walks the steps,
+ * sending each after its delay elapses.
+ *
+ * This file is the pure data layer only — mirroring inbox I1:
+ *   - the enrollments table (idempotent dbDelta) + migration v9,
+ *   - sequence-definition storage (option `zignites_chat_sequences`) with a
+ *     sanitizer + normalizing getters,
+ *   - pure, unit-tested helpers for delay maths, step lookup, scheduling and
+ *     message rendering.
+ *
+ * Enrollment + trigger wiring, the cron sender, and the admin CRUD UI land in
+ * later increments on top of these primitives.
+ *
+ * @package Zignites_Chat
+ */
+
+if (!defined('ABSPATH')) exit;
+
+/* -------------------------------------------------------------------------
+ * Schema
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Enrollments table — one row per (sequence, phone) currently or previously
+ * walking a sequence.
+ *
+ * @return string Fully-prefixed table name.
+ */
+function zignites_chat_seq_enrollments_table_name() {
+    global $wpdb;
+    return $wpdb->prefix . 'zignites_chat_sequence_enrollments';
+}
+
+/**
+ * Create the sequence enrollments table. dbDelta-based and idempotent: called
+ * from migration v9 and from the activation hook.
+ *
+ * `current_step` is the index of the NEXT step to send; `next_run_at` is when
+ * that step is due (indexed with `status` so the processor can pull due rows
+ * cheaply). The UNIQUE (sequence_id, phone) key makes enrollment idempotent.
+ */
+function zignites_chat_create_sequence_enrollments_table() {
+    global $wpdb;
+    $charset_collate = $wpdb->get_charset_collate();
+    $table           = zignites_chat_seq_enrollments_table_name();
+
+    $sql = "CREATE TABLE {$table} (
+        id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+        sequence_id VARCHAR(64) NOT NULL,
+        phone VARCHAR(40) NOT NULL,
+        status VARCHAR(20) NOT NULL DEFAULT 'active',
+        current_step INT UNSIGNED NOT NULL DEFAULT 0,
+        next_run_at DATETIME NULL,
+        enrolled_at DATETIME NOT NULL,
+        last_step_at DATETIME NULL,
+        PRIMARY KEY  (id),
+        UNIQUE KEY sequence_phone (sequence_id, phone),
+        KEY status_next (status, next_run_at)
+    ) {$charset_collate};";
+
+    require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+    dbDelta($sql);
+}
+
+/* -------------------------------------------------------------------------
+ * Trigger catalogue
+ * ----------------------------------------------------------------------- */
+
+/**
+ * The entry events a sequence can be triggered by, with the {placeholders}
+ * each one resolves in its step messages. Mirrors the wa-templates type map.
+ *
+ * @return array<string, array{label:string, placeholders:string[]}>
+ */
+function zignites_chat_seq_triggers() {
+    $triggers = array(
+        'order_completed' => array(
+            'label'        => __('Order completed', 'zignites-chat'),
+            'placeholders' => array('{name}', '{order_id}', '{total}', '{currency_symbol}', '{site}'),
+        ),
+        'optin'           => array(
+            'label'        => __('Customer opted in', 'zignites-chat'),
+            'placeholders' => array('{name}', '{site}'),
+        ),
+        'win_back'        => array(
+            'label'        => __('Win-back (inactive customer)', 'zignites-chat'),
+            'placeholders' => array('{name}', '{site}', '{days_inactive}'),
+        ),
+        'browse_abandon'  => array(
+            'label'        => __('Browse abandonment', 'zignites-chat'),
+            'placeholders' => array('{name}', '{site}', '{product}', '{product_url}'),
+        ),
+    );
+
+    /**
+     * Filter the available sequence triggers.
+     *
+     * @param array $triggers Trigger key => label + placeholders.
+     */
+    return (array) apply_filters('zignites_chat_seq_triggers', $triggers);
+}
+
+/* -------------------------------------------------------------------------
+ * Pure helpers (no DB, no globals) — unit-tested
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Convert a step delay into seconds. Pure.
+ *
+ * @param int    $value Non-negative magnitude (negatives clamp to 0).
+ * @param string $unit  'minutes' | 'hours' | 'days' (unknown → minutes).
+ * @return int Seconds.
+ */
+function zignites_chat_seq_delay_to_seconds($value, $unit) {
+    $value = (int) $value;
+    if ($value < 0) {
+        $value = 0;
+    }
+    switch ((string) $unit) {
+        case 'days':
+            return $value * DAY_IN_SECONDS;
+        case 'hours':
+            return $value * HOUR_IN_SECONDS;
+        case 'minutes':
+        default:
+            return $value * MINUTE_IN_SECONDS;
+    }
+}
+
+/**
+ * Number of steps in a sequence. Pure.
+ *
+ * @param array $sequence
+ * @return int
+ */
+function zignites_chat_seq_step_count($sequence) {
+    if (!is_array($sequence) || !isset($sequence['steps']) || !is_array($sequence['steps'])) {
+        return 0;
+    }
+    return count($sequence['steps']);
+}
+
+/**
+ * Fetch a single step by index. Pure.
+ *
+ * @param array $sequence
+ * @param int   $index
+ * @return array|null Step array, or null when out of range.
+ */
+function zignites_chat_seq_get_step($sequence, $index) {
+    $index = (int) $index;
+    if (!is_array($sequence) || !isset($sequence['steps'][$index]) || !is_array($sequence['steps'][$index])) {
+        return null;
+    }
+    return $sequence['steps'][$index];
+}
+
+/**
+ * Compute when a given step should fire, relative to a base timestamp. Pure.
+ *
+ * The base is the enrollment time for step 0 and the previous step's send time
+ * thereafter — the caller passes whichever applies, so delays accumulate step
+ * over step.
+ *
+ * @param array $sequence
+ * @param int   $index   Step index to schedule.
+ * @param int   $from_ts Base Unix timestamp.
+ * @return int Unix timestamp the step is due, or 0 when the step doesn't exist.
+ */
+function zignites_chat_seq_next_run_at($sequence, $index, $from_ts) {
+    $step = zignites_chat_seq_get_step($sequence, $index);
+    if ($step === null) {
+        return 0;
+    }
+    $delay = zignites_chat_seq_delay_to_seconds(
+        $step['delay_value'] ?? 0,
+        $step['delay_unit'] ?? 'minutes'
+    );
+    return (int) $from_ts + $delay;
+}
+
+/**
+ * Render a step message by substituting placeholders. Pure.
+ *
+ * @param string $template
+ * @param array  $values Map of '{placeholder}' => replacement.
+ * @return string
+ */
+function zignites_chat_seq_render_message($template, $values) {
+    if (!is_array($values)) {
+        return (string) $template;
+    }
+    return str_replace(array_keys($values), array_values($values), (string) $template);
+}
+
+/**
+ * Sanitize a single step. Pure. Returns null for an unusable step (no message).
+ *
+ * @param mixed $raw
+ * @return array{delay_value:int, delay_unit:string, message:string}|null
+ */
+function zignites_chat_seq_sanitize_step($raw) {
+    if (!is_array($raw)) {
+        return null;
+    }
+    $message = isset($raw['message']) ? trim(zignites_chat_sanitize_textarea($raw['message'])) : '';
+    if ($message === '') {
+        return null;
+    }
+    $value = isset($raw['delay_value']) ? (int) $raw['delay_value'] : 0;
+    if ($value < 0) {
+        $value = 0;
+    }
+    $unit = isset($raw['delay_unit']) && in_array($raw['delay_unit'], array('minutes', 'hours', 'days'), true)
+        ? $raw['delay_unit']
+        : 'minutes';
+
+    return array(
+        'delay_value' => $value,
+        'delay_unit'  => $unit,
+        'message'     => $message,
+    );
+}
+
+/**
+ * Sanitize the whole sequences definition option. Pure (no DB).
+ *
+ * Drops sequences without an id, a valid trigger, or any usable step; coerces
+ * enabled to yes/no; de-duplicates ids (last wins); caps steps per sequence.
+ *
+ * @param mixed $raw
+ * @return array<int, array{id:string, name:string, enabled:string, trigger:string, steps:array}>
+ */
+function zignites_chat_seq_sanitize_sequences($raw) {
+    if (!is_array($raw)) {
+        return array();
+    }
+
+    $valid_triggers = array_keys(zignites_chat_seq_triggers());
+    $max_steps      = (int) apply_filters('zignites_chat_seq_max_steps', 20);
+    $by_id          = array();
+
+    foreach ($raw as $entry) {
+        if (!is_array($entry)) {
+            continue;
+        }
+        $id = isset($entry['id']) ? sanitize_key((string) $entry['id']) : '';
+        if ($id === '') {
+            continue;
+        }
+        $trigger = isset($entry['trigger']) ? (string) $entry['trigger'] : '';
+        if (!in_array($trigger, $valid_triggers, true)) {
+            continue;
+        }
+
+        $steps = array();
+        if (isset($entry['steps']) && is_array($entry['steps'])) {
+            foreach ($entry['steps'] as $raw_step) {
+                $step = zignites_chat_seq_sanitize_step($raw_step);
+                if ($step !== null) {
+                    $steps[] = $step;
+                }
+                if (count($steps) >= $max_steps) {
+                    break;
+                }
+            }
+        }
+        if (empty($steps)) {
+            continue;
+        }
+
+        $by_id[$id] = array(
+            'id'      => $id,
+            'name'    => isset($entry['name']) ? sanitize_text_field((string) $entry['name']) : $id,
+            'enabled' => (isset($entry['enabled']) && $entry['enabled'] === 'yes') ? 'yes' : 'no',
+            'trigger' => $trigger,
+            'steps'   => $steps,
+        );
+    }
+
+    return array_values($by_id);
+}
+
+/* -------------------------------------------------------------------------
+ * Sequence-definition storage
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Read all configured sequences, normalized through the sanitizer so callers
+ * always get a clean, predictable shape.
+ *
+ * @return array<int, array{id:string, name:string, enabled:string, trigger:string, steps:array}>
+ */
+function zignites_chat_seq_get_sequences() {
+    return zignites_chat_seq_sanitize_sequences(get_option('zignites_chat_sequences', array()));
+}
+
+/**
+ * Find a single sequence by id.
+ *
+ * @param string $id
+ * @return array|null
+ */
+function zignites_chat_seq_find($id) {
+    $id = sanitize_key((string) $id);
+    foreach (zignites_chat_seq_get_sequences() as $sequence) {
+        if ($sequence['id'] === $id) {
+            return $sequence;
+        }
+    }
+    return null;
+}
+
+/**
+ * Active sequences for a given trigger (enabled + at least one step).
+ *
+ * @param string $trigger
+ * @return array<int, array>
+ */
+function zignites_chat_seq_active_for_trigger($trigger) {
+    $trigger = (string) $trigger;
+    $out     = array();
+    foreach (zignites_chat_seq_get_sequences() as $sequence) {
+        if ($sequence['enabled'] === 'yes' && $sequence['trigger'] === $trigger && !empty($sequence['steps'])) {
+            $out[] = $sequence;
+        }
+    }
+    return $out;
+}

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -119,6 +119,7 @@ function zignites_chat_get_migrations() {
         6 => 'zignites_chat_migration_v6_inbox_tables',
         7 => 'zignites_chat_migration_v7_inbox_notes',
         8 => 'zignites_chat_migration_v8_stock_subs',
+        9 => 'zignites_chat_migration_v9_sequence_enrollments',
     ];
 }
 
@@ -228,6 +229,17 @@ function zignites_chat_migration_v7_inbox_notes() {
 function zignites_chat_migration_v8_stock_subs() {
     if (function_exists('zignites_chat_create_stock_subs_table')) {
         zignites_chat_create_stock_subs_table();
+    }
+}
+
+/**
+ * v9: create the drip-sequence enrollments table. Idempotent dbDelta; same
+ * WC-state guard shape as the other table migrations (drip-sequences.php is
+ * only loaded once boot_modules() runs).
+ */
+function zignites_chat_migration_v9_sequence_enrollments() {
+    if (function_exists('zignites_chat_create_sequence_enrollments_table')) {
+        zignites_chat_create_sequence_enrollments_table();
     }
 }
 

--- a/tests/Unit/DripSequencesTest.php
+++ b/tests/Unit/DripSequencesTest.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+namespace ZignitesChat\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class DripSequencesTest extends TestCase
+{
+    public function test_delay_to_seconds_by_unit(): void
+    {
+        $this->assertSame(5 * MINUTE_IN_SECONDS, \zignites_chat_seq_delay_to_seconds(5, 'minutes'));
+        $this->assertSame(2 * HOUR_IN_SECONDS, \zignites_chat_seq_delay_to_seconds(2, 'hours'));
+        $this->assertSame(3 * DAY_IN_SECONDS, \zignites_chat_seq_delay_to_seconds(3, 'days'));
+    }
+
+    public function test_delay_to_seconds_clamps_and_defaults_unit(): void
+    {
+        $this->assertSame(0, \zignites_chat_seq_delay_to_seconds(-4, 'days'));
+        // Unknown unit falls back to minutes.
+        $this->assertSame(7 * MINUTE_IN_SECONDS, \zignites_chat_seq_delay_to_seconds(7, 'weeks'));
+    }
+
+    public function test_step_count_and_get_step(): void
+    {
+        $seq = ['steps' => [['message' => 'a'], ['message' => 'b']]];
+        $this->assertSame(2, \zignites_chat_seq_step_count($seq));
+        $this->assertSame('b', \zignites_chat_seq_get_step($seq, 1)['message']);
+        $this->assertNull(\zignites_chat_seq_get_step($seq, 5));
+        $this->assertSame(0, \zignites_chat_seq_step_count(['no_steps' => true]));
+    }
+
+    public function test_next_run_at_offsets_from_base(): void
+    {
+        $seq  = ['steps' => [
+            ['delay_value' => 0, 'delay_unit' => 'minutes', 'message' => 'now'],
+            ['delay_value' => 2, 'delay_unit' => 'days', 'message' => 'later'],
+        ]];
+        $base = 1000000;
+        $this->assertSame($base, \zignites_chat_seq_next_run_at($seq, 0, $base));
+        $this->assertSame($base + 2 * DAY_IN_SECONDS, \zignites_chat_seq_next_run_at($seq, 1, $base));
+        // Out-of-range step → 0 (sentinel for "no more steps").
+        $this->assertSame(0, \zignites_chat_seq_next_run_at($seq, 9, $base));
+    }
+
+    public function test_render_message_substitutes(): void
+    {
+        $out = \zignites_chat_seq_render_message('Hi {name} from {site}', ['{name}' => 'Ana', '{site}' => 'Shop']);
+        $this->assertSame('Hi Ana from Shop', $out);
+        $this->assertSame('literal', \zignites_chat_seq_render_message('literal', 'nope'));
+    }
+
+    public function test_sanitize_step_drops_empty_and_normalizes(): void
+    {
+        $this->assertNull(\zignites_chat_seq_sanitize_step(['message' => '   ']));
+        $this->assertNull(\zignites_chat_seq_sanitize_step('nope'));
+
+        $step = \zignites_chat_seq_sanitize_step(['delay_value' => -3, 'delay_unit' => 'weeks', 'message' => 'Hello']);
+        $this->assertSame(0, $step['delay_value']);
+        $this->assertSame('minutes', $step['delay_unit']); // invalid unit falls back
+        $this->assertSame('Hello', $step['message']);
+    }
+
+    public function test_sanitize_sequences_filters_and_dedupes(): void
+    {
+        $raw = [
+            ['id' => 'welcome', 'name' => 'Welcome', 'enabled' => 'yes', 'trigger' => 'order_completed',
+                'steps' => [['delay_value' => 1, 'delay_unit' => 'days', 'message' => 'Thanks!']]],
+            ['id' => '', 'trigger' => 'optin', 'steps' => [['message' => 'x']]],            // no id → dropped
+            ['id' => 'bad', 'trigger' => 'not_a_trigger', 'steps' => [['message' => 'x']]],  // bad trigger → dropped
+            ['id' => 'nosteps', 'trigger' => 'optin', 'steps' => []],                        // no usable steps → dropped
+            ['id' => 'welcome', 'name' => 'Override', 'trigger' => 'optin',                  // dup id → last wins
+                'steps' => [['message' => 'Hi']]],
+        ];
+        $clean = \zignites_chat_seq_sanitize_sequences($raw);
+        $this->assertCount(1, $clean);
+        $this->assertSame('welcome', $clean[0]['id']);
+        $this->assertSame('Override', $clean[0]['name']);
+        $this->assertSame('optin', $clean[0]['trigger']);
+        $this->assertSame('no', $clean[0]['enabled']); // last entry had no enabled key
+    }
+
+    public function test_sanitize_sequences_non_array(): void
+    {
+        $this->assertSame([], \zignites_chat_seq_sanitize_sequences('nope'));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -147,6 +147,7 @@ require_once __DIR__ . '/../includes/cart-recovery.php';
 require_once __DIR__ . '/../includes/campaigns.php';
 require_once __DIR__ . '/../includes/back-in-stock.php';
 require_once __DIR__ . '/../includes/review-request.php';
+require_once __DIR__ . '/../includes/drip-sequences.php';
 require_once __DIR__ . '/../includes/inbox.php';
 require_once __DIR__ . '/../includes/inbox-capture.php';
 require_once __DIR__ . '/../includes/inbox-admin.php';

--- a/uninstall.php
+++ b/uninstall.php
@@ -109,6 +109,7 @@ $zignites_chat_option_keys = [
     'zignites_chat_inbox_canned_replies',
     'zignites_chat_inbox_notify_enabled',
     'zignites_chat_inbox_notify_email',
+    'zignites_chat_sequences',
 ];
 
 foreach ($zignites_chat_option_keys as $zignites_chat_key) {
@@ -128,6 +129,7 @@ $zignites_chat_tables = array(
 	$wpdb->prefix . 'zignites_chat_conversations',
 	$wpdb->prefix . 'zignites_chat_messages',
 	$wpdb->prefix . 'zignites_chat_stock_subs',
+	$wpdb->prefix . 'zignites_chat_sequence_enrollments',
 );
 foreach ( $zignites_chat_tables as $zignites_chat_table ) {
 	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange -- One-time uninstall cleanup; table name is built from $wpdb->prefix, no user input.


### PR DESCRIPTION
- First increment of the drip & automation sequences feature — the pure data layer only, mirroring how the two-way inbox was built
- Adds the sequence enrollments table (migration v9, created on activation, dropped on uninstall) to track each customer walking a sequence
- Stores sequence definitions in a single option with a strict sanitizer: drops sequences without an id, a known trigger, or any usable step, de-dupes ids, and caps steps per sequence
- Defines the trigger catalogue (order completed, opted in, win-back, browse abandonment) with the placeholders each one exposes
- Pure, unit-tested scheduling helpers: delay-to-seconds by unit, step lookup, per-step run-time offsets, and message rendering
- No enrollment, cron sending, or admin UI yet — those land in the next increments (S2 triggers, S3 sender, S4 UI, S5 scan-based win-back/browse-abandon)
- 8 new unit tests; full suite at 244 passing, PHPCS green