### PR TITLE
Drip sequences: enrollment + triggers (T3.1 S2)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -536,8 +536,18 @@ Build on the merged two-way inbox (P1):
         cumulative per-step offsets, `render_message`, `sanitize_step`).
         No enrollment/cron/UI yet — mirrors inbox I1. 8 unit tests; 244 pass,
         PHPCS green.
-  - [ ] S2 — Enrollment + trigger wiring (enroll on order_completed / optin;
-        idempotent upsert into the table; respects Pro + per-sequence enable).
+  - [x] S2 — Enrollment + trigger wiring, on `feat/pro-drip-enrollment`.
+        Added a `context` column (migration v10) holding the placeholder values
+        captured when the trigger fires. `zignites_chat_seq_enroll()` is
+        idempotent (UNIQUE sequence_id+phone, existence check) and Pro-gated;
+        `enroll_all_for_trigger()` fans a phone into every active sequence for a
+        trigger. Two entry points: `woocommerce_order_status_completed` (captures
+        {name}/{order_id}/{total}/{currency_symbol}/{site}) and a new
+        `zignites_chat_customer_opted_in` action fired from
+        `zignites_chat_record_optin()` ({name}/{site}). Pure tested helpers
+        `seq_format_mysql` + `seq_build_enrollment_row` (schedules step 0 at
+        enroll + delay, serializes context). Gating stays at send time (S3).
+        3 new unit tests; 247 pass, PHPCS green.
   - [ ] S3 — Cron processor + sender: walk due enrollments, send the step via
         the dispatcher (opt-out/consent/quiet-hours/rate-limit gates), advance
         `current_step`/`next_run_at`, complete at the end. Chunked like the
@@ -611,9 +621,9 @@ Q2 (review/NPS request) + Q4 (Meta template sync) DONE** (all merged into
 `pro`). Remaining quick win: **Q5 sender-health**.
 
 **Tier 3 — T3.1 drip & automation sequences IN PROGRESS** (incremental PRs).
-**S1 engine foundation DONE** on `feat/pro-drip-sequences` (awaiting PR). Next:
-S2 enrollment + trigger wiring → S3 cron sender → S4 admin UI → S5 scan-based
-triggers. See PHASE 9 → Tier 3 for the increment breakdown.
+**S1 (engine foundation) + S2 (enrollment + triggers) DONE** (S1 merged into
+`pro`; S2 on `feat/pro-drip-enrollment` awaiting PR). Next: S3 cron sender →
+S4 admin UI → S5 scan-based triggers. See PHASE 9 → Tier 3 for the breakdown.
 
 The original Pro backlog is otherwise cleared into `pro`; the only blocked item
 is retiring `license-manager.php` (needs the Freemius credentials migration —

--- a/includes/drip-sequences.php
+++ b/includes/drip-sequences.php
@@ -9,15 +9,17 @@
  * the customer is *enrolled*; a background processor then walks the steps,
  * sending each after its delay elapses.
  *
- * This file is the pure data layer only — mirroring inbox I1:
- *   - the enrollments table (idempotent dbDelta) + migration v9,
- *   - sequence-definition storage (option `zignites_chat_sequences`) with a
- *     sanitizer + normalizing getters,
- *   - pure, unit-tested helpers for delay maths, step lookup, scheduling and
- *     message rendering.
+ * Increments so far:
+ *   - S1 (engine foundation): the enrollments table (idempotent dbDelta) +
+ *     migration v9, sequence-definition storage (option `zignites_chat_sequences`)
+ *     with a sanitizer + normalizing getters, and pure unit-tested helpers for
+ *     delay maths, step lookup, scheduling and message rendering.
+ *   - S2 (enrollment + triggers): a `context` column (migration v10) holding
+ *     the placeholder values captured when the trigger fires, idempotent
+ *     `zignites_chat_seq_enroll()`, and the order-completed / opt-in entry
+ *     points that enroll a phone into every active sequence for that trigger.
  *
- * Enrollment + trigger wiring, the cron sender, and the admin CRUD UI land in
- * later increments on top of these primitives.
+ * The cron sender and the admin CRUD UI land in later increments.
  *
  * @package Zignites_Chat
  */
@@ -61,6 +63,7 @@ function zignites_chat_create_sequence_enrollments_table() {
         next_run_at DATETIME NULL,
         enrolled_at DATETIME NOT NULL,
         last_step_at DATETIME NULL,
+        context LONGTEXT NULL,
         PRIMARY KEY  (id),
         UNIQUE KEY sequence_phone (sequence_id, phone),
         KEY status_next (status, next_run_at)
@@ -334,4 +337,195 @@ function zignites_chat_seq_active_for_trigger($trigger) {
         }
     }
     return $out;
+}
+
+/* -------------------------------------------------------------------------
+ * Enrollment
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Format a Unix timestamp as a MySQL datetime string. Pure.
+ *
+ * Used for the table's DATETIME columns. The caller passes a WP-local
+ * timestamp (current_time('timestamp')) so the stored value is comparable to
+ * current_time('mysql') without a timezone round-trip.
+ *
+ * @param int $ts
+ * @return string
+ */
+function zignites_chat_seq_format_mysql($ts) {
+    return gmdate('Y-m-d H:i:s', (int) $ts);
+}
+
+/**
+ * Build the row to insert for a new enrollment. Pure (no DB).
+ *
+ * Step 0's delay is measured from the enrollment time, so the first send is
+ * scheduled at enroll + step[0] delay. A step-0 delay of 0 schedules it for
+ * the next processor tick.
+ *
+ * @param array  $sequence Sanitized sequence (must have id + steps).
+ * @param string $phone    Normalized phone.
+ * @param int    $now_ts   Enrollment timestamp (WP-local epoch).
+ * @param array  $context  Placeholder => value map captured at trigger time.
+ * @return array{sequence_id:string, phone:string, status:string, current_step:int, next_run_at:string, enrolled_at:string, last_step_at:null, context:string}
+ */
+function zignites_chat_seq_build_enrollment_row($sequence, $phone, $now_ts, $context = array()) {
+    $now_mysql = zignites_chat_seq_format_mysql($now_ts);
+    $run_ts    = zignites_chat_seq_next_run_at($sequence, 0, $now_ts);
+
+    return array(
+        'sequence_id'  => (string) ($sequence['id'] ?? ''),
+        'phone'        => (string) $phone,
+        'status'       => 'active',
+        'current_step' => 0,
+        'next_run_at'  => $run_ts ? zignites_chat_seq_format_mysql($run_ts) : $now_mysql,
+        'enrolled_at'  => $now_mysql,
+        'last_step_at' => null,
+        'context'      => wp_json_encode(is_array($context) ? $context : array()),
+    );
+}
+
+/**
+ * Whether a phone is already enrolled in a sequence (any status). Used to keep
+ * enrollment idempotent so a repeat trigger doesn't restart the sequence.
+ *
+ * @param string $sequence_id
+ * @param string $phone Normalized phone.
+ * @return bool
+ */
+function zignites_chat_seq_enrollment_exists($sequence_id, $phone) {
+    global $wpdb;
+    $table = zignites_chat_seq_enrollments_table_name();
+    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+    return (bool) $wpdb->get_var($wpdb->prepare(
+        "SELECT id FROM {$table} WHERE sequence_id = %s AND phone = %s",
+        (string) $sequence_id,
+        (string) $phone
+    ));
+}
+
+/**
+ * Enroll a phone into a sequence. Idempotent: a number already enrolled in the
+ * same sequence is skipped. Gating (opt-out / consent / quiet hours / rate
+ * limit) is applied later at send time, not here.
+ *
+ * @param array|string $sequence Sanitized sequence array or its id.
+ * @param string       $phone    Phone in any format.
+ * @param array        $context  Placeholder => value map for later rendering.
+ * @return bool True when a new enrollment was created.
+ */
+function zignites_chat_seq_enroll($sequence, $phone, $context = array()) {
+    if (is_string($sequence)) {
+        $sequence = zignites_chat_seq_find($sequence);
+    }
+    if (!is_array($sequence) || empty($sequence['id']) || empty($sequence['steps'])) {
+        return false;
+    }
+    if (function_exists('zignites_chat_is_pro_active') && !zignites_chat_is_pro_active()) {
+        return false;
+    }
+
+    $phone = zignites_chat_normalize_phone($phone);
+    if ($phone === '') {
+        return false;
+    }
+    if (zignites_chat_seq_enrollment_exists($sequence['id'], $phone)) {
+        return false;
+    }
+
+    $row = zignites_chat_seq_build_enrollment_row($sequence, $phone, current_time('timestamp'), $context);
+
+    global $wpdb;
+    $table = zignites_chat_seq_enrollments_table_name();
+    // last_step_at is left to its NULL column default.
+    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+    $wpdb->insert(
+        $table,
+        array(
+            'sequence_id'  => $row['sequence_id'],
+            'phone'        => $row['phone'],
+            'status'       => $row['status'],
+            'current_step' => $row['current_step'],
+            'next_run_at'  => $row['next_run_at'],
+            'enrolled_at'  => $row['enrolled_at'],
+            'context'      => $row['context'],
+        ),
+        array('%s', '%s', '%s', '%d', '%s', '%s', '%s')
+    );
+
+    return (bool) $wpdb->insert_id;
+}
+
+/**
+ * Enroll a phone into every active sequence for a trigger, sharing one context.
+ *
+ * @param string $trigger
+ * @param string $phone
+ * @param array  $context
+ * @return void
+ */
+function zignites_chat_seq_enroll_all_for_trigger($trigger, $phone, $context = array()) {
+    if (function_exists('zignites_chat_is_pro_active') && !zignites_chat_is_pro_active()) {
+        return;
+    }
+    foreach (zignites_chat_seq_active_for_trigger($trigger) as $sequence) {
+        zignites_chat_seq_enroll($sequence, $phone, $context);
+    }
+}
+
+/* -------------------------------------------------------------------------
+ * Triggers
+ * ----------------------------------------------------------------------- */
+
+add_action('woocommerce_order_status_completed', 'zignites_chat_seq_enroll_on_order_completed', 20, 1);
+add_action('zignites_chat_customer_opted_in', 'zignites_chat_seq_enroll_on_optin', 10, 2);
+
+/**
+ * order_completed trigger — enroll the order's billing phone into every active
+ * post-purchase sequence, capturing order placeholders for later rendering.
+ *
+ * @param int $order_id
+ * @return void
+ */
+function zignites_chat_seq_enroll_on_order_completed($order_id) {
+    $sequences = zignites_chat_seq_active_for_trigger('order_completed');
+    if (empty($sequences)) {
+        return;
+    }
+    $order = function_exists('wc_get_order') ? wc_get_order($order_id) : null;
+    if (!$order) {
+        return;
+    }
+    $phone = $order->get_billing_phone();
+    if (!$phone) {
+        return;
+    }
+
+    $context = array(
+        '{name}'            => $order->get_billing_first_name(),
+        '{order_id}'        => $order->get_id(),
+        '{total}'           => $order->get_total(),
+        '{currency_symbol}' => function_exists('zignites_chat_currency_symbol_text') ? zignites_chat_currency_symbol_text() : '',
+        '{site}'            => function_exists('get_bloginfo') ? get_bloginfo('name') : '',
+    );
+
+    foreach ($sequences as $sequence) {
+        zignites_chat_seq_enroll($sequence, $phone, $context);
+    }
+}
+
+/**
+ * optin trigger — enroll a freshly-consented phone into every active welcome
+ * sequence. Fired by zignites_chat_record_optin().
+ *
+ * @param string $phone
+ * @param string $source
+ * @return void
+ */
+function zignites_chat_seq_enroll_on_optin($phone, $source = '') {
+    zignites_chat_seq_enroll_all_for_trigger('optin', $phone, array(
+        '{name}' => '',
+        '{site}' => function_exists('get_bloginfo') ? get_bloginfo('name') : '',
+    ));
 }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -120,6 +120,7 @@ function zignites_chat_get_migrations() {
         7 => 'zignites_chat_migration_v7_inbox_notes',
         8 => 'zignites_chat_migration_v8_stock_subs',
         9 => 'zignites_chat_migration_v9_sequence_enrollments',
+        10 => 'zignites_chat_migration_v10_sequence_context',
     ];
 }
 
@@ -238,6 +239,17 @@ function zignites_chat_migration_v8_stock_subs() {
  * only loaded once boot_modules() runs).
  */
 function zignites_chat_migration_v9_sequence_enrollments() {
+    if (function_exists('zignites_chat_create_sequence_enrollments_table')) {
+        zignites_chat_create_sequence_enrollments_table();
+    }
+}
+
+/**
+ * v10: add the enrollments `context` column (placeholder values captured at
+ * trigger time). Idempotent dbDelta re-run of the table creator, same guard
+ * shape as the other table migrations.
+ */
+function zignites_chat_migration_v10_sequence_context() {
     if (function_exists('zignites_chat_create_sequence_enrollments_table')) {
         zignites_chat_create_sequence_enrollments_table();
     }

--- a/includes/optin.php
+++ b/includes/optin.php
@@ -124,6 +124,16 @@ function zignites_chat_record_optin($phone, $source = 'checkout') {
     if (function_exists('zignites_chat_dispatch_webhook')) {
         zignites_chat_dispatch_webhook('customer.opted_in', ['phone' => $phone, 'source' => $source]);
     }
+
+    /**
+     * Fires after a phone gives explicit WhatsApp consent. Decoupled entry
+     * point for opt-in-triggered automations (e.g. drip welcome sequences).
+     *
+     * @param string $phone  Normalized phone (digits only).
+     * @param string $source Capture source.
+     */
+    do_action('zignites_chat_customer_opted_in', $phone, $source);
+
     return true;
 }
 

--- a/tests/Unit/DripSequencesTest.php
+++ b/tests/Unit/DripSequencesTest.php
@@ -84,4 +84,37 @@ final class DripSequencesTest extends TestCase
     {
         $this->assertSame([], \zignites_chat_seq_sanitize_sequences('nope'));
     }
+
+    public function test_format_mysql_is_utc_deterministic(): void
+    {
+        $this->assertSame('1970-01-01 00:00:00', \zignites_chat_seq_format_mysql(0));
+        $this->assertSame('1970-01-12 13:46:40', \zignites_chat_seq_format_mysql(1000000));
+    }
+
+    public function test_build_enrollment_row_schedules_first_step(): void
+    {
+        $seq = [
+            'id'    => 'welcome',
+            'steps' => [['delay_value' => 2, 'delay_unit' => 'days', 'message' => 'hi']],
+        ];
+        $base = 1000000;
+        $row  = \zignites_chat_seq_build_enrollment_row($seq, '15551234567', $base, ['{name}' => 'Ana']);
+
+        $this->assertSame('welcome', $row['sequence_id']);
+        $this->assertSame('15551234567', $row['phone']);
+        $this->assertSame('active', $row['status']);
+        $this->assertSame(0, $row['current_step']);
+        $this->assertNull($row['last_step_at']);
+        $this->assertSame(\zignites_chat_seq_format_mysql($base), $row['enrolled_at']);
+        $this->assertSame(\zignites_chat_seq_format_mysql($base + 2 * DAY_IN_SECONDS), $row['next_run_at']);
+        $this->assertSame('{"{name}":"Ana"}', $row['context']);
+    }
+
+    public function test_build_enrollment_row_zero_delay_runs_at_enroll(): void
+    {
+        $seq = ['id' => 's', 'steps' => [['delay_value' => 0, 'delay_unit' => 'minutes', 'message' => 'x']]];
+        $row = \zignites_chat_seq_build_enrollment_row($seq, '123', 555, []);
+        $this->assertSame($row['enrolled_at'], $row['next_run_at']);
+        $this->assertSame('[]', $row['context']);
+    }
 }


### PR DESCRIPTION
- Second increment — wires up enrolling customers into sequences when a trigger fires
- Adds a context column (migration v10) so the placeholder values are captured at trigger time and rendered later by the sender
- Enrollment is idempotent and Pro-gated: a phone already in a sequence won't be restarted by a repeat trigger
- Order-completed trigger enrolls the billing phone into every active post-purchase sequence, capturing name/order id/total/currency/site
- Opt-in trigger enrolls a freshly-consented phone into welcome sequences, via a new decoupled customer-opted-in action fired from record_optin()
- Send-time gating (opt-out, consent, quiet hours, rate limit) stays in the sender increment (S3); enrollment is intentionally permissive
- Pure helpers for the mysql timestamp + enrollment row are unit-tested
- 3 new unit tests; full suite at 247 passing, PHPCS green