### PR TITLE
Sender health panel (Q5)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -645,8 +645,20 @@ Build on the merged two-way inbox (P1):
       `wa_count_body_params` (highest {{n}} in the BODY component),
       `wa_sync_normalize_templates`. Options cleaned on uninstall. 8 unit tests;
       236 pass, PHPCS + JS clean.
-- [ ] Q5 — Sender health panel: WABA quality rating + messaging tier on the
-      dashboard.
+- [x] Q5 — Sender health panel — done on `feat/pro-sender-health`.
+      `includes/sender-health.php`: a dashboard panel showing the WhatsApp
+      sender's **quality rating** (GREEN/YELLOW/RED → High/Medium/Low, colour
+      coded) and **messaging limit tier** (TIER_* → "N customers / 24h"),
+      pulled from the Cloud API phone-number node
+      (`GET /{phone_id}?fields=quality_rating,messaging_limit_tier,…`) using the
+      saved Cloud token + `zignites_chat_cloud_phone_id`. Cloud-only — the panel
+      renders nothing on Twilio (no equivalent) or free builds. Cached in
+      `zignites_chat_sender_health` (with `checked_at`); a "Refresh" button
+      re-pulls on demand via AJAX (`zignites_chat_refresh_sender_health`, nonce +
+      manage_options + Pro gated), no cron. Reuses the Q4 Graph plumbing. Pure
+      tested helpers `health_endpoint`, `health_normalize`,
+      `health_quality_meta`, `health_tier_label`. Option cleaned on uninstall.
+      7 unit tests; 263 pass, PHPCS + JS clean.
 
 ---
 
@@ -655,21 +667,19 @@ Build on the merged two-way inbox (P1):
 are all built — T1.1/T1.2 merged into `pro`; T1.3 on `feat/pro-optin-capture`
 awaiting PR. Live smoke tests pending on each (user action).
 
-**Tier 2 COMPLETE.** Quick wins **Q3 (quiet hours), Q1 (back-in-stock),
-Q2 (review/NPS request) + Q4 (Meta template sync) DONE** (all merged into
-`pro`). Remaining quick win: **Q5 sender-health**.
+**Tier 2 COMPLETE.** All quick wins **Q1 (back-in-stock), Q2 (review/NPS),
+Q3 (quiet hours), Q4 (Meta template sync) DONE** (merged into `pro`); **Q5
+(sender health) DONE** on `feat/pro-sender-health` (awaiting PR).
 
 **Tier 3 — T3.1 drip & automation sequences COMPLETE.** All increments S1–S6
-built (S1–S5 merged into `pro`; S6 browse-abandon scan on
-`feat/pro-drip-browse-abandon` awaiting PR). Drip sequences are fully usable —
-admin CRUD, order-completed / opt-in / win-back / browse-abandon triggers, the
-5-minute sender with all marketing gates, and two daily-scan triggers. See
-PHASE 9 → Tier 3.
+built and merged into `pro`. Drip sequences are fully usable — admin CRUD,
+order-completed / opt-in / win-back / browse-abandon triggers, the 5-minute
+sender with all marketing gates, and two daily-scan triggers. See PHASE 9 →
+Tier 3.
 
-**Only remaining roadmap item: Q5 — sender health panel** (WABA quality rating
-+ messaging tier on the dashboard). Everything else in the Pro backlog is
-cleared into `pro`; the one blocked item is retiring `license-manager.php`
-(needs the Freemius credentials migration — user action).
+**Roadmap is now clear.** With Q5 done, every Pro backlog item is built; the
+only outstanding work is retiring `license-manager.php` (blocked on the
+Freemius credentials migration — user action) and the live smoke tests below.
 
 Pending live verifications (user action): two-way inbox Twilio/Meta smoke test
 (PR #71, merged); GPT catalog context (PR #72, merged); and observing the rate

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -249,6 +249,21 @@ function zignites_chat_enqueue_admin_scripts($hook) {
         ]);
     }
 
+    // Dashboard — sender-health "Refresh" button (Pro + Cloud provider only).
+    if (strpos($hook, 'zignites-chat-dashboard') !== false
+        && function_exists('zignites_chat_is_pro_active') && zignites_chat_is_pro_active()
+        && get_option('zignites_chat_api_provider', 'twilio') === 'cloud') {
+        wp_enqueue_script('zignites-chat-sender-health-js', ZIGNITES_CHAT_URL . 'assets/js/sender-health.js', [], ZIGNITES_CHAT_VERSION, true);
+        wp_localize_script('zignites-chat-sender-health-js', 'zignitesChatSenderHealth', [
+            'ajaxUrl' => admin_url('admin-ajax.php'),
+            'nonce'   => wp_create_nonce('zignites_chat_sender_health'),
+            'i18n'    => [
+                'checking' => __('Checking…', 'zignites-chat'),
+                'error'    => __('Could not refresh sender health. Please try again.', 'zignites-chat'),
+            ],
+        ]);
+    }
+
     // Campaigns page.
     if (strpos($hook, 'zignites-chat-campaigns') !== false) {
         wp_enqueue_media(); // WP media library frame for the campaign attachment picker.

--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -49,6 +49,13 @@ $zignites_chat_dash_open_rate = $zignites_chat_dash_totals['sent'] > 0
     </div>
 </div>
 
+<?php
+// Sender health (Pro + Cloud provider only — renders nothing otherwise).
+if (function_exists('zignites_chat_render_sender_health_panel')) {
+    zignites_chat_render_sender_health_panel();
+}
+?>
+
 <?php if (!$zignites_chat_dash_is_pro) : ?>
     <h2 style="margin-top:28px;"><?php esc_html_e('Unlock more with Zignites Chat Pro', 'zignites-chat'); ?></h2>
     <div class="zignites-chat-dashboard-teasers">

--- a/assets/js/sender-health.js
+++ b/assets/js/sender-health.js
@@ -1,0 +1,48 @@
+// Zignites Chat – Refresh WhatsApp sender health (quality rating + messaging tier).
+
+(function () {
+    document.addEventListener('DOMContentLoaded', function () {
+        var btn = document.getElementById('zignites-chat-refresh-sender-health');
+        if (!btn) return;
+
+        var cfg = (typeof zignitesChatSenderHealth !== 'undefined') ? zignitesChatSenderHealth : {};
+        var i18n = cfg.i18n || {};
+        var msg = document.getElementById('zignites-chat-sender-health-status');
+
+        btn.addEventListener('click', function () {
+            btn.disabled = true;
+            var original = btn.textContent;
+            btn.textContent = i18n.checking || 'Checking…';
+            if (msg) { msg.textContent = ''; msg.className = 'description'; }
+
+            var body = 'action=zignites_chat_refresh_sender_health'
+                + '&nonce=' + encodeURIComponent(cfg.nonce || '');
+
+            fetch(cfg.ajaxUrl, {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: body
+            }).then(function (r) { return r.json(); }).then(function (res) {
+                btn.disabled = false;
+                btn.textContent = original;
+                if (res && res.success) {
+                    // Reload so the panel re-renders the fresh snapshot from PHP.
+                    window.location.reload();
+                } else {
+                    if (msg) {
+                        msg.textContent = (res && res.data && res.data.message) || (i18n.error || '');
+                        msg.className = 'description zignites-chat-sync-error';
+                    }
+                }
+            }).catch(function () {
+                btn.disabled = false;
+                btn.textContent = original;
+                if (msg) {
+                    msg.textContent = i18n.error || '';
+                    msg.className = 'description zignites-chat-sync-error';
+                }
+            });
+        });
+    });
+})();

--- a/includes/class-zignites-chat-plugin.php
+++ b/includes/class-zignites-chat-plugin.php
@@ -72,6 +72,7 @@ final class Plugin {
         require_once ZIGNITES_CHAT_PATH . 'includes/providers/class-zignites-chat-provider-cloud.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/wa-templates.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/wa-template-sync.php';
+        require_once ZIGNITES_CHAT_PATH . 'includes/sender-health.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/media.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/rate-limiter.php';
         require_once ZIGNITES_CHAT_PATH . 'includes/quiet-hours.php';

--- a/includes/sender-health.php
+++ b/includes/sender-health.php
@@ -1,0 +1,284 @@
+<?php
+/**
+ * Sender health panel (Pro) — roadmap Q5.
+ *
+ * Surfaces the two numbers a WhatsApp sender most needs to watch on the
+ * dashboard: the phone number's **quality rating** (GREEN / YELLOW / RED) and
+ * its **messaging limit tier** (how many unique customers it may start
+ * conversations with per 24h). Both live on the WhatsApp Cloud API phone
+ * number node, so the panel only applies to the Cloud provider — Twilio
+ * exposes no equivalent and the panel stays hidden for it.
+ *
+ * It reuses the Q4 template-sync plumbing: the saved Cloud token +
+ * `zignites_chat_cloud_phone_id`, a single Graph read, and a cached result the
+ * dashboard renders. A "Refresh" button re-pulls on demand (AJAX); there is no
+ * cron — health changes slowly and an on-demand check keeps it simple.
+ *
+ * Storage:
+ *   option `zignites_chat_sender_health` — last normalized snapshot
+ *                                          (autoload off), with `checked_at`.
+ *
+ * The endpoint builder, response normaliser, quality-rating meta and tier
+ * label are pure and unit-tested; the rest is Graph API + AJAX + render glue.
+ *
+ * @package Zignites_Chat
+ */
+
+if (!defined('ABSPATH')) exit;
+
+/** Graph API version — shared with the Cloud provider / template sync (Q4). */
+if (!defined('ZIGNITES_CHAT_GRAPH_VERSION')) {
+    define('ZIGNITES_CHAT_GRAPH_VERSION', 'v19.0');
+}
+
+/* -------------------------------------------------------------------------
+ * Pure helpers (no network, no DB) — unit-tested
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Build the phone-number Graph endpoint carrying the health fields. Pure.
+ *
+ * @param string $phone_id WhatsApp Cloud API phone number ID.
+ * @return string Endpoint URL, or '' when the phone ID is empty.
+ */
+function zignites_chat_health_endpoint($phone_id) {
+    $phone_id = trim((string) $phone_id);
+    if ($phone_id === '') {
+        return '';
+    }
+    return 'https://graph.facebook.com/' . ZIGNITES_CHAT_GRAPH_VERSION . '/'
+        . rawurlencode($phone_id)
+        . '?fields=quality_rating,messaging_limit_tier,display_phone_number,verified_name,name_status';
+}
+
+/**
+ * Normalise a Graph phone-number node into the stable shape the panel renders.
+ * Pure. Missing rating / tier collapse to 'UNKNOWN' so the caller never has to
+ * special-case absent fields.
+ *
+ * @param mixed $data Decoded JSON node.
+ * @return array{quality_rating:string, messaging_tier:string, display_phone_number:string, verified_name:string, name_status:string}
+ */
+function zignites_chat_health_normalize($data) {
+    if (!is_array($data)) {
+        $data = array();
+    }
+    $rating = strtoupper(trim((string) ($data['quality_rating'] ?? '')));
+    $tier   = strtoupper(trim((string) ($data['messaging_limit_tier'] ?? '')));
+
+    return array(
+        'quality_rating'       => $rating !== '' ? $rating : 'UNKNOWN',
+        'messaging_tier'       => $tier !== '' ? $tier : 'UNKNOWN',
+        'display_phone_number' => sanitize_text_field((string) ($data['display_phone_number'] ?? '')),
+        'verified_name'        => sanitize_text_field((string) ($data['verified_name'] ?? '')),
+        'name_status'          => strtoupper(trim((string) ($data['name_status'] ?? ''))),
+    );
+}
+
+/**
+ * Map a quality rating to a display level, label and colour. Pure.
+ *
+ * @param string $rating GREEN | YELLOW | RED | anything else.
+ * @return array{level:string, label:string, color:string}
+ */
+function zignites_chat_health_quality_meta($rating) {
+    switch (strtoupper(trim((string) $rating))) {
+        case 'GREEN':
+            return array('level' => 'green', 'label' => __('High', 'zignites-chat'), 'color' => '#46b450');
+        case 'YELLOW':
+            return array('level' => 'yellow', 'label' => __('Medium', 'zignites-chat'), 'color' => '#dba617');
+        case 'RED':
+            return array('level' => 'red', 'label' => __('Low', 'zignites-chat'), 'color' => '#d63638');
+        default:
+            return array('level' => 'unknown', 'label' => __('Unknown', 'zignites-chat'), 'color' => '#8c8f94');
+    }
+}
+
+/**
+ * Turn a messaging-limit tier into a human label. Pure.
+ *
+ * @param string $tier TIER_250 | TIER_1K | TIER_10K | TIER_100K | TIER_UNLIMITED | …
+ * @return string
+ */
+function zignites_chat_health_tier_label($tier) {
+    $tier = strtoupper(trim((string) $tier));
+    if ($tier === 'TIER_UNLIMITED') {
+        return __('Unlimited', 'zignites-chat');
+    }
+    $counts = array(
+        'TIER_50'   => '50',
+        'TIER_250'  => '250',
+        'TIER_1K'   => '1,000',
+        'TIER_10K'  => '10,000',
+        'TIER_100K' => '100,000',
+    );
+    if (isset($counts[$tier])) {
+        return sprintf(
+            /* translators: %s: number of unique customers the sender may message per 24 hours */
+            __('%s customers / 24h', 'zignites-chat'),
+            $counts[$tier]
+        );
+    }
+    return __('Unknown', 'zignites-chat');
+}
+
+/* -------------------------------------------------------------------------
+ * Stored snapshot
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Read the cached health snapshot.
+ *
+ * @return array Empty array when nothing has been fetched yet.
+ */
+function zignites_chat_health_get_cached() {
+    $stored = get_option('zignites_chat_sender_health', array());
+    return is_array($stored) ? $stored : array();
+}
+
+/* -------------------------------------------------------------------------
+ * Fetch from the Graph API
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Pull the phone number's health from the Graph API and cache it.
+ *
+ * @param string $phone_id Phone number ID (falls back to the saved option).
+ * @return array Normalised snapshot (with `checked_at`), or ['error' => …].
+ */
+function zignites_chat_health_fetch($phone_id = '') {
+    $token    = trim((string) get_option('zignites_chat_cloud_token', ''));
+    $phone_id = trim((string) $phone_id);
+    if ($phone_id === '') {
+        $phone_id = trim((string) get_option('zignites_chat_cloud_phone_id', ''));
+    }
+
+    if ($token === '' || $phone_id === '') {
+        return array('error' => __('Add your Cloud API access token and Phone Number ID (General Settings) to see sender health.', 'zignites-chat'));
+    }
+
+    $response = wp_remote_get(zignites_chat_health_endpoint($phone_id), array(
+        'timeout' => 20,
+        'headers' => array('Authorization' => 'Bearer ' . $token),
+    ));
+
+    if (is_wp_error($response)) {
+        return array('error' => $response->get_error_message());
+    }
+
+    $code = (int) wp_remote_retrieve_response_code($response);
+    $data = json_decode(wp_remote_retrieve_body($response), true);
+
+    if ($code !== 200) {
+        $message = is_array($data) && isset($data['error']['message'])
+            ? (string) $data['error']['message']
+            : sprintf(
+                /* translators: %d: HTTP status code returned by the Graph API */
+                __('Meta Graph API returned HTTP %d. Check the access token and Phone Number ID.', 'zignites-chat'),
+                $code
+            );
+        return array('error' => $message);
+    }
+
+    $snapshot               = zignites_chat_health_normalize($data);
+    $snapshot['checked_at'] = current_time('mysql');
+    update_option('zignites_chat_sender_health', $snapshot, false);
+
+    return $snapshot;
+}
+
+/* -------------------------------------------------------------------------
+ * AJAX — "Refresh" button on the dashboard
+ * ----------------------------------------------------------------------- */
+
+add_action('wp_ajax_zignites_chat_refresh_sender_health', 'zignites_chat_ajax_refresh_sender_health');
+
+/**
+ * Handle the dashboard refresh request.
+ *
+ * Capability: manage_options. Nonce: zignites_chat_sender_health.
+ */
+function zignites_chat_ajax_refresh_sender_health() {
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error(array('message' => __('Unauthorized', 'zignites-chat')), 403);
+    }
+    if (!check_ajax_referer('zignites_chat_sender_health', 'nonce', false)) {
+        wp_send_json_error(array('message' => __('Bad nonce', 'zignites-chat')), 400);
+    }
+    if (function_exists('zignites_chat_is_pro_active') && !zignites_chat_is_pro_active()) {
+        wp_send_json_error(array('message' => __('Pro required', 'zignites-chat')), 403);
+    }
+
+    $result = zignites_chat_health_fetch();
+
+    if (!empty($result['error'])) {
+        wp_send_json_error(array('message' => (string) $result['error']));
+    }
+
+    wp_send_json_success(array('message' => __('Sender health refreshed.', 'zignites-chat')));
+}
+
+/* -------------------------------------------------------------------------
+ * Dashboard panel
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Render the sender-health panel on the dashboard. No-op unless this is a Pro
+ * build on the Cloud provider — quality rating / messaging tier are Cloud-only
+ * concepts.
+ *
+ * @return void
+ */
+function zignites_chat_render_sender_health_panel() {
+    if (function_exists('zignites_chat_is_pro_active') && !zignites_chat_is_pro_active()) {
+        return;
+    }
+    if (get_option('zignites_chat_api_provider', 'twilio') !== 'cloud') {
+        return;
+    }
+
+    $health    = zignites_chat_health_get_cached();
+    $has_data  = !empty($health) && isset($health['quality_rating']);
+    $quality   = zignites_chat_health_quality_meta($has_data ? $health['quality_rating'] : 'UNKNOWN');
+    $tier      = zignites_chat_health_tier_label($has_data ? $health['messaging_tier'] : 'UNKNOWN');
+    $phone     = $has_data ? (string) ($health['display_phone_number'] ?? '') : '';
+    $checked   = $has_data ? (string) ($health['checked_at'] ?? '') : '';
+    ?>
+    <h2 style="margin-top:28px;"><?php esc_html_e('Sender Health', 'zignites-chat'); ?></h2>
+    <div class="zignites-chat-dashboard-widget" id="zignites-chat-sender-health">
+        <div class="zignites-chat-dashboard-widget-stats">
+            <div class="zignites-chat-dashboard-widget-stat">
+                <span class="dashicons dashicons-shield-alt" style="color:<?php echo esc_attr($quality['color']); ?>;"></span>
+                <div class="zignites-chat-stat-value" style="color:<?php echo esc_attr($quality['color']); ?>;"><?php echo esc_html($quality['label']); ?></div>
+                <div class="zignites-chat-stat-label"><?php esc_html_e('Quality Rating', 'zignites-chat'); ?></div>
+            </div>
+            <div class="zignites-chat-dashboard-widget-stat">
+                <span class="dashicons dashicons-chart-bar"></span>
+                <div class="zignites-chat-stat-value"><?php echo esc_html($tier); ?></div>
+                <div class="zignites-chat-stat-label"><?php esc_html_e('Messaging Limit', 'zignites-chat'); ?></div>
+            </div>
+            <div class="zignites-chat-dashboard-widget-stat">
+                <span class="dashicons dashicons-whatsapp"></span>
+                <div class="zignites-chat-stat-value"><?php echo esc_html($phone !== '' ? $phone : '—'); ?></div>
+                <div class="zignites-chat-stat-label"><?php esc_html_e('Sender Number', 'zignites-chat'); ?></div>
+            </div>
+        </div>
+        <div class="zignites-chat-dashboard-widget-actions">
+            <button type="button" class="button" id="zignites-chat-refresh-sender-health"><?php esc_html_e('Refresh', 'zignites-chat'); ?></button>
+            <span class="description" id="zignites-chat-sender-health-status" style="margin-left:10px;">
+                <?php
+                if ($checked !== '') {
+                    printf(
+                        /* translators: %s: human-readable time since the last health check */
+                        esc_html__('Last checked %s ago', 'zignites-chat'),
+                        esc_html(human_time_diff(strtotime($checked), current_time('timestamp')))
+                    );
+                } else {
+                    esc_html_e('Not checked yet — click Refresh.', 'zignites-chat');
+                }
+                ?>
+            </span>
+        </div>
+    </div>
+    <?php
+}

--- a/tests/Unit/SenderHealthTest.php
+++ b/tests/Unit/SenderHealthTest.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+namespace ZignitesChat\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class SenderHealthTest extends TestCase
+{
+    public function test_endpoint_builds_phone_node_url(): void
+    {
+        $url = \zignites_chat_health_endpoint('109876');
+        $this->assertStringContainsString('/109876?', $url);
+        $this->assertStringContainsString('fields=quality_rating,messaging_limit_tier', $url);
+        $this->assertStringContainsString('display_phone_number', $url);
+    }
+
+    public function test_endpoint_empty_phone_returns_empty(): void
+    {
+        $this->assertSame('', \zignites_chat_health_endpoint('   '));
+    }
+
+    public function test_normalize_maps_node_and_uppercases(): void
+    {
+        $out = \zignites_chat_health_normalize([
+            'quality_rating'       => 'green',
+            'messaging_limit_tier' => 'tier_1k',
+            'display_phone_number' => '+1 555-0100',
+            'verified_name'        => 'Acme Co',
+            'name_status'          => 'approved',
+        ]);
+        $this->assertSame('GREEN', $out['quality_rating']);
+        $this->assertSame('TIER_1K', $out['messaging_tier']);
+        $this->assertSame('+1 555-0100', $out['display_phone_number']);
+        $this->assertSame('Acme Co', $out['verified_name']);
+        $this->assertSame('APPROVED', $out['name_status']);
+    }
+
+    public function test_normalize_defaults_missing_to_unknown(): void
+    {
+        $out = \zignites_chat_health_normalize([]);
+        $this->assertSame('UNKNOWN', $out['quality_rating']);
+        $this->assertSame('UNKNOWN', $out['messaging_tier']);
+        $this->assertSame('', $out['display_phone_number']);
+
+        $junk = \zignites_chat_health_normalize('nope');
+        $this->assertSame('UNKNOWN', $junk['quality_rating']);
+    }
+
+    public function test_quality_meta_levels(): void
+    {
+        $this->assertSame('green', \zignites_chat_health_quality_meta('GREEN')['level']);
+        $this->assertSame('yellow', \zignites_chat_health_quality_meta('yellow')['level']);
+        $this->assertSame('red', \zignites_chat_health_quality_meta('RED')['level']);
+        // Unknown / unrecognised ratings fall through to the grey "unknown" level.
+        $this->assertSame('unknown', \zignites_chat_health_quality_meta('')['level']);
+        $this->assertSame('unknown', \zignites_chat_health_quality_meta('NA')['level']);
+        // Each level carries a label + colour.
+        $green = \zignites_chat_health_quality_meta('GREEN');
+        $this->assertSame('High', $green['label']);
+        $this->assertSame('#46b450', $green['color']);
+    }
+
+    public function test_tier_label_maps_known_tiers(): void
+    {
+        $this->assertStringContainsString('1,000', \zignites_chat_health_tier_label('TIER_1K'));
+        $this->assertStringContainsString('100,000', \zignites_chat_health_tier_label('tier_100k'));
+        $this->assertSame('Unlimited', \zignites_chat_health_tier_label('TIER_UNLIMITED'));
+    }
+
+    public function test_tier_label_unknown_for_unrecognised(): void
+    {
+        $this->assertSame('Unknown', \zignites_chat_health_tier_label('TIER_WHATEVER'));
+        $this->assertSame('Unknown', \zignites_chat_health_tier_label(''));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -142,6 +142,7 @@ if (!function_exists('zignites_chat_is_pro_active')) {
 require_once __DIR__ . '/../includes/helpers.php';
 require_once __DIR__ . '/../includes/wa-templates.php';
 require_once __DIR__ . '/../includes/wa-template-sync.php';
+require_once __DIR__ . '/../includes/sender-health.php';
 require_once __DIR__ . '/../includes/media.php';
 require_once __DIR__ . '/../includes/cart-recovery.php';
 require_once __DIR__ . '/../includes/campaigns.php';

--- a/uninstall.php
+++ b/uninstall.php
@@ -112,6 +112,7 @@ $zignites_chat_option_keys = [
     'zignites_chat_sequences',
     'zignites_chat_seq_winback_days',
     'zignites_chat_seq_browse_days',
+    'zignites_chat_sender_health',
 ];
 
 foreach ($zignites_chat_option_keys as $zignites_chat_key) {


### PR DESCRIPTION
Adds a dashboard panel so merchants can see the two numbers that decide whether their WhatsApp sending stays healthy, without leaving WP:

- Quality rating — GREEN/YELLOW/RED shown as High/Medium/Low, colour coded so a slipping rating is obvious at a glance.
- Messaging limit tier — TIER_* mapped to a plain "N customers / 24h" (or Unlimited), plus the verified sender number.

How it works:

- Pulls both from the Cloud API phone-number node (GET /{phone_id}?fields=quality_rating,messaging_limit_tier,...) using the Cloud token + saved Phone Number ID — the same Graph plumbing as the Q4 template sync.
- Cloud-only: quality rating / messaging tier are Meta concepts, so the panel renders nothing on the Twilio provider or on free builds.
- The snapshot is cached in an option (with a checked-at stamp) and shown with a "Last checked N ago" line; a Refresh button re-pulls on demand via AJAX (nonce + manage_options + Pro gated). No cron — health moves slowly and an on-demand check keeps it simple.

Housekeeping:

- New module wired into boot_modules; dashboard JS enqueued only on the Pro + Cloud dashboard. Cached option cleaned up on uninstall.
- Pure helpers (endpoint builder, response normaliser, quality meta, tier label) are unit tested — 7 new tests, full suite 263 green, PHPCS + JS lint clean.

Closes the Pro roadmap: every backlog item is now built.