### PR TITLE
Drip sequences: admin CRUD UI (T3.1 S4)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -560,9 +560,17 @@ Build on the merged two-way inbox (P1):
         other senders. Pure tested helper `seq_plan_advance` (next step → active
         with new next_run_at, or completed). 2 new unit tests; 249 pass, PHPCS
         green.
-  - [ ] S4 — Admin CRUD UI: a Pro "Sequences" submenu to create/edit sequences
-        (trigger + ordered steps with delays + messages) and an enrollment
-        count per sequence.
+  - [x] S4 — Admin CRUD UI, on `feat/pro-drip-admin-ui`. A Pro "Sequences"
+        submenu (`tab-sequences.php` + `assets/js/sequences.js`): each sequence
+        is an editable card (id, name, enabled, trigger, ordered delay+message
+        steps); steps and whole sequences are added/removed client-side and the
+        `zignites_chat_sequences` option round-trips through the existing
+        sanitizer on save (registered in `zignites_chat_sequences_group`), so
+        blank/removed cards drop server-side. Existing cards show their live
+        enrollment counts (active/completed/cancelled) and a read-only id;
+        the trigger dropdown reveals that trigger's placeholders. Upsell card
+        added. Pure tested helper `seq_shape_counts` + a grouped-count query
+        `seq_enrollment_counts`. 2 new unit tests; 251 pass, PHPCS + JS clean.
   - [ ] S5 — Scan-based triggers: win-back (no order in N days) + browse-abandon
         (viewed product, no order), each a scheduled scan that enrolls matches.
 
@@ -629,11 +637,12 @@ Q2 (review/NPS request) + Q4 (Meta template sync) DONE** (all merged into
 `pro`). Remaining quick win: **Q5 sender-health**.
 
 **Tier 3 — T3.1 drip & automation sequences IN PROGRESS** (incremental PRs).
-**S1 (engine foundation), S2 (enrollment + triggers) + S3 (cron sender) DONE**
-(S1/S2 merged into `pro`; S3 on `feat/pro-drip-sender` awaiting PR). At this
-point drip sequences are fully functional end-to-end — they just lack a UI, so
-sequences must be defined via the `zignites_chat_sequences` option/filter. Next:
-S4 admin UI → S5 scan-based triggers. See PHASE 9 → Tier 3 for the breakdown.
+**S1–S4 DONE** (S1/S2/S3 merged into `pro`; S4 admin UI on
+`feat/pro-drip-admin-ui` awaiting PR). Drip sequences are now fully usable from
+the admin — create/edit sequences with trigger + delay/message steps, enroll on
+order-completed / opt-in, walk + send on the 5-minute cron with all marketing
+gates. Only **S5 (scan-based win-back + browse-abandon triggers)** remains to
+finish T3.1. See PHASE 9 → Tier 3 for the breakdown.
 
 The original Pro backlog is otherwise cleared into `pro`; the only blocked item
 is retiring `license-manager.php` (needs the Freemius credentials migration —

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -120,6 +120,12 @@ function zignites_chat_register_settings() {
     // WABA ID drives the "Sync from Meta" pull on the same page.
     register_setting('zignites_chat_wa_templates_group', 'zignites_chat_cloud_waba_id', ['sanitize_callback' => 'zignites_chat_sanitize_text']);
 
+    // Drip & automation sequences (Pro).
+    register_setting('zignites_chat_sequences_group', 'zignites_chat_sequences', [
+        'sanitize_callback' => 'zignites_chat_seq_sanitize_sequences',
+        'default'           => [],
+    ]);
+
     // License.
     register_setting('zignites_chat_license_group', 'zignites_chat_license_key', ['sanitize_callback' => 'zignites_chat_sanitize_text']);
 }
@@ -155,6 +161,7 @@ function zignites_chat_register_admin_menus() {
         ['zignites-chat-quiet',         __('Quiet Hours', 'zignites-chat'),      'zignites_chat_render_quiet_page',         true],
         ['zignites-chat-stock',         __('Back in Stock', 'zignites-chat'),    'zignites_chat_render_stock_page',         true],
         ['zignites-chat-review',        __('Review Requests', 'zignites-chat'),  'zignites_chat_render_review_page',        true],
+        ['zignites-chat-sequences',     __('Sequences', 'zignites-chat'),        'zignites_chat_render_sequences_page',     true],
         ['zignites-chat-campaigns',     __('Campaigns', 'zignites-chat'),        'zignites_chat_render_campaigns_page',     true],
         ['zignites-chat-inbox',         __('Inbox', 'zignites-chat'),            'zignites_chat_render_inbox_page',         true],
         ['zignites-chat-analytics',     __('Analytics', 'zignites-chat'),        'zignites_chat_render_analytics_page',     true],
@@ -254,6 +261,16 @@ function zignites_chat_enqueue_admin_scripts($hook) {
                 'completed'    => __('Completed', 'zignites-chat'),
                 'running'      => __('Running', 'zignites-chat'),
                 'queued'       => __('Queued', 'zignites-chat'),
+            ],
+        ]);
+    }
+
+    // Sequences page — dynamic add/remove of sequences + steps.
+    if (strpos($hook, 'zignites-chat-sequences') !== false) {
+        wp_enqueue_script('zignites-chat-sequences-js', ZIGNITES_CHAT_URL . 'assets/js/sequences.js', [], ZIGNITES_CHAT_VERSION, true);
+        wp_localize_script('zignites-chat-sequences-js', 'zignitesChatSequences', [
+            'i18n' => [
+                'removeSequence' => __('Remove this sequence? It will be deleted when you save.', 'zignites-chat'),
             ],
         ]);
     }
@@ -477,6 +494,24 @@ function zignites_chat_render_review_page() {
     zignites_chat_admin_page_close();
 }
 
+function zignites_chat_render_sequences_page() {
+    if (!current_user_can('manage_options')) {
+        wp_die(esc_html__('Unauthorized', 'zignites-chat'));
+    }
+    zignites_chat_admin_page_open(__('Drip & Automation Sequences', 'zignites-chat'));
+    if (!zignites_chat_is_pro_active()) {
+        zignites_chat_render_pro_upgrade_notice('sequences');
+        zignites_chat_admin_page_close();
+        return;
+    }
+    echo '<form method="post" action="options.php">';
+    settings_fields('zignites_chat_sequences_group');
+    require ZIGNITES_CHAT_PATH . 'admin/views/tab-sequences.php';
+    submit_button();
+    echo '</form>';
+    zignites_chat_admin_page_close();
+}
+
 function zignites_chat_render_quiet_page() {
     if (!current_user_can('manage_options')) {
         wp_die(esc_html__('Unauthorized', 'zignites-chat'));
@@ -660,6 +695,16 @@ function zignites_chat_render_pro_upgrade_notice($feature = '') {
                 __('Point customers at any review or NPS link', 'zignites-chat'),
                 __('Respects opt-outs, consent and quiet hours', 'zignites-chat'),
                 __('Grow ratings without lifting a finger', 'zignites-chat'),
+            ],
+        ],
+        'sequences' => [
+            'title'       => __('Drip & Automation Sequences', 'zignites-chat'),
+            'description' => __('Build multi-step WhatsApp journeys — welcome series, win-back, browse abandonment — that send themselves on a schedule once a customer triggers them.', 'zignites-chat'),
+            'benefits'    => [
+                __('Multi-step flows with per-step delays and messages', 'zignites-chat'),
+                __('Triggered by order completed, opt-in and more', 'zignites-chat'),
+                __('Customers walk the steps automatically over days', 'zignites-chat'),
+                __('Respects opt-outs, consent, quiet hours and rate limits', 'zignites-chat'),
             ],
         ],
         'quiet' => [

--- a/admin/views/tab-sequences.php
+++ b/admin/views/tab-sequences.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Drip & automation sequences settings view (T3.1 S4).
+ *
+ * Renders the configured sequences as editable cards (id, name, enabled,
+ * trigger, ordered delay+message steps) inside the options.php form opened by
+ * zignites_chat_render_sequences_page(). The whole `zignites_chat_sequences`
+ * option round-trips through zignites_chat_seq_sanitize_sequences() on save, so
+ * blank/removed cards are dropped server-side. Cards and steps are added or
+ * removed client-side by assets/js/sequences.js.
+ */
+if (!defined('ABSPATH')) exit;
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals -- View partial: locals/closures are scoped to the including render function.
+
+$zignites_chat_seq_list     = zignites_chat_seq_get_sequences();
+$zignites_chat_seq_triggers = zignites_chat_seq_triggers();
+$zignites_chat_seq_counts   = zignites_chat_seq_enrollment_counts();
+$zignites_chat_seq_units     = array(
+    'minutes' => __('minutes', 'zignites-chat'),
+    'hours'   => __('hours', 'zignites-chat'),
+    'days'    => __('days', 'zignites-chat'),
+);
+
+/**
+ * Render one step row. $si / $sti may be numeric (existing) or placeholder
+ * tokens (__SI__/__STI__) used by the JS templates.
+ */
+$zignites_chat_render_step = function ($si, $sti, $step) use ($zignites_chat_seq_units) {
+    $field = 'zignites_chat_sequences[' . $si . '][steps][' . $sti . ']';
+    $value = isset($step['delay_value']) ? (int) $step['delay_value'] : 0;
+    $unit  = isset($step['delay_unit']) ? (string) $step['delay_unit'] : 'minutes';
+    $msg   = isset($step['message']) ? (string) $step['message'] : '';
+    ?>
+    <div class="zignites-chat-seq-step" style="border-left:3px solid #dcdcde;padding:8px 12px;margin:8px 0;background:#fbfbfc;">
+        <p style="margin:0 0 6px;">
+            <?php esc_html_e('Wait', 'zignites-chat'); ?>
+            <input type="number" min="0" step="1" class="small-text" name="<?php echo esc_attr($field . '[delay_value]'); ?>" value="<?php echo esc_attr((string) $value); ?>" />
+            <select name="<?php echo esc_attr($field . '[delay_unit]'); ?>">
+                <?php foreach ($zignites_chat_seq_units as $zignites_chat_unit_key => $zignites_chat_unit_label) : ?>
+                    <option value="<?php echo esc_attr($zignites_chat_unit_key); ?>" <?php selected($unit, $zignites_chat_unit_key); ?>><?php echo esc_html($zignites_chat_unit_label); ?></option>
+                <?php endforeach; ?>
+            </select>
+            <?php esc_html_e('then send:', 'zignites-chat'); ?>
+            <button type="button" class="button-link zignites-chat-seq-remove-step" style="color:#b32d2e;margin-left:8px;"><?php esc_html_e('remove step', 'zignites-chat'); ?></button>
+        </p>
+        <textarea class="large-text" rows="2" name="<?php echo esc_attr($field . '[message]'); ?>" placeholder="<?php esc_attr_e('Message… use the placeholders for this trigger', 'zignites-chat'); ?>"><?php echo esc_textarea($msg); ?></textarea>
+    </div>
+    <?php
+};
+
+/**
+ * Render one sequence card. $si numeric for existing, '__SI__' for the JS
+ * template. $is_new toggles an editable vs read-only id field.
+ */
+$zignites_chat_render_card = function ($si, $seq, $is_new, $counts) use ($zignites_chat_seq_triggers, $zignites_chat_render_step) {
+    $field = 'zignites_chat_sequences[' . $si . ']';
+    $id      = isset($seq['id']) ? (string) $seq['id'] : '';
+    $name    = isset($seq['name']) ? (string) $seq['name'] : '';
+    $enabled = (isset($seq['enabled']) && $seq['enabled'] === 'yes');
+    $trigger = isset($seq['trigger']) ? (string) $seq['trigger'] : '';
+    $steps   = (isset($seq['steps']) && is_array($seq['steps']) && !empty($seq['steps'])) ? $seq['steps'] : array(array());
+    $stat    = ($id !== '' && isset($counts[$id])) ? $counts[$id] : null;
+    ?>
+    <div class="zignites-chat-seq-card" data-seq-index="<?php echo esc_attr((string) $si); ?>" data-next-step="<?php echo esc_attr((string) count($steps)); ?>" style="border:1px solid #c3c4c7;border-radius:6px;background:#fff;padding:4px 16px 12px;margin:16px 0;">
+        <table class="form-table" role="presentation">
+            <tr>
+                <th scope="row"><?php esc_html_e('Sequence ID', 'zignites-chat'); ?></th>
+                <td>
+                    <?php if ($is_new) : ?>
+                        <input type="text" class="regular-text" name="<?php echo esc_attr($field . '[id]'); ?>" value="<?php echo esc_attr($id); ?>" placeholder="welcome_series" />
+                        <p class="description"><?php esc_html_e('Lowercase letters, numbers and underscores. Used as the unique key — pick it once.', 'zignites-chat'); ?></p>
+                    <?php else : ?>
+                        <code><?php echo esc_html($id); ?></code>
+                        <input type="hidden" name="<?php echo esc_attr($field . '[id]'); ?>" value="<?php echo esc_attr($id); ?>" />
+                        <?php if ($stat) : ?>
+                            <span class="description" style="margin-left:12px;">
+                                <?php
+                                printf(
+                                    /* translators: 1: active count, 2: completed count, 3: cancelled count */
+                                    esc_html__('Enrollments — %1$d active, %2$d completed, %3$d cancelled', 'zignites-chat'),
+                                    (int) $stat['active'],
+                                    (int) $stat['completed'],
+                                    (int) $stat['cancelled']
+                                );
+                                ?>
+                            </span>
+                        <?php endif; ?>
+                    <?php endif; ?>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php esc_html_e('Name', 'zignites-chat'); ?></th>
+                <td><input type="text" class="regular-text" name="<?php echo esc_attr($field . '[name]'); ?>" value="<?php echo esc_attr($name); ?>" placeholder="<?php esc_attr_e('Welcome series', 'zignites-chat'); ?>" /></td>
+            </tr>
+            <tr>
+                <th scope="row"><?php esc_html_e('Enabled', 'zignites-chat'); ?></th>
+                <td>
+                    <label>
+                        <input type="hidden" name="<?php echo esc_attr($field . '[enabled]'); ?>" value="no" />
+                        <input type="checkbox" name="<?php echo esc_attr($field . '[enabled]'); ?>" value="yes" <?php checked($enabled, true); ?> />
+                        <?php esc_html_e('Active — new triggers enroll customers', 'zignites-chat'); ?>
+                    </label>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php esc_html_e('Trigger', 'zignites-chat'); ?></th>
+                <td>
+                    <select class="zignites-chat-seq-trigger" name="<?php echo esc_attr($field . '[trigger]'); ?>">
+                        <?php foreach ($zignites_chat_seq_triggers as $zignites_chat_trig_key => $zignites_chat_trig_meta) : ?>
+                            <option value="<?php echo esc_attr($zignites_chat_trig_key); ?>" data-placeholders="<?php echo esc_attr(implode(' ', (array) $zignites_chat_trig_meta['placeholders'])); ?>" <?php selected($trigger, $zignites_chat_trig_key); ?>><?php echo esc_html($zignites_chat_trig_meta['label']); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                    <p class="description zignites-chat-seq-placeholders"></p>
+                </td>
+            </tr>
+        </table>
+
+        <div class="zignites-chat-seq-steps">
+            <?php foreach (array_values($steps) as $zignites_chat_sti => $zignites_chat_step) {
+                $zignites_chat_render_step($si, $zignites_chat_sti, is_array($zignites_chat_step) ? $zignites_chat_step : array());
+            } ?>
+        </div>
+
+        <p>
+            <button type="button" class="button zignites-chat-seq-add-step"><?php esc_html_e('+ Add step', 'zignites-chat'); ?></button>
+            <button type="button" class="button zignites-chat-seq-remove" style="float:right;color:#b32d2e;"><?php esc_html_e('Remove sequence', 'zignites-chat'); ?></button>
+        </p>
+    </div>
+    <?php
+};
+?>
+<h2><?php esc_html_e('Drip & Automation Sequences', 'zignites-chat'); ?></h2>
+<p class="description" style="max-width:780px;">
+    <?php esc_html_e('Build multi-step WhatsApp journeys that send themselves. Pick a trigger, then add steps — each step waits a delay and sends a message. Customers are enrolled when the trigger fires and walk the steps automatically. Marketing rules apply: opt-outs and missing consent stop a sequence, and quiet hours / rate limits are respected.', 'zignites-chat'); ?>
+</p>
+
+<div id="zignites-chat-sequences-list">
+    <?php foreach ($zignites_chat_seq_list as $zignites_chat_si => $zignites_chat_seq) {
+        $zignites_chat_render_card($zignites_chat_si, $zignites_chat_seq, false, $zignites_chat_seq_counts);
+    } ?>
+</div>
+
+<p>
+    <button type="button" class="button button-secondary" id="zignites-chat-add-sequence"><?php esc_html_e('+ Add sequence', 'zignites-chat'); ?></button>
+</p>
+
+<script type="text/template" id="zignites-chat-seq-card-tpl">
+    <?php $zignites_chat_render_card('__SI__', array('steps' => array(array())), true, array()); ?>
+</script>
+<script type="text/template" id="zignites-chat-seq-step-tpl">
+    <?php $zignites_chat_render_step('__SI__', '__STI__', array()); ?>
+</script>

--- a/assets/js/sequences.js
+++ b/assets/js/sequences.js
@@ -1,0 +1,86 @@
+// Zignites Chat – Drip & automation sequences editor.
+// Adds/removes sequence cards and step rows client-side. The whole option is
+// re-sanitized server-side on save, so removed cards (not submitted) are dropped.
+
+(function () {
+    document.addEventListener('DOMContentLoaded', function () {
+        var list = document.getElementById('zignites-chat-sequences-list');
+        if (!list) return;
+
+        var cfg = (typeof zignitesChatSequences !== 'undefined') ? zignitesChatSequences : {};
+        var i18n = cfg.i18n || {};
+        var cardTpl = document.getElementById('zignites-chat-seq-card-tpl');
+        var stepTpl = document.getElementById('zignites-chat-seq-step-tpl');
+        var newSeqCounter = 1000; // high, collision-free indices for added cards
+
+        // Reflect the selected trigger's placeholders under the dropdown.
+        function refreshPlaceholders(card) {
+            var select = card.querySelector('.zignites-chat-seq-trigger');
+            var hint = card.querySelector('.zignites-chat-seq-placeholders');
+            if (!select || !hint) return;
+            var opt = select.options[select.selectedIndex];
+            var ph = opt ? (opt.getAttribute('data-placeholders') || '') : '';
+            hint.textContent = ph ? ('Placeholders: ' + ph) : '';
+        }
+
+        function addStep(card) {
+            if (!stepTpl) return;
+            var si = card.getAttribute('data-seq-index');
+            var nextStep = parseInt(card.getAttribute('data-next-step') || '0', 10);
+            var html = stepTpl.innerHTML
+                .split('__SI__').join(si)
+                .split('__STI__').join(String(nextStep));
+            card.setAttribute('data-next-step', String(nextStep + 1));
+            var steps = card.querySelector('.zignites-chat-seq-steps');
+            var wrap = document.createElement('div');
+            wrap.innerHTML = html.trim();
+            while (wrap.firstChild) steps.appendChild(wrap.firstChild);
+        }
+
+        function wireCard(card) {
+            refreshPlaceholders(card);
+            var trigger = card.querySelector('.zignites-chat-seq-trigger');
+            if (trigger) trigger.addEventListener('change', function () { refreshPlaceholders(card); });
+        }
+
+        // Event delegation for the dynamic buttons.
+        document.addEventListener('click', function (e) {
+            var t = e.target;
+            if (!(t instanceof Element)) return;
+
+            if (t.classList.contains('zignites-chat-seq-add-step')) {
+                e.preventDefault();
+                addStep(t.closest('.zignites-chat-seq-card'));
+            } else if (t.classList.contains('zignites-chat-seq-remove-step')) {
+                e.preventDefault();
+                var step = t.closest('.zignites-chat-seq-step');
+                if (step) step.parentNode.removeChild(step);
+            } else if (t.classList.contains('zignites-chat-seq-remove')) {
+                e.preventDefault();
+                if (window.confirm(i18n.removeSequence || 'Remove this sequence?')) {
+                    var card = t.closest('.zignites-chat-seq-card');
+                    if (card) card.parentNode.removeChild(card);
+                }
+            }
+        });
+
+        var addBtn = document.getElementById('zignites-chat-add-sequence');
+        if (addBtn && cardTpl) {
+            addBtn.addEventListener('click', function () {
+                var si = 'new_' + (newSeqCounter++);
+                var html = cardTpl.innerHTML.split('__SI__').join(si);
+                var wrap = document.createElement('div');
+                wrap.innerHTML = html.trim();
+                var card = wrap.querySelector('.zignites-chat-seq-card');
+                if (card) {
+                    list.appendChild(card);
+                    wireCard(card);
+                }
+            });
+        }
+
+        // Wire the server-rendered cards.
+        var cards = list.querySelectorAll('.zignites-chat-seq-card');
+        for (var i = 0; i < cards.length; i++) wireCard(cards[i]);
+    });
+})();

--- a/includes/drip-sequences.php
+++ b/includes/drip-sequences.php
@@ -739,3 +739,50 @@ function zignites_chat_seq_complete_enrollment($id) {
         array('%d')
     );
 }
+
+/* -------------------------------------------------------------------------
+ * Enrollment counts (admin UI)
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Shape grouped (sequence_id, status, count) rows into a per-sequence map. Pure.
+ *
+ * @param array $rows Rows with ->sequence_id, ->status, ->c (or array keys).
+ * @return array<string, array{active:int, completed:int, cancelled:int, total:int}>
+ */
+function zignites_chat_seq_shape_counts($rows) {
+    $out = array();
+    if (!is_array($rows)) {
+        return $out;
+    }
+    foreach ($rows as $row) {
+        $row    = (array) $row;
+        $id     = (string) ($row['sequence_id'] ?? '');
+        $status = (string) ($row['status'] ?? '');
+        $count  = (int) ($row['c'] ?? 0);
+        if ($id === '') {
+            continue;
+        }
+        if (!isset($out[$id])) {
+            $out[$id] = array('active' => 0, 'completed' => 0, 'cancelled' => 0, 'total' => 0);
+        }
+        if (isset($out[$id][$status])) {
+            $out[$id][$status] += $count;
+        }
+        $out[$id]['total'] += $count;
+    }
+    return $out;
+}
+
+/**
+ * Per-sequence enrollment counts by status, for the admin Sequences page.
+ *
+ * @return array<string, array{active:int, completed:int, cancelled:int, total:int}>
+ */
+function zignites_chat_seq_enrollment_counts() {
+    global $wpdb;
+    $table = zignites_chat_seq_enrollments_table_name();
+    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+    $rows = $wpdb->get_results("SELECT sequence_id, status, COUNT(*) AS c FROM {$table} GROUP BY sequence_id, status");
+    return zignites_chat_seq_shape_counts($rows);
+}

--- a/tests/Unit/DripSequencesTest.php
+++ b/tests/Unit/DripSequencesTest.php
@@ -146,4 +146,26 @@ final class DripSequencesTest extends TestCase
         $this->assertNull($plan['next_run_at']);
         $this->assertSame(\zignites_chat_seq_format_mysql($now), $plan['last_step_at']);
     }
+
+    public function test_shape_counts_buckets_by_sequence_and_status(): void
+    {
+        $rows = [
+            ['sequence_id' => 'welcome', 'status' => 'active', 'c' => 3],
+            ['sequence_id' => 'welcome', 'status' => 'completed', 'c' => 5],
+            ['sequence_id' => 'welcome', 'status' => 'cancelled', 'c' => 1],
+            ['sequence_id' => 'winback', 'status' => 'active', 'c' => 2],
+            ['sequence_id' => 'winback', 'status' => 'weird', 'c' => 4], // unknown status: only totalled
+        ];
+        $out = \zignites_chat_seq_shape_counts($rows);
+
+        $this->assertSame(['active' => 3, 'completed' => 5, 'cancelled' => 1, 'total' => 9], $out['welcome']);
+        $this->assertSame(2, $out['winback']['active']);
+        $this->assertSame(6, $out['winback']['total']);
+    }
+
+    public function test_shape_counts_handles_junk(): void
+    {
+        $this->assertSame([], \zignites_chat_seq_shape_counts('nope'));
+        $this->assertSame([], \zignites_chat_seq_shape_counts([['status' => 'active', 'c' => 1]])); // no sequence_id
+    }
 }


### PR DESCRIPTION
- Fourth increment — a Pro "Sequences" admin page to build and manage drip flows without touching code
- Each sequence is an editable card: id, name, enable toggle, trigger, and an ordered list of delay + message steps
- Add or remove steps and whole sequences right in the page; the trigger dropdown shows that trigger's available placeholders
- Existing sequences display their live enrollment counts (active, completed, cancelled) and keep a read-only id so in-flight enrollments aren't orphaned
- Saving round-trips the whole option through the existing sanitizer, so blank or removed cards are dropped server-side — no separate delete plumbing
- Adds the upsell card for the page on the free build
- Pure count-shaping helper is unit-tested; 2 new tests, full suite at 251 passing, PHPCS + JS clean
- With this, drip sequences are fully usable from the admin; only the scan-based win-back / browse-abandon triggers (S5) remain