### PR TITLE
Drip sequences: browse-abandon scan (T3.1 S6)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -520,7 +520,7 @@ Build on the merged two-way inbox (P1):
       doesn't wipe canned replies. 3 unit tests; 214 pass, PHPCS + lint green.
 
 ### Tier 3 — platform / automation
-- [🟡] T3.1 — Drip & automation sequences (welcome, win-back, browse-abandon)
+- [x] T3.1 — Drip & automation sequences (welcome, win-back, browse-abandon)
       as multi-step, rule-based flows rather than discrete features. Biggest
       build; the strategic differentiator. **Built in reviewable increments**
       (decision 2026-06-08), one PR each off `pro`:
@@ -580,11 +580,22 @@ Build on the merged two-way inbox (P1):
         last-9-digits phone match, verified). Context {name}/{site}/{days_inactive};
         enrollment idempotency prevents repeats. Pure tested helper
         `seq_winback_window`. 2 new unit tests; 253 pass, PHPCS green.
-  - [ ] S6 — Browse-abandon scan (split out of S5, decision 2026-06-08): track
-        product views for logged-in customers who have a billing phone on file,
-        and a scan enrolls those who viewed but didn't buy within a window into
-        browse_abandon sequences ({product}/{product_url}). Guests aren't
-        targeted (no phone/consent) — documented limitation. Closes T3.1.
+  - [x] S6 — Browse-abandon scan, on `feat/pro-drip-browse-abandon`. Closes
+        T3.1. Two halves sharing the S5 daily-scan cron: (1) view tracking —
+        `woocommerce_before_single_product` stamps the most-recently-viewed
+        product + time onto user meta (`_zignites_chat_last_view_at` /
+        `_zignites_chat_last_view_product`), but only for logged-in customers
+        with a billing phone on file and only while a browse_abandon sequence is
+        active (no wasted writes); (2) the scan reuses the shared one-day
+        lookback slice — a customer whose last view aged to exactly N days old
+        today (`zignites_chat_seq_browse_days`, default 1, set on the Sequences
+        page) and who hasn't ordered since enrolls into every active
+        browse_abandon sequence with {product}/{product_url}. Guests aren't
+        targeted (no phone/consent) and only the latest view is kept per user —
+        both documented limitations. Win-back's window helper was generalized to
+        `seq_lookback_window` (win-back now a thin alias). Settings + view meta
+        cleaned on uninstall; the scan cron was already wired into
+        deactivate/uninstall in S5. 3 new unit tests; 256 pass, PHPCS green.
 
 ### Quick wins (reuse existing plumbing)
 - [x] Q1 — Back-in-stock alerts — done on `feat/pro-back-in-stock`.
@@ -648,17 +659,17 @@ awaiting PR. Live smoke tests pending on each (user action).
 Q2 (review/NPS request) + Q4 (Meta template sync) DONE** (all merged into
 `pro`). Remaining quick win: **Q5 sender-health**.
 
-**Tier 3 — T3.1 drip & automation sequences IN PROGRESS** (incremental PRs).
-**S1–S5 DONE** (S1–S4 merged into `pro`; S5 win-back scan on
-`feat/pro-drip-scan-triggers` awaiting PR). Drip sequences are fully usable —
-admin CRUD, order-completed / opt-in / win-back triggers, the 5-minute sender
-with all marketing gates. Only **S6 (browse-abandon scan)** remains to close
-T3.1; it was split out of S5 (2026-06-08) because browse-abandon can only target
-logged-in customers with a phone on file. See PHASE 9 → Tier 3.
+**Tier 3 — T3.1 drip & automation sequences COMPLETE.** All increments S1–S6
+built (S1–S5 merged into `pro`; S6 browse-abandon scan on
+`feat/pro-drip-browse-abandon` awaiting PR). Drip sequences are fully usable —
+admin CRUD, order-completed / opt-in / win-back / browse-abandon triggers, the
+5-minute sender with all marketing gates, and two daily-scan triggers. See
+PHASE 9 → Tier 3.
 
-The original Pro backlog is otherwise cleared into `pro`; the only blocked item
-is retiring `license-manager.php` (needs the Freemius credentials migration —
-user action).
+**Only remaining roadmap item: Q5 — sender health panel** (WABA quality rating
++ messaging tier on the dashboard). Everything else in the Pro backlog is
+cleared into `pro`; the one blocked item is retiring `license-manager.php`
+(needs the Freemius credentials migration — user action).
 
 Pending live verifications (user action): two-way inbox Twilio/Meta smoke test
 (PR #71, merged); GPT catalog context (PR #72, merged); and observing the rate

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -126,6 +126,7 @@ function zignites_chat_register_settings() {
         'default'           => [],
     ]);
     register_setting('zignites_chat_sequences_group', 'zignites_chat_seq_winback_days', ['sanitize_callback' => 'zignites_chat_sanitize_int']);
+    register_setting('zignites_chat_sequences_group', 'zignites_chat_seq_browse_days', ['sanitize_callback' => 'zignites_chat_sanitize_int']);
 
     // License.
     register_setting('zignites_chat_license_group', 'zignites_chat_license_key', ['sanitize_callback' => 'zignites_chat_sanitize_text']);

--- a/admin/views/tab-sequences.php
+++ b/admin/views/tab-sequences.php
@@ -142,6 +142,13 @@ $zignites_chat_render_card = function ($si, $seq, $is_new, $counts) use ($zignit
             <p class="description"><?php esc_html_e('A daily scan enrolls customers into your “win-back” sequences once their most recent order is this many days old. Only used by sequences with the win-back trigger.', 'zignites-chat'); ?></p>
         </td>
     </tr>
+    <tr>
+        <th scope="row"><label for="zignites_chat_seq_browse_days"><?php esc_html_e('Browse-abandon delay (days)', 'zignites-chat'); ?></label></th>
+        <td>
+            <input type="number" min="1" step="1" class="small-text" id="zignites_chat_seq_browse_days" name="zignites_chat_seq_browse_days" value="<?php echo esc_attr((string) max(1, (int) get_option('zignites_chat_seq_browse_days', 1))); ?>" />
+            <p class="description"><?php esc_html_e('A daily scan enrolls customers into your “browse-abandon” sequences this many days after they last viewed a product without ordering. Only logged-in customers with a billing phone on file are tracked — guests can’t be messaged. Only used by sequences with the browse-abandon trigger.', 'zignites-chat'); ?></p>
+        </td>
+    </tr>
 </table>
 
 <div id="zignites-chat-sequences-list">

--- a/includes/drip-sequences.php
+++ b/includes/drip-sequences.php
@@ -27,8 +27,12 @@
  *     per-sequence enrollment counts.
  *   - S5 (win-back scan): a daily scan that enrolls customers who have gone
  *     quiet (most recent order N days back) into win_back sequences.
- *
- * Browse-abandon scanning is the remaining follow-up (S6).
+ *   - S6 (browse-abandon scan): track product views for logged-in customers
+ *     who have a billing phone on file, then a daily scan enrolls those who
+ *     browsed N days back but haven't bought since into browse_abandon
+ *     sequences (with {product}/{product_url} context). Guests are not
+ *     targeted — they have no phone/consent on file — so browse-abandon only
+ *     covers logged-in shoppers; this is a documented limitation.
  *
  * @package Zignites_Chat
  */
@@ -824,19 +828,33 @@ function zignites_chat_seq_unschedule_scan_cron() {
 }
 
 /**
- * Compute the win-back order slice: the one-day window that ends N days before
- * $now_ts and opens N+1 days before. Pure.
+ * Compute a one-day lookback slice: the window that ends N days before $now_ts
+ * and opens N+1 days before. Pure. Shared by the win-back and browse-abandon
+ * scans so each only has to inspect the single day that "aged into" its
+ * threshold today, keeping the scan bounded.
+ *
+ * @param int $now_ts
+ * @param int $days Threshold in days (clamped to >= 1).
+ * @return array{after:int, before:int} Unix timestamps bounding the slice.
+ */
+function zignites_chat_seq_lookback_window($now_ts, $days) {
+    $days = max(1, (int) $days);
+    return array(
+        'after'  => (int) $now_ts - ($days + 1) * DAY_IN_SECONDS,
+        'before' => (int) $now_ts - $days * DAY_IN_SECONDS,
+    );
+}
+
+/**
+ * Compute the win-back order slice. Pure. Thin alias over the shared lookback
+ * window (kept for call-site clarity / back-compat).
  *
  * @param int $now_ts
  * @param int $days Inactivity threshold (clamped to >= 1).
  * @return array{after:int, before:int} Unix timestamps bounding the slice.
  */
 function zignites_chat_seq_winback_window($now_ts, $days) {
-    $days = max(1, (int) $days);
-    return array(
-        'after'  => (int) $now_ts - ($days + 1) * DAY_IN_SECONDS,
-        'before' => (int) $now_ts - $days * DAY_IN_SECONDS,
-    );
+    return zignites_chat_seq_lookback_window($now_ts, $days);
 }
 
 /**
@@ -940,6 +958,158 @@ function zignites_chat_seq_run_winback_scan() {
             '{name}'          => $order->get_billing_first_name(),
             '{site}'          => $site,
             '{days_inactive}' => $days,
+        );
+        foreach ($sequences as $sequence) {
+            zignites_chat_seq_enroll($sequence, $phone, $context);
+        }
+    }
+}
+
+/* -------------------------------------------------------------------------
+ * Browse-abandon scan trigger (S6)
+ *
+ * Two halves sharing the daily-scan cron from S5:
+ *   1. View tracking — when a logged-in customer with a billing phone on file
+ *      opens a product page we stamp their most-recently-viewed product + the
+ *      time onto user meta (only while a browse_abandon sequence is active, so
+ *      stores not using the feature take no extra writes). Guests are skipped:
+ *      with no phone/consent there's nobody to message later — the documented
+ *      limitation that scoped S6 to logged-in shoppers.
+ *   2. The scan — the same one-day lookback slice as win-back: a customer whose
+ *      last view aged to exactly N days old today, and who hasn't ordered
+ *      since, gets enrolled into every active browse_abandon sequence with
+ *      {product}/{product_url} for the thing they left behind.
+ *
+ * Only the latest view is kept per user (one stamp, overwritten), so the scan
+ * targets the most recent browse intent and storage stays bounded — also a
+ * documented limitation.
+ * ----------------------------------------------------------------------- */
+
+add_action('woocommerce_before_single_product', 'zignites_chat_seq_track_product_view');
+add_action('zignites_chat_seq_daily_scan', 'zignites_chat_seq_run_browse_abandon_scan');
+
+/**
+ * User-meta key holding the Unix timestamp of a customer's most recent product
+ * view (scanned as a numeric range).
+ */
+function zignites_chat_seq_browse_view_at_meta_key() {
+    return '_zignites_chat_last_view_at';
+}
+
+/**
+ * User-meta key holding the product id of a customer's most recent view.
+ */
+function zignites_chat_seq_browse_view_product_meta_key() {
+    return '_zignites_chat_last_view_product';
+}
+
+/**
+ * Record a product view for the current logged-in customer.
+ *
+ * Fired on the single-product template. Only stamps the view when Pro is
+ * active, at least one browse_abandon sequence is live, and the visitor is a
+ * logged-in customer with a usable billing phone on file — everyone else can't
+ * be targeted by the later scan, so there's nothing to record.
+ *
+ * @return void
+ */
+function zignites_chat_seq_track_product_view() {
+    if (!is_user_logged_in()) {
+        return; // Guests have no phone/consent — not targeted (documented).
+    }
+    if (function_exists('zignites_chat_is_pro_active') && !zignites_chat_is_pro_active()) {
+        return;
+    }
+    // Skip the write entirely when no browse_abandon sequence would use it.
+    if (empty(zignites_chat_seq_active_for_trigger('browse_abandon'))) {
+        return;
+    }
+
+    global $product;
+    $product_id = 0;
+    if (is_object($product) && method_exists($product, 'get_id')) {
+        $product_id = (int) $product->get_id();
+    } elseif (function_exists('get_the_ID')) {
+        $product_id = (int) get_the_ID();
+    }
+    if ($product_id <= 0) {
+        return;
+    }
+
+    $user_id = get_current_user_id();
+    $phone   = get_user_meta($user_id, 'billing_phone', true);
+    if (!$phone || zignites_chat_normalize_phone($phone) === '') {
+        return; // No phone on file → can't message later.
+    }
+
+    update_user_meta($user_id, zignites_chat_seq_browse_view_at_meta_key(), (int) current_time('timestamp'));
+    update_user_meta($user_id, zignites_chat_seq_browse_view_product_meta_key(), $product_id);
+}
+
+/**
+ * Daily browse-abandon scan: enroll logged-in customers whose most recent
+ * product view falls in the N-days-back slice and who haven't ordered since.
+ *
+ * @return void
+ */
+function zignites_chat_seq_run_browse_abandon_scan() {
+    if (function_exists('zignites_chat_is_pro_active') && !zignites_chat_is_pro_active()) {
+        return;
+    }
+    $sequences = zignites_chat_seq_active_for_trigger('browse_abandon');
+    if (empty($sequences)) {
+        return;
+    }
+
+    $days   = max(1, (int) get_option('zignites_chat_seq_browse_days', 1));
+    $window = zignites_chat_seq_lookback_window(current_time('timestamp'), $days);
+    $limit  = max(1, (int) apply_filters('zignites_chat_seq_browse_scan_limit', 300));
+
+    $user_ids = get_users(array(
+        'number'     => $limit,
+        'fields'     => 'ID',
+        // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+        'meta_query' => array(
+            array(
+                'key'     => zignites_chat_seq_browse_view_at_meta_key(),
+                'value'   => array($window['after'], $window['before']),
+                'compare' => 'BETWEEN',
+                'type'    => 'NUMERIC',
+            ),
+        ),
+    ));
+    if (empty($user_ids) || !is_array($user_ids)) {
+        return;
+    }
+
+    $site = function_exists('get_bloginfo') ? get_bloginfo('name') : '';
+    $seen = array();
+
+    foreach ($user_ids as $user_id) {
+        $user_id = (int) $user_id;
+        $phone   = get_user_meta($user_id, 'billing_phone', true);
+        $digits  = zignites_chat_normalize_phone($phone);
+        if ($digits === '' || isset($seen[$digits])) {
+            continue;
+        }
+        $seen[$digits] = true;
+
+        // Skip anyone who bought after they browsed — they converted.
+        if (zignites_chat_seq_has_order_since($digits, $window['before'])) {
+            continue;
+        }
+
+        $product_id = (int) get_user_meta($user_id, zignites_chat_seq_browse_view_product_meta_key(), true);
+        $product    = ($product_id > 0 && function_exists('wc_get_product')) ? wc_get_product($product_id) : null;
+        if (!$product) {
+            continue; // Product gone / unpublished → nothing to reference.
+        }
+
+        $context = array(
+            '{name}'        => get_user_meta($user_id, 'billing_first_name', true),
+            '{site}'        => $site,
+            '{product}'     => $product->get_name(),
+            '{product_url}' => get_permalink($product_id),
         );
         foreach ($sequences as $sequence) {
             zignites_chat_seq_enroll($sequence, $phone, $context);

--- a/tests/Unit/DripSequencesTest.php
+++ b/tests/Unit/DripSequencesTest.php
@@ -186,4 +186,31 @@ final class DripSequencesTest extends TestCase
         $this->assertSame($now - 2 * DAY_IN_SECONDS, $win['after']);
         $this->assertSame($now - 1 * DAY_IN_SECONDS, $win['before']);
     }
+
+    public function test_lookback_window_brackets_the_slice(): void
+    {
+        $now = 100 * DAY_IN_SECONDS;
+        $win = \zignites_chat_seq_lookback_window($now, 7);
+        $this->assertSame($now - 8 * DAY_IN_SECONDS, $win['after']);
+        $this->assertSame($now - 7 * DAY_IN_SECONDS, $win['before']);
+        // The slice is always exactly one day wide.
+        $this->assertSame(DAY_IN_SECONDS, $win['before'] - $win['after']);
+    }
+
+    public function test_lookback_window_clamps_days(): void
+    {
+        $now = 1000000;
+        $win = \zignites_chat_seq_lookback_window($now, 0); // clamps to 1 (browse default)
+        $this->assertSame($now - 2 * DAY_IN_SECONDS, $win['after']);
+        $this->assertSame($now - 1 * DAY_IN_SECONDS, $win['before']);
+    }
+
+    public function test_winback_window_delegates_to_lookback(): void
+    {
+        $now = 5_000_000;
+        $this->assertSame(
+            \zignites_chat_seq_lookback_window($now, 60),
+            \zignites_chat_seq_winback_window($now, 60)
+        );
+    }
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -111,6 +111,7 @@ $zignites_chat_option_keys = [
     'zignites_chat_inbox_notify_email',
     'zignites_chat_sequences',
     'zignites_chat_seq_winback_days',
+    'zignites_chat_seq_browse_days',
 ];
 
 foreach ($zignites_chat_option_keys as $zignites_chat_key) {
@@ -135,6 +136,11 @@ $zignites_chat_tables = array(
 foreach ( $zignites_chat_tables as $zignites_chat_table ) {
 	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange -- One-time uninstall cleanup; table name is built from $wpdb->prefix, no user input.
 	$wpdb->query( "DROP TABLE IF EXISTS `{$zignites_chat_table}`" );
+}
+
+// Drop the browse-abandon view-tracking user meta (drip sequences S6).
+foreach ( array( '_zignites_chat_last_view_at', '_zignites_chat_last_view_product' ) as $zignites_chat_meta_key ) {
+	delete_metadata( 'user', 0, $zignites_chat_meta_key, '', true );
 }
 
 // Clear any scheduled cron events the plugin registered.


### PR DESCRIPTION
Closes T3.1 — the last drip increment. Browse-abandon now works in two halves that share the S5 daily-scan cron:

- View tracking: on a single-product page we stamp the most-recently viewed product + time onto user meta, but only for logged-in customers who have a billing phone on file, and only while a browse_abandon sequence is actually active — so stores not using the feature take no extra writes. Guests are skipped on purpose (no phone/consent to message later) and only the latest view is kept per user; both are documented limitations.
- The scan: reuses the same one-day lookback slice as win-back. A customer whose last view aged to exactly N days old today, and who hasn't ordered since, gets enrolled into every active browse_abandon sequence with {product}/{product_url} for the thing they left behind.

Other bits:

- New "Browse-abandon delay (days)" setting on the Sequences page (zignites_chat_seq_browse_days, default 1), registered + sanitized.
- Generalized win-back's window helper to seq_lookback_window; win-back is now a thin alias so existing call sites and tests stay put.
- Uninstall drops the new option and the view-tracking user meta; the scan cron was already wired into deactivate/uninstall back in S5.
- 3 new unit tests for the shared lookback window; full suite 256 green, PHPCS clean on changed files.