### PR TITLE
Drip sequences: win-back scan trigger (T3.1 S5)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -571,8 +571,20 @@ Build on the merged two-way inbox (P1):
         the trigger dropdown reveals that trigger's placeholders. Upsell card
         added. Pure tested helper `seq_shape_counts` + a grouped-count query
         `seq_enrollment_counts`. 2 new unit tests; 251 pass, PHPCS + JS clean.
-  - [ ] S5 — Scan-based triggers: win-back (no order in N days) + browse-abandon
-        (viewed product, no order), each a scheduled scan that enrolls matches.
+  - [x] S5 — Win-back scan, on `feat/pro-drip-scan-triggers`. A daily cron
+        (`zignites_chat_seq_daily_scan`, unscheduled on deactivate, cleared on
+        uninstall) enrolls quiet customers into win_back sequences. To stay
+        bounded it scans only the one-day order slice that falls exactly N days
+        back (N = `zignites_chat_seq_winback_days`, default 60, set on the
+        Sequences page) and skips anyone who has ordered since (HPOS-safe
+        last-9-digits phone match, verified). Context {name}/{site}/{days_inactive};
+        enrollment idempotency prevents repeats. Pure tested helper
+        `seq_winback_window`. 2 new unit tests; 253 pass, PHPCS green.
+  - [ ] S6 — Browse-abandon scan (split out of S5, decision 2026-06-08): track
+        product views for logged-in customers who have a billing phone on file,
+        and a scan enrolls those who viewed but didn't buy within a window into
+        browse_abandon sequences ({product}/{product_url}). Guests aren't
+        targeted (no phone/consent) — documented limitation. Closes T3.1.
 
 ### Quick wins (reuse existing plumbing)
 - [x] Q1 — Back-in-stock alerts — done on `feat/pro-back-in-stock`.
@@ -637,12 +649,12 @@ Q2 (review/NPS request) + Q4 (Meta template sync) DONE** (all merged into
 `pro`). Remaining quick win: **Q5 sender-health**.
 
 **Tier 3 — T3.1 drip & automation sequences IN PROGRESS** (incremental PRs).
-**S1–S4 DONE** (S1/S2/S3 merged into `pro`; S4 admin UI on
-`feat/pro-drip-admin-ui` awaiting PR). Drip sequences are now fully usable from
-the admin — create/edit sequences with trigger + delay/message steps, enroll on
-order-completed / opt-in, walk + send on the 5-minute cron with all marketing
-gates. Only **S5 (scan-based win-back + browse-abandon triggers)** remains to
-finish T3.1. See PHASE 9 → Tier 3 for the breakdown.
+**S1–S5 DONE** (S1–S4 merged into `pro`; S5 win-back scan on
+`feat/pro-drip-scan-triggers` awaiting PR). Drip sequences are fully usable —
+admin CRUD, order-completed / opt-in / win-back triggers, the 5-minute sender
+with all marketing gates. Only **S6 (browse-abandon scan)** remains to close
+T3.1; it was split out of S5 (2026-06-08) because browse-abandon can only target
+logged-in customers with a phone on file. See PHASE 9 → Tier 3.
 
 The original Pro backlog is otherwise cleared into `pro`; the only blocked item
 is retiring `license-manager.php` (needs the Freemius credentials migration —

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -125,6 +125,7 @@ function zignites_chat_register_settings() {
         'sanitize_callback' => 'zignites_chat_seq_sanitize_sequences',
         'default'           => [],
     ]);
+    register_setting('zignites_chat_sequences_group', 'zignites_chat_seq_winback_days', ['sanitize_callback' => 'zignites_chat_sanitize_int']);
 
     // License.
     register_setting('zignites_chat_license_group', 'zignites_chat_license_key', ['sanitize_callback' => 'zignites_chat_sanitize_text']);

--- a/admin/views/tab-sequences.php
+++ b/admin/views/tab-sequences.php
@@ -134,6 +134,16 @@ $zignites_chat_render_card = function ($si, $seq, $is_new, $counts) use ($zignit
     <?php esc_html_e('Build multi-step WhatsApp journeys that send themselves. Pick a trigger, then add steps — each step waits a delay and sends a message. Customers are enrolled when the trigger fires and walk the steps automatically. Marketing rules apply: opt-outs and missing consent stop a sequence, and quiet hours / rate limits are respected.', 'zignites-chat'); ?>
 </p>
 
+<table class="form-table" role="presentation">
+    <tr>
+        <th scope="row"><label for="zignites_chat_seq_winback_days"><?php esc_html_e('Win-back inactivity (days)', 'zignites-chat'); ?></label></th>
+        <td>
+            <input type="number" min="1" step="1" class="small-text" id="zignites_chat_seq_winback_days" name="zignites_chat_seq_winback_days" value="<?php echo esc_attr((string) max(1, (int) get_option('zignites_chat_seq_winback_days', 60))); ?>" />
+            <p class="description"><?php esc_html_e('A daily scan enrolls customers into your “win-back” sequences once their most recent order is this many days old. Only used by sequences with the win-back trigger.', 'zignites-chat'); ?></p>
+        </td>
+    </tr>
+</table>
+
 <div id="zignites-chat-sequences-list">
     <?php foreach ($zignites_chat_seq_list as $zignites_chat_si => $zignites_chat_seq) {
         $zignites_chat_render_card($zignites_chat_si, $zignites_chat_seq, false, $zignites_chat_seq_counts);

--- a/includes/class-zignites-chat-plugin.php
+++ b/includes/class-zignites-chat-plugin.php
@@ -143,6 +143,9 @@ final class Plugin {
         if (function_exists('zignites_chat_seq_unschedule_cron')) {
             zignites_chat_seq_unschedule_cron();
         }
+        if (function_exists('zignites_chat_seq_unschedule_scan_cron')) {
+            zignites_chat_seq_unschedule_scan_cron();
+        }
         wp_clear_scheduled_hook('zignites_chat_cleanup_analytics');
     }
 

--- a/includes/drip-sequences.php
+++ b/includes/drip-sequences.php
@@ -23,8 +23,12 @@
  *     marketing gates (quiet hours skip the run, opt-out/consent cancel the
  *     enrollment, the shared rate limiter stops the run) — then advances the
  *     step or completes the enrollment.
+ *   - S4 (admin UI): the "Sequences" settings page (CRUD over the option) +
+ *     per-sequence enrollment counts.
+ *   - S5 (win-back scan): a daily scan that enrolls customers who have gone
+ *     quiet (most recent order N days back) into win_back sequences.
  *
- * The admin CRUD UI lands in a later increment.
+ * Browse-abandon scanning is the remaining follow-up (S6).
  *
  * @package Zignites_Chat
  */
@@ -785,4 +789,160 @@ function zignites_chat_seq_enrollment_counts() {
     // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
     $rows = $wpdb->get_results("SELECT sequence_id, status, COUNT(*) AS c FROM {$table} GROUP BY sequence_id, status");
     return zignites_chat_seq_shape_counts($rows);
+}
+
+/* -------------------------------------------------------------------------
+ * Win-back scan trigger (S5)
+ *
+ * A daily scan enrolls customers who have gone quiet into win_back sequences.
+ * To stay bounded it only looks at the one-day order slice that falls exactly
+ * N days back (N = the configured inactivity threshold): a customer whose most
+ * recent order sits in that slice "went quiet" today, so they enroll today.
+ * Enrollment idempotency keeps a repeat from re-enrolling them.
+ * ----------------------------------------------------------------------- */
+
+add_action('init', 'zignites_chat_seq_schedule_scan_cron');
+add_action('zignites_chat_seq_daily_scan', 'zignites_chat_seq_run_winback_scan');
+
+/**
+ * Ensure the daily scan event is scheduled.
+ */
+function zignites_chat_seq_schedule_scan_cron() {
+    if (!wp_next_scheduled('zignites_chat_seq_daily_scan')) {
+        wp_schedule_event(time() + HOUR_IN_SECONDS, 'daily', 'zignites_chat_seq_daily_scan');
+    }
+}
+
+/**
+ * Clear the daily scan event (deactivation / uninstall).
+ */
+function zignites_chat_seq_unschedule_scan_cron() {
+    $timestamp = wp_next_scheduled('zignites_chat_seq_daily_scan');
+    if ($timestamp) {
+        wp_unschedule_event($timestamp, 'zignites_chat_seq_daily_scan');
+    }
+}
+
+/**
+ * Compute the win-back order slice: the one-day window that ends N days before
+ * $now_ts and opens N+1 days before. Pure.
+ *
+ * @param int $now_ts
+ * @param int $days Inactivity threshold (clamped to >= 1).
+ * @return array{after:int, before:int} Unix timestamps bounding the slice.
+ */
+function zignites_chat_seq_winback_window($now_ts, $days) {
+    $days = max(1, (int) $days);
+    return array(
+        'after'  => (int) $now_ts - ($days + 1) * DAY_IN_SECONDS,
+        'before' => (int) $now_ts - $days * DAY_IN_SECONDS,
+    );
+}
+
+/**
+ * Whether a phone has any completed/processing order placed after $since_ts.
+ * Used to drop customers who have actually come back (so they aren't won back).
+ *
+ * @param string $phone
+ * @param int    $since_ts
+ * @return bool
+ */
+function zignites_chat_seq_has_order_since($phone, $since_ts) {
+    if (!function_exists('wc_get_orders')) {
+        return false;
+    }
+    $digits = zignites_chat_normalize_phone($phone);
+    if ($digits === '') {
+        return false;
+    }
+    $suffix = substr($digits, -9);
+
+    $orders = wc_get_orders(array(
+        'limit'        => 5,
+        'return'       => 'objects',
+        'status'       => array('wc-completed', 'wc-processing'),
+        'date_created' => '>' . (int) $since_ts,
+        'meta_query'   => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+            array(
+                'key'     => '_billing_phone',
+                'value'   => $suffix,
+                'compare' => 'LIKE',
+            ),
+        ),
+    ));
+    if (empty($orders) || !is_array($orders)) {
+        return false;
+    }
+    foreach ($orders as $order) {
+        if (!is_object($order)) {
+            continue;
+        }
+        // Confirm the last-digits LIKE wasn't a coincidental collision.
+        if (!function_exists('zignites_chat_cod_phone_matches')
+            || zignites_chat_cod_phone_matches($digits, $order->get_billing_phone())) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Daily win-back scan: enroll customers whose most recent order falls in the
+ * N-days-back slice into every active win_back sequence.
+ *
+ * @return void
+ */
+function zignites_chat_seq_run_winback_scan() {
+    if (function_exists('zignites_chat_is_pro_active') && !zignites_chat_is_pro_active()) {
+        return;
+    }
+    $sequences = zignites_chat_seq_active_for_trigger('win_back');
+    if (empty($sequences) || !function_exists('wc_get_orders')) {
+        return;
+    }
+
+    $days   = max(1, (int) get_option('zignites_chat_seq_winback_days', 60));
+    $window = zignites_chat_seq_winback_window(current_time('timestamp'), $days);
+    $limit  = max(1, (int) apply_filters('zignites_chat_seq_winback_scan_limit', 300));
+
+    $orders = wc_get_orders(array(
+        'limit'        => $limit,
+        'orderby'      => 'date',
+        'order'        => 'DESC',
+        'return'       => 'objects',
+        'status'       => array('wc-completed', 'wc-processing'),
+        'date_created' => $window['after'] . '...' . $window['before'],
+    ));
+    if (empty($orders) || !is_array($orders)) {
+        return;
+    }
+
+    $site = function_exists('get_bloginfo') ? get_bloginfo('name') : '';
+    $seen = array();
+
+    foreach ($orders as $order) {
+        if (!is_object($order)) {
+            continue;
+        }
+        $phone  = $order->get_billing_phone();
+        $digits = zignites_chat_normalize_phone($phone);
+        if ($digits === '' || isset($seen[$digits])) {
+            continue;
+        }
+        $seen[$digits] = true;
+
+        // Skip anyone who ordered again after the slice — they're active.
+        if (zignites_chat_seq_has_order_since($digits, $window['before'])) {
+            continue;
+        }
+
+        $context = array(
+            '{name}'          => $order->get_billing_first_name(),
+            '{site}'          => $site,
+            '{days_inactive}' => $days,
+        );
+        foreach ($sequences as $sequence) {
+            zignites_chat_seq_enroll($sequence, $phone, $context);
+        }
+    }
 }

--- a/tests/Unit/DripSequencesTest.php
+++ b/tests/Unit/DripSequencesTest.php
@@ -168,4 +168,22 @@ final class DripSequencesTest extends TestCase
         $this->assertSame([], \zignites_chat_seq_shape_counts('nope'));
         $this->assertSame([], \zignites_chat_seq_shape_counts([['status' => 'active', 'c' => 1]])); // no sequence_id
     }
+
+    public function test_winback_window_brackets_the_slice(): void
+    {
+        $now = 100 * DAY_IN_SECONDS;
+        $win = \zignites_chat_seq_winback_window($now, 60);
+        $this->assertSame($now - 61 * DAY_IN_SECONDS, $win['after']);
+        $this->assertSame($now - 60 * DAY_IN_SECONDS, $win['before']);
+        // The slice is always exactly one day wide.
+        $this->assertSame(DAY_IN_SECONDS, $win['before'] - $win['after']);
+    }
+
+    public function test_winback_window_clamps_days(): void
+    {
+        $now = 1000000;
+        $win = \zignites_chat_seq_winback_window($now, 0); // clamps to 1
+        $this->assertSame($now - 2 * DAY_IN_SECONDS, $win['after']);
+        $this->assertSame($now - 1 * DAY_IN_SECONDS, $win['before']);
+    }
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -110,6 +110,7 @@ $zignites_chat_option_keys = [
     'zignites_chat_inbox_notify_enabled',
     'zignites_chat_inbox_notify_email',
     'zignites_chat_sequences',
+    'zignites_chat_seq_winback_days',
 ];
 
 foreach ($zignites_chat_option_keys as $zignites_chat_key) {
@@ -148,6 +149,7 @@ $zignites_chat_cron_hooks = array(
 	'zignites_chat_webhook_retry',
 	'zignites_chat_process_stock_alerts',
 	'zignites_chat_process_sequences',
+	'zignites_chat_seq_daily_scan',
 );
 foreach ($zignites_chat_cron_hooks as $zignites_chat_hook) {
 	wp_clear_scheduled_hook($zignites_chat_hook);


### PR DESCRIPTION
- Adds the win-back trigger — a daily scan that re-engages customers who have gone quiet by enrolling them into win-back sequences
- Stays bounded by only scanning the one-day order slice that falls exactly N days back, so a customer who just went quiet is picked up that day
- Skips anyone who has ordered again since (HPOS-safe phone match, verified), so active customers aren't won back by mistake
- Inactivity threshold is configurable on the Sequences page (default 60 days); enrollment idempotency keeps repeats from re-enrolling the same person
- Daily cron is unscheduled on deactivation and cleared on uninstall
- Browse-abandon was split into its own follow-up (S6) since it can only target logged-in customers who have a phone on file
- Pure window helper is unit-tested; 2 new tests, full suite at 253 passing, PHPCS green