### PR TITLE
Drip sequences: cron processor + sender (T3.1 S3)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -548,10 +548,18 @@ Build on the merged two-way inbox (P1):
         `seq_format_mysql` + `seq_build_enrollment_row` (schedules step 0 at
         enroll + delay, serializes context). Gating stays at send time (S3).
         3 new unit tests; 247 pass, PHPCS green.
-  - [ ] S3 — Cron processor + sender: walk due enrollments, send the step via
-        the dispatcher (opt-out/consent/quiet-hours/rate-limit gates), advance
-        `current_step`/`next_run_at`, complete at the end. Chunked like the
-        other bulk senders.
+  - [x] S3 — Cron processor + sender, on `feat/pro-drip-sender`. A recurring
+        5-minute event (`zignites_chat_process_sequences`, reusing the shared
+        `zignites_chat_five_minutes` schedule; unscheduled on deactivate, cleared
+        on uninstall) pulls due active enrollments (`next_run_at <= now`, chunked
+        30), renders the current step from the stored context, sends via the
+        dispatcher (`type=sequence`), then advances. Gating: quiet hours skip the
+        whole run; opt-out / missing-consent and a removed/disabled sequence
+        cancel the enrollment permanently; the shared rate limiter breaks the run
+        (rows stay due for the next tick). Advance is fire-and-forget like the
+        other senders. Pure tested helper `seq_plan_advance` (next step → active
+        with new next_run_at, or completed). 2 new unit tests; 249 pass, PHPCS
+        green.
   - [ ] S4 — Admin CRUD UI: a Pro "Sequences" submenu to create/edit sequences
         (trigger + ordered steps with delays + messages) and an enrollment
         count per sequence.
@@ -621,8 +629,10 @@ Q2 (review/NPS request) + Q4 (Meta template sync) DONE** (all merged into
 `pro`). Remaining quick win: **Q5 sender-health**.
 
 **Tier 3 — T3.1 drip & automation sequences IN PROGRESS** (incremental PRs).
-**S1 (engine foundation) + S2 (enrollment + triggers) DONE** (S1 merged into
-`pro`; S2 on `feat/pro-drip-enrollment` awaiting PR). Next: S3 cron sender →
+**S1 (engine foundation), S2 (enrollment + triggers) + S3 (cron sender) DONE**
+(S1/S2 merged into `pro`; S3 on `feat/pro-drip-sender` awaiting PR). At this
+point drip sequences are fully functional end-to-end — they just lack a UI, so
+sequences must be defined via the `zignites_chat_sequences` option/filter. Next:
 S4 admin UI → S5 scan-based triggers. See PHASE 9 → Tier 3 for the breakdown.
 
 The original Pro backlog is otherwise cleared into `pro`; the only blocked item

--- a/includes/class-zignites-chat-plugin.php
+++ b/includes/class-zignites-chat-plugin.php
@@ -140,6 +140,9 @@ final class Plugin {
         if (function_exists('zignites_chat_unschedule_campaign_promoter_cron')) {
             zignites_chat_unschedule_campaign_promoter_cron();
         }
+        if (function_exists('zignites_chat_seq_unschedule_cron')) {
+            zignites_chat_seq_unschedule_cron();
+        }
         wp_clear_scheduled_hook('zignites_chat_cleanup_analytics');
     }
 

--- a/includes/drip-sequences.php
+++ b/includes/drip-sequences.php
@@ -18,8 +18,13 @@
  *     the placeholder values captured when the trigger fires, idempotent
  *     `zignites_chat_seq_enroll()`, and the order-completed / opt-in entry
  *     points that enroll a phone into every active sequence for that trigger.
+ *   - S3 (cron processor + sender): a recurring 5-minute event that sends each
+ *     active enrollment's due step through the dispatcher — applying the
+ *     marketing gates (quiet hours skip the run, opt-out/consent cancel the
+ *     enrollment, the shared rate limiter stops the run) — then advances the
+ *     step or completes the enrollment.
  *
- * The cron sender and the admin CRUD UI land in later increments.
+ * The admin CRUD UI lands in a later increment.
  *
  * @package Zignites_Chat
  */
@@ -528,4 +533,209 @@ function zignites_chat_seq_enroll_on_optin($phone, $source = '') {
         '{name}' => '',
         '{site}' => function_exists('get_bloginfo') ? get_bloginfo('name') : '',
     ));
+}
+
+/* -------------------------------------------------------------------------
+ * Cron processor + sender (S3)
+ * ----------------------------------------------------------------------- */
+
+// Reuse the 5-minute schedule registered by cart-recovery.php; re-declare the
+// guarded filter so the processor doesn't depend on module load order.
+add_filter('cron_schedules', function ($schedules) {
+    if (!isset($schedules['zignites_chat_five_minutes'])) {
+        $schedules['zignites_chat_five_minutes'] = array(
+            'interval' => 5 * MINUTE_IN_SECONDS,
+            'display'  => __('Every 5 minutes (Zignites Chat)', 'zignites-chat'),
+        );
+    }
+    return $schedules;
+});
+
+add_action('init', 'zignites_chat_seq_schedule_cron');
+add_action('zignites_chat_process_sequences', 'zignites_chat_seq_process_enrollments');
+
+/**
+ * Ensure the recurring sequence processor event is scheduled.
+ */
+function zignites_chat_seq_schedule_cron() {
+    if (!wp_next_scheduled('zignites_chat_process_sequences')) {
+        wp_schedule_event(time() + 60, 'zignites_chat_five_minutes', 'zignites_chat_process_sequences');
+    }
+}
+
+/**
+ * Clear the processor event (deactivation / uninstall).
+ */
+function zignites_chat_seq_unschedule_cron() {
+    $timestamp = wp_next_scheduled('zignites_chat_process_sequences');
+    if ($timestamp) {
+        wp_unschedule_event($timestamp, 'zignites_chat_process_sequences');
+    }
+}
+
+/**
+ * Compute the enrollment's state after sending its current step. Pure.
+ *
+ * The next step's delay is measured from $now_ts (this send time), so delays
+ * accumulate step over step. When there is no next step the enrollment is
+ * completed (next_run_at cleared).
+ *
+ * @param array  $sequence     Sanitized sequence.
+ * @param int    $current_step Index of the step just sent.
+ * @param int    $now_ts       Send timestamp (WP-local epoch).
+ * @return array{status:string, current_step:int, next_run_at:?string, last_step_at:string}
+ */
+function zignites_chat_seq_plan_advance($sequence, $current_step, $now_ts) {
+    $next   = (int) $current_step + 1;
+    $run_ts = zignites_chat_seq_next_run_at($sequence, $next, $now_ts);
+    $last   = zignites_chat_seq_format_mysql($now_ts);
+
+    if ($run_ts) {
+        return array(
+            'status'       => 'active',
+            'current_step' => $next,
+            'next_run_at'  => zignites_chat_seq_format_mysql($run_ts),
+            'last_step_at' => $last,
+        );
+    }
+    return array(
+        'status'       => 'completed',
+        'current_step' => $next,
+        'next_run_at'  => null,
+        'last_step_at' => $last,
+    );
+}
+
+/**
+ * Cron callback: send the due step for each active enrollment, then advance it.
+ *
+ * Chunked like the other bulk senders. Quiet hours skip the whole run (picked
+ * up next tick); the shared rate limiter stops the run mid-way (remaining rows
+ * stay due). Opt-out / missing-consent and removed/disabled sequences cancel
+ * the enrollment permanently rather than retrying.
+ *
+ * @return void
+ */
+function zignites_chat_seq_process_enrollments() {
+    if (function_exists('zignites_chat_is_pro_active') && !zignites_chat_is_pro_active()) {
+        return;
+    }
+    // Quiet hours: defer the entire run to a later tick (drip is marketing).
+    if (function_exists('zignites_chat_quiet_hours_active') && zignites_chat_quiet_hours_active()) {
+        return;
+    }
+
+    global $wpdb;
+    $table = zignites_chat_seq_enrollments_table_name();
+    $now   = current_time('mysql');
+    $chunk = max(1, min(100, (int) apply_filters('zignites_chat_seq_chunk_size', 30)));
+
+    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+    $rows = $wpdb->get_results($wpdb->prepare(
+        "SELECT id, sequence_id, phone, current_step, context FROM {$table}
+         WHERE status = 'active' AND next_run_at IS NOT NULL AND next_run_at <= %s
+         ORDER BY next_run_at ASC LIMIT %d",
+        $now,
+        $chunk
+    ));
+    if (!$rows) {
+        return;
+    }
+
+    foreach ($rows as $row) {
+        $sequence = zignites_chat_seq_find($row->sequence_id);
+
+        // Sequence removed or switched off mid-flight → stop this enrollment.
+        if (!is_array($sequence) || $sequence['enabled'] !== 'yes') {
+            zignites_chat_seq_cancel_enrollment((int) $row->id);
+            continue;
+        }
+
+        // Marketing gate: opted out, or consent required and missing → permanent.
+        if (function_exists('zignites_chat_marketing_blocked') && zignites_chat_marketing_blocked($row->phone)) {
+            zignites_chat_seq_cancel_enrollment((int) $row->id);
+            continue;
+        }
+
+        $step = zignites_chat_seq_get_step($sequence, (int) $row->current_step);
+        if ($step === null) {
+            // current_step fell out of range (sequence shrank) → done.
+            zignites_chat_seq_complete_enrollment((int) $row->id);
+            continue;
+        }
+
+        // Shared per-minute budget: stop the run when exhausted; the rows left
+        // stay due and the next tick resumes. Checked before the send so a
+        // saturated window doesn't advance anyone.
+        if (function_exists('zignites_chat_outbound_rate_acquire') && !zignites_chat_outbound_rate_acquire()) {
+            break;
+        }
+
+        $context = json_decode((string) $row->context, true);
+        if (!is_array($context)) {
+            $context = array();
+        }
+        $message = zignites_chat_seq_render_message($step['message'], $context);
+
+        if (trim($message) !== '') {
+            zignites_chat_send_whatsapp_message($row->phone, $message, false, array(
+                'type'        => 'sequence',
+                'sequence_id' => $sequence['id'],
+                'step'        => (int) $row->current_step,
+            ));
+        }
+
+        // Fire-and-forget advance (mirrors back-in-stock / status sends): the
+        // analytics log records delivery state; we always move the step on.
+        $plan = zignites_chat_seq_plan_advance($sequence, (int) $row->current_step, current_time('timestamp'));
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+        $wpdb->update(
+            $table,
+            array(
+                'status'       => $plan['status'],
+                'current_step' => $plan['current_step'],
+                'next_run_at'  => $plan['next_run_at'],
+                'last_step_at' => $plan['last_step_at'],
+            ),
+            array('id' => (int) $row->id),
+            array('%s', '%d', '%s', '%s'),
+            array('%d')
+        );
+    }
+}
+
+/**
+ * Mark an enrollment cancelled (permanent stop, no more sends).
+ *
+ * @param int $id
+ * @return void
+ */
+function zignites_chat_seq_cancel_enrollment($id) {
+    global $wpdb;
+    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+    $wpdb->update(
+        zignites_chat_seq_enrollments_table_name(),
+        array('status' => 'cancelled', 'next_run_at' => null),
+        array('id' => (int) $id),
+        array('%s', '%s'),
+        array('%d')
+    );
+}
+
+/**
+ * Mark an enrollment completed (reached the end of the sequence).
+ *
+ * @param int $id
+ * @return void
+ */
+function zignites_chat_seq_complete_enrollment($id) {
+    global $wpdb;
+    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+    $wpdb->update(
+        zignites_chat_seq_enrollments_table_name(),
+        array('status' => 'completed', 'next_run_at' => null),
+        array('id' => (int) $id),
+        array('%s', '%s'),
+        array('%d')
+    );
 }

--- a/tests/Unit/DripSequencesTest.php
+++ b/tests/Unit/DripSequencesTest.php
@@ -117,4 +117,33 @@ final class DripSequencesTest extends TestCase
         $this->assertSame($row['enrolled_at'], $row['next_run_at']);
         $this->assertSame('[]', $row['context']);
     }
+
+    public function test_plan_advance_schedules_next_step(): void
+    {
+        $seq = ['id' => 'w', 'steps' => [
+            ['delay_value' => 0, 'delay_unit' => 'minutes', 'message' => 'a'],
+            ['delay_value' => 1, 'delay_unit' => 'hours', 'message' => 'b'],
+        ]];
+        $now  = 2000000;
+        $plan = \zignites_chat_seq_plan_advance($seq, 0, $now);
+
+        $this->assertSame('active', $plan['status']);
+        $this->assertSame(1, $plan['current_step']);
+        $this->assertSame(\zignites_chat_seq_format_mysql($now + HOUR_IN_SECONDS), $plan['next_run_at']);
+        $this->assertSame(\zignites_chat_seq_format_mysql($now), $plan['last_step_at']);
+    }
+
+    public function test_plan_advance_completes_after_last_step(): void
+    {
+        $seq = ['id' => 'w', 'steps' => [
+            ['delay_value' => 0, 'delay_unit' => 'minutes', 'message' => 'a'],
+        ]];
+        $now  = 2000000;
+        $plan = \zignites_chat_seq_plan_advance($seq, 0, $now);
+
+        $this->assertSame('completed', $plan['status']);
+        $this->assertSame(1, $plan['current_step']);
+        $this->assertNull($plan['next_run_at']);
+        $this->assertSame(\zignites_chat_seq_format_mysql($now), $plan['last_step_at']);
+    }
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -147,6 +147,7 @@ $zignites_chat_cron_hooks = array(
 	'zignites_chat_send_review_request',
 	'zignites_chat_webhook_retry',
 	'zignites_chat_process_stock_alerts',
+	'zignites_chat_process_sequences',
 );
 foreach ($zignites_chat_cron_hooks as $zignites_chat_hook) {
 	wp_clear_scheduled_hook($zignites_chat_hook);


### PR DESCRIPTION
- Third increment — the engine that actually walks enrollments and sends each step
- Adds a recurring 5-minute event that pulls due active enrollments (chunked), renders the current step from the context captured at enrollment, and sends it through the WhatsApp dispatcher
- After sending, advances to the next step (scheduling it by its delay) or completes the enrollment when the sequence ends
- Respects the marketing gates: quiet hours skip the whole run, opt-outs and missing consent cancel the enrollment, and the shared rate limiter stops the run so leftover rows resume next tick
- A removed or switched-off sequence cancels its in-flight enrollments instead of erroring
- Cron is unscheduled on deactivation and cleared on uninstall
- With this, drip sequences work end-to-end; only the admin UI is left (sequences are configured via the option/filter for now)
- Pure step-advance helper is unit-tested; 2 new tests, full suite at 249 passing, PHPCS green